### PR TITLE
@throws JSDoc support, subtyping LUB, slim signature pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,140 @@
+# AGENTS
+
+Guidance for AI agents and human contributors working in `ts-gen`.
+
+## What this project does
+
+`ts-gen` is a TypeScript-to-Rust binding generator. It reads `.d.ts`
+files and emits Rust source containing `#[wasm_bindgen] extern "C"`
+blocks. The output is meant to compile cleanly against `wasm-bindgen`
+and let downstream Rust code interact with JS APIs that are described
+purely by their TypeScript declarations.
+
+## Project layout
+
+```text
+src/
+├── lib.rs                     # public API (`parse_source`, re-exports)
+├── ir.rs                      # IR types (TypeRef, ClassDecl, …)
+├── context.rs                 # GlobalContext (scopes, registry, externals)
+├── external_map.rs            # `--external Foo=::path::Bar` resolution
+├── parse/                     # .d.ts → IR
+│   ├── docs.rs                # JSDoc extraction (incl. @throws)
+│   ├── members.rs             # interface / class member converters
+│   ├── merge.rs               # var + interface merging
+│   ├── classify.rs            # interface classification (class-like vs dictionary)
+│   ├── types.rs               # TS type → IR TypeRef
+│   ├── scope.rs               # scope / TypeId arena
+│   ├── first_pass/            # two-phase population
+│   │   ├── collect.rs         # phase 1: name registry
+│   │   └── populate.rs        # phase 2: full IR
+│   └── mod.rs                 # post-passes (merge_class_pairs, …)
+├── codegen/                   # IR → Rust source
+│   ├── mod.rs                 # entry, `generate(...)`
+│   ├── classes.rs             # extern blocks for class-like types
+│   ├── functions.rs           # free function / variable bindings
+│   ├── enums.rs               # string + numeric enums
+│   ├── signatures.rs          # parameter expansion + per-callable layer
+│   ├── subtyping.rs           # builtin parents + `lub_types` (LUB)
+│   └── typemap.rs             # TypeRef → syn tokens, `to_return_type`, externals
+└── util/                      # naming, diagnostics, dedup helpers
+
+tests/
+├── fixtures/*.d.ts            # input declarations
+├── snapshots/*.rs             # expected generated output (BLESS=1 to update)
+└── snapshot.rs                # the snapshot harness
+
+integration-tests/
+├── tests/*.rs                 # hand-written integration tests
+└── build.rs                   # generates per-test bindings via the library API
+```
+
+## Conventions
+
+The single source of truth for "how does construct X translate?" is
+[`CONVENTIONS.md`](CONVENTIONS.md). It catalogues every TypeScript →
+Rust pattern we handle, ordered from simplest (primitives) to most
+complex (subtyping LUB across unions).
+
+**When to update `CONVENTIONS.md`:**
+
+* Adding a new TS construct → add a numbered section.
+* Changing an existing translation rule → update its section.
+* Bug fix that changes user-visible output → update if the fix changes
+  the documented behaviour, otherwise just add a snapshot test.
+
+A PR that changes the codegen output without a corresponding
+`CONVENTIONS.md` change is suspect — either the convention was missing
+(add it) or the change is unintentional (revisit it).
+
+## Code style
+
+* Comments describe **nuance**, not the obvious. No `// ---` separators.
+* Doc comments on public items use `///`; module-level docs use `//!`.
+* Diagnostic-worthy oddities go through `DiagnosticCollector::warn`,
+  not `println!`/`eprintln!`.
+* Internal helpers are crate-private (`pub(crate)`) unless there's a
+  reason to expose them to library consumers.
+
+## Build / test recipes
+
+The `justfile` is the single source for repeatable commands:
+
+```sh
+just test                # unit + snapshot tests
+just test-overwrite      # bless snapshots after intentional output changes
+just test-integration    # wasm-bindgen integration tests (needs wasm32 target)
+just clippy              # workspace clippy with -D warnings
+just fmt                 # apply rustfmt
+just fmt-check           # CI rustfmt --check
+```
+
+All recipes use `cargo +stable` because the upstream workspace pins an
+older toolchain via `rust-toolchain.toml`. CI uses the same.
+
+## Tests
+
+Three layers:
+
+1. **Unit tests** (`cargo test --lib`) — focused, white-box checks of
+   internal helpers (parse logic, naming, subtyping LUB, signature
+   expansion). New behaviour should ship with unit tests in the
+   relevant module's `#[cfg(test)] mod tests`.
+2. **Snapshot tests** (`cargo test --test snapshot`) — fixture-driven.
+   Every fixture under `tests/fixtures/` pairs with a snapshot under
+   `tests/snapshots/`. Re-bless with `BLESS=1 cargo test`. Snapshot
+   diffs in PRs should match documented convention changes — silently
+   diff-only PRs are a smell.
+3. **Integration tests** (`integration-tests/`) — actual wasm-bindgen
+   compilation + browser/V8 execution. Used for end-to-end ABI
+   correctness. Lives in its own crate that only builds for `wasm32`.
+
+## Pipeline
+
+```text
+.d.ts files
+  └─> oxc_parser (AST)
+        └─> Phase 1: collect type names into TypeRegistry
+              └─> Phase 2: populate full IR (resolve refs, merge var+iface, …)
+                    └─> Post-passes (merge_class_pairs, classify, resolve imports)
+                          └─> Codegen (CodegenContext, to_syn_type, emitters)
+                                └─> syn::File → prettyplease → .rs
+```
+
+The two-phase parse is essential: phase 1 establishes name → kind
+mappings so phase 2 can resolve forward references without re-walking
+the AST.
+
+## When in doubt
+
+* **Are the conventions documented?** Check `CONVENTIONS.md` first; the
+  pattern you're touching may already be specified there.
+* **Is there a fixture?** Add one. A targeted `.d.ts` snippet in
+  `tests/fixtures/` plus its rendered snapshot is the cheapest way to
+  pin behaviour.
+* **Does the change affect the rendered output?** Run
+  `just test-overwrite` and review the snapshot diff carefully.
+* **Is the change cross-cutting?** Likely belongs in `signatures.rs`
+  (per-callable layer), `typemap.rs` (per-type), or `subtyping.rs`
+  (lattice). If you're adding a new module, consider whether a helper
+  in an existing one would do.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,542 @@
+# Conventions: TypeScript → Rust
+
+This document is the canonical reference for how `ts-gen` translates
+TypeScript declarations into `wasm-bindgen` Rust bindings. It covers the
+patterns we handle, what they emit, and the rules behind each translation.
+
+Conventions are listed roughly from simplest to most complex. New
+conventions belong here first; tests and codegen come second. Keep the file
+in sync with the snapshot fixtures (`tests/fixtures/*.d.ts` paired with
+`tests/snapshots/*.rs`).
+
+> **Maintenance**: when changing a convention or adding a new one, update
+> this file in the same PR. Diff-only snapshot changes that aren't
+> documented are a smell.
+
+---
+
+## 1. Primitive types
+
+| TypeScript                      | Rust                       |
+| ------------------------------- | -------------------------- |
+| `string`                        | `String` / `&str`          |
+| `number`                        | `f64`                      |
+| `boolean`                       | `bool`                     |
+| `bigint`                        | `i64`                      |
+| `void`                          | `()` (or omitted from sig) |
+| `undefined`                     | `Undefined`                |
+| `null`                          | `()`                       |
+| `any` / `unknown`               | `JsValue`                  |
+| `never`                         | `JsValue`                  |
+| `object`                        | `Object`                   |
+
+`String` vs `&str` (or `Object` vs `&Object` etc.) is chosen by argument
+position vs return position — see [§ Argument vs Return Position].
+
+## 2. Optional and nullable types
+
+* `T | null` → `Option<T>` in return position, `Option<T>` in argument
+  position. (`null`-only is rare; treated like `undefined`.)
+* `T | undefined` and `T | null | undefined` → also `Option<T>`. We coalesce
+  at parse time; the rendered union has no separate `null`/`undefined`
+  arm.
+* `T?` on a property → `Option<T>`. The setter takes `Option<T>` too, so
+  callers can clear the property by passing `None`.
+* `f(x?: T)` (optional parameter) → produces an overload pair, *not* an
+  `Option<T>` parameter. See [§ Optional Parameter Truncation].
+
+## 3. Property accessors
+
+```ts
+interface Foo {
+  readonly bar: string;
+  baz: number;
+}
+```
+
+emits:
+
+```rust
+#[wasm_bindgen(method, getter)]
+pub fn bar(this: &Foo) -> String;
+
+#[wasm_bindgen(method, getter)]
+pub fn baz(this: &Foo) -> f64;
+#[wasm_bindgen(method, setter, js_name = "baz")]
+pub fn set_baz(this: &Foo, val: f64);
+```
+
+`readonly` properties get a getter only. Non-readonly properties get both;
+the setter is named `set_<snake_case>`.
+
+## 4. Naming conversion
+
+* JS `camelCase` / `PascalCase` identifiers → Rust `snake_case` for fns,
+  `PascalCase` for types.
+* `js_name = "..."` is emitted whenever the Rust ident differs from the JS
+  ident, so `wasm-bindgen` binds to the correct runtime name.
+* Reserved Rust keywords (e.g. `type`, `match`, `move`) are emitted as raw
+  identifiers (`r#type`).
+
+## 5. JS-name collisions with `js_sys` glob imports
+
+The generated preamble does `use js_sys::*;`, which brings every `js_sys`
+type into scope. A locally declared class with a colliding name (e.g.
+`WebAssembly.Global` vs `js_sys::Global`) would be ambiguous at every
+reference. We resolve this by:
+
+1. Picking a suffixed Rust ident (`Global` → `Global_`) for the
+   internal declaration.
+2. Keeping `js_name = "Global"` on the wasm-bindgen attr so the JS-side
+   binding is unaffected.
+3. Re-exporting under the original name so the public Rust path is
+   unchanged: `pub use Global_ as Global;`
+
+```rust
+pub mod web_assembly {
+    use js_sys::*;
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(extends = Object, js_name = "Global", js_namespace = "WebAssembly")]
+        pub type Global_;
+        #[wasm_bindgen(constructor, catch, js_name = "Global")]
+        pub fn new(...) -> Result<Global_, JsValue>;
+    }
+    pub use Global_ as Global;   // public face
+}
+```
+
+Consumers always write `web_assembly::Global`. The `_` suffix is an
+internal detail.
+
+## 6. Classes
+
+```ts
+class Greeter {
+  constructor(name: string);
+  greet(): string;
+}
+```
+
+emits a `pub type Greeter;` plus method bindings inside an
+`extern "C"` block. Constructors get `#[wasm_bindgen(constructor, catch)]`
+because JS constructors can always throw.
+
+`abstract` classes skip the constructor (you can't `new` an abstract
+class).
+
+## 7. Interfaces (class-like vs dictionary)
+
+Interfaces are classified by shape (see `parse/classify.rs`):
+
+* **Class-like** — has methods, used as a type: emit `pub type Foo;` plus
+  member bindings, just like a class. No constructor.
+* **Dictionary** — properties only, no methods, used as an options bag:
+  emit `pub type Foo;` plus a Rust-side `new()` factory and (usually) a
+  fluent builder. Setters/getters are still emitted as wasm-bindgen
+  bindings, the builder just calls them. See [§ 8 Dictionary builders].
+
+Multiple interface declarations with the same name + module context merge:
+their members union, their `extends` lists merge.
+
+## 8. Dictionary builders
+
+Dictionaries get an `impl` block with a Rust-side `new()` plus an
+ergonomic builder, depending on the property mix.
+
+### 8a. All-mutable properties → builder
+
+```ts
+interface ResponseInit {
+  status?: number;
+  statusText?: string;
+  headers?: Headers;
+}
+```
+
+emits:
+
+```rust
+impl ResponseInit {
+    pub fn new() -> Self { /* unchecked_into of new Object */ }
+    pub fn builder() -> ResponseInitBuilder { /* … */ }
+}
+
+pub struct ResponseInitBuilder { inner: ResponseInit }
+impl ResponseInitBuilder {
+    pub fn status(mut self, val: f64) -> Self {
+        self.inner.set_status(val);
+        self
+    }
+    pub fn status_text(mut self, val: &str) -> Self { /* … */ }
+    pub fn headers(mut self, val: &Headers) -> Self { /* … */ }
+    pub fn build(self) -> ResponseInit { self.inner }
+}
+```
+
+The builder's setter methods take ownership of `self` and return `Self`,
+producing the standard fluent chain:
+
+```rust
+let init = ResponseInit::builder().status(200.0).status_text("OK").build();
+```
+
+### 8b. Required properties → fallible `build() -> Result<T, JsValue>`
+
+When at least one property is required (no `?` and no `readonly` exempting
+it), the builder tracks unset required props with a `required: u64`
+bitmask and `build()` returns a `Result`:
+
+```rust
+pub struct NumberIndexedBuilder {
+    inner: NumberIndexed,
+    required: u64,
+}
+impl NumberIndexedBuilder {
+    pub fn length(mut self, val: f64) -> Self {
+        self.inner.set_length(val);
+        self.required &= 18446744073709551614u64; // clear bit 0
+        self
+    }
+    pub fn build(self) -> Result<NumberIndexed, JsValue> {
+        if self.required != 0 {
+            let mut missing = Vec::new();
+            if self.required & 1u64 != 0 {
+                missing.push("missing required property `length`");
+            }
+            return Err(JsValue::from_str(&format!(
+                "{}: {}",
+                stringify!(NumberIndexed),
+                missing.join(", ")
+            )));
+        }
+        Ok(self.inner)
+    }
+}
+```
+
+The bitmask supports up to 64 required properties per dictionary, which
+is more than enough for any realistic options bag.
+
+### 8c. Has any `readonly` property → `new()` only, no builder
+
+A dictionary that exposes a `readonly` property can't be fully
+constructed from the JS side via plain setter calls (the runtime would
+reject the write). To avoid silently producing invalid objects, ts-gen
+falls back to emitting only `new()`:
+
+```rust
+impl FooWithReadonly {
+    pub fn new() -> Self { /* unchecked_into of new Object */ }
+}
+```
+
+Callers must construct the underlying JS object themselves and cast
+into `FooWithReadonly` — there's no Rust-side builder for these.
+
+### 8d. Variadic / overloaded setters
+
+When a property's setter has union types (or the spec defines multiple
+setter overloads), each variant becomes a distinct builder method with
+the standard `_with_<type>` suffix — same naming machinery as method
+overloads (see [§ 11 Signature flattening]). Calling more than one of
+them on the same builder overwrites earlier values.
+
+```ts
+interface ResponseInit {
+  headers?: Headers | string[][] | Record<string, string>;
+}
+```
+
+emits builder methods `headers`, `headers_with_array`,
+`headers_with_record`.
+
+## 9. `var X: { new(...): T }` patterns
+
+The TypeScript trick of declaring a class via a variable + interface pair:
+
+```ts
+interface MyClass {
+  foo(): void;
+}
+declare var MyClass: {
+  new (n: number): MyClass;
+};
+```
+
+is recognised at parse time. The variable contributes the constructor,
+the interface contributes the methods, and the merged result emits as a
+single class. See `merge.rs` for the heuristic.
+
+## 10. Module-scoped constructor variables
+
+```ts
+declare module "cloudflare:email" {
+  let _EmailMessage: {
+    prototype: EmailMessage;
+    new (from: string, to: string, raw: ReadableStream | string): EmailMessage;
+  };
+  export { _EmailMessage as EmailMessage };
+}
+```
+
+Recognised as a module-scoped class declaration. Output:
+
+```rust
+pub mod email {
+    #[wasm_bindgen(module = "cloudflare:email")]
+    extern "C" {
+        #[wasm_bindgen]
+        pub type EmailMessage;
+        #[wasm_bindgen(constructor, catch)]
+        pub fn new(from: &str, to: &str, raw: &str) -> Result<EmailMessage, JsValue>;
+        // ...
+    }
+}
+```
+
+The `export { _EmailMessage as EmailMessage }` rename is captured in the
+`TypeRegistry::export_renames` map and applied to the public name.
+
+## 11. Signature flattening
+
+TypeScript can describe a single callable in several ways that all mean
+"there are multiple shapes of arguments this accepts": explicit
+overloads, optional parameters, union-typed parameters, variadics. They
+go through one shared pipeline in
+`codegen::signatures::expand_signatures` so the binding names and
+dedup behaviour stay consistent across the four cases.
+
+### 10a. The four input forms
+
+```ts
+// Explicit overloads — one or more sibling declarations sharing a name.
+function fetch(url: string): Promise<Response>;
+function fetch(url: string, init: RequestInit): Promise<Response>;
+
+// Optional parameters — `?` produces a truncation variant per prefix.
+function f(a: string, b?: number, c?: boolean): void;
+
+// Union-typed parameters — expand via cartesian product.
+function send(body: string | ArrayBuffer): void;
+
+// Variadic — `...args` becomes a wasm-bindgen `variadic` slice.
+function log(...args: any[]): void;
+```
+
+Conceptually all four describe the same thing: a JS callable whose
+caller has more than one valid argument shape.
+
+### 10b. The pipeline
+
+For every JS callable, `ts-gen`:
+
+1. **Per-overload expansion**: For each overload's parameter list,
+   generate every concrete variant. Optional params produce truncation
+   variants (one per prefix `[(a), (a, b), (a, b, c)]`); union params
+   expand via cartesian product (`(string | ArrayBuffer)` →
+   `[(string), (ArrayBuffer)]`); a trailing variadic stays trailing.
+2. **Cross-overload dedup**: When multiple overloads expand to the same
+   concrete parameter list, drop the duplicates. Two overloads that
+   both truncate to `(callback)` produce only one binding.
+3. **Suffix assignment**: Across all surviving expansions, compute
+   `_with_X` / `_with_X_and_Y` suffixes that disambiguate them. The
+   shortest-arity (or first) variant gets `""`; longer variants are
+   named after their additional parameters.
+
+The output is a `Vec<{ name_suffix, params }>` — a focused
+parameter-axis result. The per-callable layer (`build_signatures`)
+then handles the orthogonal decisions (base name, async-ness, `try_`
+companions, doc, error type).
+
+### 10c. Examples
+
+Optional truncation:
+
+```rust
+pub fn f(a: &str);
+pub fn f_with_b(a: &str, b: f64);
+pub fn f_with_b_and_c(a: &str, b: f64, c: bool);
+```
+
+Union-typed parameters:
+
+```rust
+pub fn send(body: &str);
+pub fn send_with_array_buffer(body: &ArrayBuffer);
+```
+
+Variadic — when it's the only differentiator from a sibling overload,
+the parameter name becomes the suffix:
+
+```rust
+#[wasm_bindgen(variadic)]
+pub fn log(args: &[JsValue]);
+```
+
+Mixed inputs — overload + optional + union:
+
+```ts
+function show(): void;
+function show(value: string | number, opts?: ShowOpts): void;
+```
+
+Phase 1 expands overload 1 over `string | number × optional opts` to
+four variants: `(string)`, `(number)`, `(string, opts)`,
+`(number, opts)`. Phase 2 dedups against overload 0's empty `()`.
+Phase 3 assigns suffixes:
+
+```rust
+pub fn show();
+pub fn show_with_value(value: &str);
+pub fn show_with_value_and_opts(value: &str, opts: &ShowOpts);
+pub fn show_with_value_a(value: f64);
+pub fn show_with_value_a_and_opts(value: f64, opts: &ShowOpts);
+```
+
+`compute_rust_names` in `codegen::signatures` handles the suffix
+disambiguation, including readability adjustments when the same
+parameter name appears in multiple alternatives.
+
+### 10d. Why a single pipeline
+
+Treating optional, union, overload, and variadic as one parameter-axis
+problem keeps suffix naming consistent (the `_with_X` rules apply to
+every binding regardless of which input form produced it),
+keeps cross-overload dedup honest (truncation collisions get dropped
+once across all input forms), and keeps the per-callable layer
+oblivious to the combinatorics.
+
+An earlier design interleaved the four expansions across the codebase
+and produced near-duplicate bindings whenever two of them combined.
+
+## 12. Methods + the `try_<name>` companion
+
+For sync methods and free functions, every primary binding gets a fallible
+companion that catches synchronous JS exceptions:
+
+```rust
+#[wasm_bindgen(method)]
+pub fn frobnicate(this: &Foo) -> String;
+
+#[wasm_bindgen(method, catch, js_name = "frobnicate")]
+pub fn try_frobnicate(this: &Foo) -> Result<String, JsValue>;
+```
+
+The non-`try_` form panics on JS throw; the `try_` form returns `Result`.
+Setters and constructors don't get a `try_` companion (setters never
+catch; constructors always catch).
+
+## 13. `Promise<T>` returns become `async fn`
+
+```ts
+function fetch(url: string): Promise<Response>;
+```
+
+emits a single async signature with `catch`:
+
+```rust
+#[wasm_bindgen(catch)]
+pub async fn fetch(url: &str) -> Result<Response, JsValue>;
+```
+
+* The async + catch form is already fallible — no `try_fetch` companion.
+* `wasm-bindgen` rewraps the `T` as `Promise<T>` on the JS side.
+* Constructors and setters never become async.
+
+## 14. `@throws` JSDoc → typed error
+
+```ts
+/**
+ * @throws {ImagesError} if upload fails
+ */
+upload(file: File): Promise<ImageMetadata>;
+```
+
+emits `Result<ImageMetadata, ImagesError>` instead of `Result<_,
+JsValue>`. Recognised forms:
+
+* `@throws {TypeError} when foo` — single type
+* `@throws {TypeError | RangeError} when bar` — inline union
+* `@throws {@link ImagesError} if foo` — `{@link X}` collapses to `X`
+* Multiple `@throws` lines aggregate into one effective union
+* `@throws Sentence describing condition.` — pure prose, no structured
+  type extracted
+
+The original prose surfaces in the rendered doc as an `## Errors` section.
+
+## 15. Subtyping LUB across unions
+
+`TypeRef::Union` resolution applies a Least Upper Bound across its members
+based on the subtyping lattice in `codegen::subtyping`:
+
+```text
+TypeError                            -> Error
+TypeError | RangeError               -> Error      (both subclass Error)
+TypeError | string                   -> JsValue    (no shared ancestor below Object)
+BadRequestError | NotFoundError      -> StreamError (when both extend StreamError)
+```
+
+The lattice is built from:
+
+* A static `BUILTIN_PARENTS` table for JS Error / DOM / collection /
+  typed-array hierarchies.
+* User-declared `class extends X` / `interface extends X` chains, walked
+  through the codegen scope.
+
+When the deepest common ancestor is `Object` (no useful narrowing), the
+union erases to `JsValue` — the existing default. This rule is universal:
+it applies to `@throws` unions and to any TS union return type.
+
+## 16. Module declarations and namespace nesting
+
+```ts
+declare module "cloudflare:email" {
+  // ...
+}
+```
+
+emits a `pub mod email { ... }` (the prefix `cloudflare:` is stripped to
+the part after the last `:`). All bindings inside use
+`#[wasm_bindgen(module = "cloudflare:email")]`. Cross-module references
+go through the parent scope's re-exports.
+
+```ts
+namespace WebAssembly {
+  class Module { ... }
+}
+```
+
+emits a `pub mod web_assembly { ... }` with `#[wasm_bindgen(js_namespace
+= "WebAssembly")]` on each member. The namespace lookup is one-deep —
+nested namespaces are not yet supported.
+
+## 17. Type aliases and `export { X as Y }`
+
+* `type Foo = Bar;` → `pub type Foo = Bar;` if `Bar` is a recognised
+  type, or chases the alias chain to its terminal during codegen.
+* `export { Local as Public };` (sourceless) → recorded in
+  `TypeRegistry::export_renames`. The local declaration is published
+  under the public name, and any redundant alias stub is suppressed.
+* `export { X as Y } from "...";` (with source) → registered as an import
+  from the named module.
+
+## 18. String and numeric enums
+
+```ts
+enum Color { Red = "red", Green = "green" }
+```
+
+emits a `pub enum Color { Red, Green }` plus serde-aware `to_string` /
+`try_from_str` impls. `wasm-bindgen` doesn't handle string enums
+natively, so we lower these to Rust-side enums + a `JsValue` round-trip.
+
+Numeric enums lower similarly with explicit discriminant values.
+
+## 19. Multiple-context name resolution
+
+When the same name appears in different `ModuleContext`s (e.g. a global
+`interface EmailMessage` and a `cloudflare:email`-scoped class
+`EmailMessage`), they remain distinct types. `merge_class_pairs` keys on
+`(name, ModuleContext)` to keep them separate. Same-context same-name
+still merges as expected.

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -26,8 +26,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::codegen::signatures::{
-    dedupe_name, expand_signatures, generate_concrete_params, is_void_return, ExpandedSignature,
-    SignatureKind,
+    build_signatures, dedupe_name, generate_concrete_params, is_void_return, CallableSpec,
+    FunctionSignature, SignatureKind,
 };
 use crate::codegen::typemap::{to_return_type, to_syn_type, CodegenContext, TypePosition};
 use crate::ir::{
@@ -118,6 +118,19 @@ impl<'a> ClassConfig<'a> {
             cgctx,
             scope,
         }
+    }
+
+    /// Rust name to use everywhere the class identifier appears in generated
+    /// code (`pub type X`, `this: &X`, `static_method_of = X`, …).
+    ///
+    /// When the declared name collides with a `js_sys` reserved identifier,
+    /// `CodegenContext::resolve_collisions` chose a suffixed alternative
+    /// (`Global` → `Global_`); this method threads that through. Falls back
+    /// to the original `rust_name` when no rename was registered.
+    fn effective_rust_name(&self) -> String {
+        self.cgctx
+            .and_then(|ctx| ctx.renamed_locals.get(&self.rust_name).cloned())
+            .unwrap_or_else(|| self.rust_name.clone())
     }
 }
 
@@ -210,7 +223,7 @@ pub fn generate_dictionary_extern(
 /// }
 /// ```
 fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
-    let rust_type = super::typemap::make_ident(&config.rust_name);
+    let rust_type = super::typemap::make_ident(&config.effective_rust_name());
     let builder_name = super::typemap::make_ident(&format!("{}Builder", config.rust_name));
 
     // If any getter lacks a corresponding setter the type has readonly
@@ -292,12 +305,17 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
         };
 
         let mut setter_used = HashSet::new();
-        let setter_sigs = expand_signatures(
-            &g.js_name,
-            &[&[setter_param]],
-            &crate::ir::TypeRef::Void,
-            SignatureKind::Setter,
-            &None,
+        let setter_overloads = [&[setter_param][..]];
+        let void = crate::ir::TypeRef::Void;
+        let setter_sigs = build_signatures(
+            &CallableSpec {
+                js_name: &g.js_name,
+                kind: SignatureKind::Setter,
+                overloads: &setter_overloads,
+                return_type: &void,
+                error_type: None,
+                doc: &None,
+            },
             &mut setter_used,
             config.cgctx,
             config.scope,
@@ -479,12 +497,22 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                     .map(|c| c.params.as_slice())
                     .collect();
                 let doc = constructor_overloads.first().and_then(|c| c.doc.clone());
-                let sigs = expand_signatures(
-                    &config.js_name,
-                    &overloads,
-                    &TypeRef::Named(config.rust_name.clone()),
-                    SignatureKind::Constructor,
-                    &doc,
+                // Use the first overload's `@throws` (if any) as the error
+                // type for the constructor — TS overloads conventionally
+                // share semantics, and the first one carries the doc.
+                let throws = constructor_overloads
+                    .first()
+                    .and_then(|c| c.throws.as_ref());
+                let return_type = TypeRef::Named(config.rust_name.clone());
+                let sigs = build_signatures(
+                    &CallableSpec {
+                        js_name: &config.js_name,
+                        kind: SignatureKind::Constructor,
+                        overloads: &overloads,
+                        return_type: &return_type,
+                        error_type: throws,
+                        doc: &doc,
+                    },
                     &mut used_names,
                     config.cgctx,
                     config.scope,
@@ -503,12 +531,16 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                 let overloads: Vec<&[Param]> = group.iter().map(|m| m.params.as_slice()).collect();
                 let doc = group.first().and_then(|m| m.doc.clone());
                 let return_type = &group[0].return_type;
-                let sigs = expand_signatures(
-                    &m.js_name,
-                    &overloads,
-                    return_type,
-                    SignatureKind::Method,
-                    &doc,
+                let throws = group.first().and_then(|m| m.throws.as_ref());
+                let sigs = build_signatures(
+                    &CallableSpec {
+                        js_name: &m.js_name,
+                        kind: SignatureKind::Method,
+                        overloads: &overloads,
+                        return_type,
+                        error_type: throws,
+                        doc: &doc,
+                    },
                     &mut used_names,
                     config.cgctx,
                     config.scope,
@@ -527,12 +559,16 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                 let overloads: Vec<&[Param]> = group.iter().map(|m| m.params.as_slice()).collect();
                 let doc = group.first().and_then(|m| m.doc.clone());
                 let return_type = &group[0].return_type;
-                let sigs = expand_signatures(
-                    &m.js_name,
-                    &overloads,
-                    return_type,
-                    SignatureKind::StaticMethod,
-                    &doc,
+                let throws = group.first().and_then(|m| m.throws.as_ref());
+                let sigs = build_signatures(
+                    &CallableSpec {
+                        js_name: &m.js_name,
+                        kind: SignatureKind::StaticMethod,
+                        overloads: &overloads,
+                        return_type,
+                        error_type: throws,
+                        doc: &doc,
+                    },
                     &mut used_names,
                     config.cgctx,
                     config.scope,
@@ -566,11 +602,24 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
         None => quote! { #[wasm_bindgen] },
     };
 
+    // Re-export the type under its original (un-suffixed) name when collision
+    // resolution renamed it. The suffixed name (`Foo_`) is purely an internal
+    // disambiguator against the `use js_sys::*` glob inside the surrounding
+    // module — it must never leak into the public Rust path consumers see.
+    let public_alias = if config.effective_rust_name() != config.rust_name {
+        let public = super::typemap::make_ident(&config.rust_name);
+        let internal = super::typemap::make_ident(&config.effective_rust_name());
+        quote! { pub use #internal as #public; }
+    } else {
+        quote! {}
+    };
+
     quote! {
         #wb_extern_attr
         extern "C" {
             #(#items)*
         }
+        #public_alias
     }
 }
 
@@ -582,7 +631,16 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
 /// pub type FooBar;
 /// ```
 fn generate_type_decl(config: &ClassConfig) -> TokenStream {
-    let rust_ident = super::typemap::make_ident(&config.rust_name);
+    // If the bare class name collided with a `js_sys` reserved name (e.g.
+    // `Global`, `Function`), `CodegenContext::resolve_collisions` chose a
+    // suffixed Rust name (`Global_`). The type decl needs to use that
+    // renamed identifier so references through `to_syn_type` line up.
+    // The original JS-side name still goes through `js_name = "..."` below.
+    let rust_name = config
+        .cgctx
+        .and_then(|ctx| ctx.renamed_locals.get(&config.rust_name).cloned())
+        .unwrap_or_else(|| config.rust_name.clone());
+    let rust_ident = super::typemap::make_ident(&rust_name);
     let js_name = &config.js_name;
 
     // Build wasm_bindgen attribute parts
@@ -611,8 +669,10 @@ fn generate_type_decl(config: &ClassConfig) -> TokenStream {
         wb_parts.push(quote! { extends = Object });
     }
 
-    // Only emit js_name if it differs from the Rust name
-    if config.js_name != config.rust_name {
+    // Emit `js_name` whenever the JS-side class name differs from the Rust
+    // ident we'll use — that's true after a collision rename even if the
+    // `config.rust_name` (pre-rename) matched `js_name`.
+    if rust_name != *js_name {
         wb_parts.push(quote! { js_name = #js_name });
     }
 
@@ -634,18 +694,21 @@ fn generate_type_decl(config: &ClassConfig) -> TokenStream {
     }
 }
 
-/// Generate a constructor binding from an expanded signature.
-fn generate_expanded_constructor(config: &ClassConfig, sig: &ExpandedSignature) -> TokenStream {
+/// Generate a constructor binding from a resolved signature.
+fn generate_expanded_constructor(config: &ClassConfig, sig: &FunctionSignature) -> TokenStream {
     let rust_ident = super::typemap::make_ident(&sig.rust_name);
-    let rust_type = super::typemap::make_ident(&config.rust_name);
     let params = generate_concrete_params(&sig.params, config.cgctx, config.scope);
     let doc = super::doc_tokens(&sig.doc);
 
-    let ret = if sig.catch {
-        quote! { Result<#rust_type, JsValue> }
-    } else {
-        quote! { #rust_type }
-    };
+    // Constructors always return the constructed type, wrapped in Result
+    // when `catch` (which is always-true here per `SignatureKind::Constructor`).
+    let ret = to_return_type(
+        &sig.return_type,
+        sig.catch,
+        sig.error_type.as_ref(),
+        config.cgctx,
+        config.scope,
+    );
 
     let mut wb_parts = vec![quote! { constructor }];
     if sig.catch {
@@ -666,9 +729,9 @@ fn generate_expanded_constructor(config: &ClassConfig, sig: &ExpandedSignature) 
 }
 
 /// Generate an instance method binding from an expanded signature.
-fn generate_expanded_method(config: &ClassConfig, sig: &ExpandedSignature) -> TokenStream {
+fn generate_expanded_method(config: &ClassConfig, sig: &FunctionSignature) -> TokenStream {
     let rust_ident = super::typemap::make_ident(&sig.rust_name);
-    let this_type = super::typemap::make_ident(&config.rust_name);
+    let this_type = super::typemap::make_ident(&config.effective_rust_name());
     let params = generate_concrete_params(&sig.params, config.cgctx, config.scope);
     let doc = super::doc_tokens(&sig.doc);
     let has_variadic = sig.params.last().is_some_and(|p| p.variadic);
@@ -686,7 +749,13 @@ fn generate_expanded_method(config: &ClassConfig, sig: &ExpandedSignature) -> To
         wb_parts.push(quote! { js_name = #js_name });
     }
 
-    let ret_ty = to_return_type(&sig.return_type, sig.catch, config.cgctx, config.scope);
+    let ret_ty = to_return_type(
+        &sig.return_type,
+        sig.catch,
+        sig.error_type.as_ref(),
+        config.cgctx,
+        config.scope,
+    );
     let ret = if is_void_return(&sig.return_type) && !sig.catch {
         quote! {}
     } else {
@@ -707,9 +776,9 @@ fn generate_expanded_method(config: &ClassConfig, sig: &ExpandedSignature) -> To
 }
 
 /// Generate a static method binding from an expanded signature.
-fn generate_expanded_static_method(config: &ClassConfig, sig: &ExpandedSignature) -> TokenStream {
+fn generate_expanded_static_method(config: &ClassConfig, sig: &FunctionSignature) -> TokenStream {
     let rust_ident = super::typemap::make_ident(&sig.rust_name);
-    let class_ident = super::typemap::make_ident(&config.rust_name);
+    let class_ident = super::typemap::make_ident(&config.effective_rust_name());
     let params = generate_concrete_params(&sig.params, config.cgctx, config.scope);
     let doc = super::doc_tokens(&sig.doc);
     let has_variadic = sig.params.last().is_some_and(|p| p.variadic);
@@ -726,7 +795,13 @@ fn generate_expanded_static_method(config: &ClassConfig, sig: &ExpandedSignature
         wb_parts.push(quote! { js_name = #js_name });
     }
 
-    let ret_ty = to_return_type(&sig.return_type, sig.catch, config.cgctx, config.scope);
+    let ret_ty = to_return_type(
+        &sig.return_type,
+        sig.catch,
+        sig.error_type.as_ref(),
+        config.cgctx,
+        config.scope,
+    );
     let ret = if is_void_return(&sig.return_type) && !sig.catch {
         quote! {}
     } else {
@@ -752,7 +827,7 @@ fn generate_getter(
     getter: &GetterMember,
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
-    let this_type = super::typemap::make_ident(&config.rust_name);
+    let this_type = super::typemap::make_ident(&config.effective_rust_name());
     let doc = super::doc_tokens(&getter.doc);
 
     let candidate = to_snake_case(&getter.js_name);
@@ -796,7 +871,7 @@ fn generate_setter(
     setter: &SetterMember,
     used_names: &mut HashSet<String>,
 ) -> Vec<TokenStream> {
-    let this_type = super::typemap::make_ident(&config.rust_name);
+    let this_type = super::typemap::make_ident(&config.effective_rust_name());
     let doc = setter.doc.clone();
 
     // Treat the setter as a single-param method and expand through signatures
@@ -807,12 +882,17 @@ fn generate_setter(
         variadic: false,
     };
 
-    let sigs = expand_signatures(
-        &setter.js_name,
-        &[&[param]],
-        &crate::ir::TypeRef::Void,
-        SignatureKind::Setter,
-        &doc,
+    let overloads = [&[param][..]];
+    let void = crate::ir::TypeRef::Void;
+    let sigs = build_signatures(
+        &CallableSpec {
+            js_name: &setter.js_name,
+            kind: SignatureKind::Setter,
+            overloads: &overloads,
+            return_type: &void,
+            error_type: None,
+            doc: &doc,
+        },
         used_names,
         config.cgctx,
         config.scope,
@@ -845,7 +925,7 @@ fn generate_static_getter(
     getter: &StaticGetterMember,
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
-    let class_ident = super::typemap::make_ident(&config.rust_name);
+    let class_ident = super::typemap::make_ident(&config.effective_rust_name());
     let doc = super::doc_tokens(&getter.doc);
 
     let candidate = to_snake_case(&getter.js_name);
@@ -881,7 +961,7 @@ fn generate_static_setter(
     setter: &StaticSetterMember,
     used_names: &mut HashSet<String>,
 ) -> Vec<TokenStream> {
-    let class_ident = super::typemap::make_ident(&config.rust_name);
+    let class_ident = super::typemap::make_ident(&config.effective_rust_name());
     let doc = setter.doc.clone();
 
     let param = crate::ir::Param {
@@ -891,12 +971,17 @@ fn generate_static_setter(
         variadic: false,
     };
 
-    let sigs = expand_signatures(
-        &setter.js_name,
-        &[&[param]],
-        &crate::ir::TypeRef::Void,
-        SignatureKind::StaticSetter,
-        &doc,
+    let overloads = [&[param][..]];
+    let void = crate::ir::TypeRef::Void;
+    let sigs = build_signatures(
+        &CallableSpec {
+            js_name: &setter.js_name,
+            kind: SignatureKind::StaticSetter,
+            overloads: &overloads,
+            return_type: &void,
+            error_type: None,
+            doc: &doc,
+        },
         used_names,
         config.cgctx,
         config.scope,

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -4,7 +4,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::codegen::signatures::{
-    expand_signatures, generate_concrete_params, is_void_return, ExpandedSignature, SignatureKind,
+    build_signatures, generate_concrete_params, is_void_return, CallableSpec, FunctionSignature,
+    SignatureKind,
 };
 use crate::codegen::typemap::{to_return_type, to_syn_type, CodegenContext, TypePosition};
 use crate::parse::scope::ScopeId;
@@ -14,7 +15,8 @@ use crate::ir::{FunctionDecl, ModuleContext, VariableDecl};
 
 /// Generate wasm_bindgen extern blocks for a free function.
 ///
-/// Expands optional params into multiple overloads, and generates `try_` variants.
+/// Resolves overloads + try_/async/catch via [`build_signatures`], then
+/// emits one extern block per resulting [`FunctionSignature`].
 pub fn generate_function(
     decl: &FunctionDecl,
     ctx: &ModuleContext,
@@ -22,24 +24,7 @@ pub fn generate_function(
     doc: &Option<String>,
     scope: ScopeId,
 ) -> TokenStream {
-    let mut used_names = HashSet::new();
-    let sigs = expand_signatures(
-        &decl.js_name,
-        &[decl.params.as_slice()],
-        &decl.return_type,
-        SignatureKind::Function,
-        doc,
-        &mut used_names,
-        cgctx,
-        scope,
-    );
-
-    let items: Vec<TokenStream> = sigs
-        .iter()
-        .map(|sig| generate_expanded_free_function(sig, ctx, cgctx, None, scope))
-        .collect();
-
-    quote! { #(#items)* }
+    emit_function(decl, ctx, cgctx, doc, None, scope)
 }
 
 /// Generate wasm_bindgen extern blocks for a free function inside a namespace.
@@ -51,13 +36,28 @@ pub fn generate_function_with_js_namespace(
     doc: &Option<String>,
     scope: ScopeId,
 ) -> TokenStream {
+    emit_function(decl, ctx, cgctx, doc, Some(js_namespace), scope)
+}
+
+fn emit_function(
+    decl: &FunctionDecl,
+    ctx: &ModuleContext,
+    cgctx: Option<&CodegenContext<'_>>,
+    doc: &Option<String>,
+    js_namespace: Option<&str>,
+    scope: ScopeId,
+) -> TokenStream {
     let mut used_names = HashSet::new();
-    let sigs = expand_signatures(
-        &decl.js_name,
-        &[decl.params.as_slice()],
-        &decl.return_type,
-        SignatureKind::Function,
-        doc,
+    let overloads = [decl.params.as_slice()];
+    let sigs = build_signatures(
+        &CallableSpec {
+            js_name: &decl.js_name,
+            kind: SignatureKind::Function,
+            overloads: &[overloads[0]],
+            return_type: &decl.return_type,
+            error_type: decl.throws.as_ref(),
+            doc,
+        },
         &mut used_names,
         cgctx,
         scope,
@@ -65,15 +65,15 @@ pub fn generate_function_with_js_namespace(
 
     let items: Vec<TokenStream> = sigs
         .iter()
-        .map(|sig| generate_expanded_free_function(sig, ctx, cgctx, Some(js_namespace), scope))
+        .map(|sig| generate_expanded_free_function(sig, ctx, cgctx, js_namespace, scope))
         .collect();
 
     quote! { #(#items)* }
 }
 
-/// Generate a single extern block for one expanded free function signature.
+/// Generate a single extern block for one resolved free function signature.
 fn generate_expanded_free_function(
-    sig: &ExpandedSignature,
+    sig: &FunctionSignature,
     ctx: &ModuleContext,
     cgctx: Option<&CodegenContext<'_>>,
     js_namespace: Option<&str>,
@@ -81,7 +81,13 @@ fn generate_expanded_free_function(
 ) -> TokenStream {
     let rust_ident = super::typemap::make_ident(&sig.rust_name);
     let params = generate_concrete_params(&sig.params, cgctx, scope);
-    let ret_ty = to_return_type(&sig.return_type, sig.catch, cgctx, scope);
+    let ret_ty = to_return_type(
+        &sig.return_type,
+        sig.catch,
+        sig.error_type.as_ref(),
+        cgctx,
+        scope,
+    );
     let doc = super::doc_tokens(&sig.doc);
     let has_variadic = sig.params.last().is_some_and(|p| p.variadic);
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,6 +7,7 @@ pub mod classes;
 pub mod enums;
 pub mod functions;
 pub mod signatures;
+pub mod subtyping;
 pub mod typemap;
 
 use proc_macro2::TokenStream;

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -1,37 +1,30 @@
 //! Signature expansion: expand TypeScript overloads (with optional/variadic/union
-//! params) into multiple concrete Rust signatures with computed names.
+//! params) into multiple concrete Rust parameter lists, each tagged with a
+//! disambiguating name suffix.
 //!
-//! This implements the core overload expansion algorithm, following the same
-//! pattern as wasm-bindgen's webidl codegen (`util.rs:create_imports`).
+//! This module is focused exclusively on the **parameter axis** — what
+//! variants does a single JS callable produce based on its overloads, optionals,
+//! and union-typed params? Decisions about `catch` / `try_` / `async fn` /
+//! return types belong in the per-callable emitters (constructors, methods,
+//! free functions, static methods) — those are the parts that vary by what
+//! kind of callable we're emitting and what the source IR member tells us
+//! about errors and async-ness.
 //!
-//! # Overview
-//!
-//! TypeScript overloads describe multiple ways to call the same runtime function.
-//! They are semantically equivalent to unions spread across declarations.
-//! `expand_signatures` takes ALL overloads of a single JS function and produces
-//! the complete set of Rust bindings for it.
-//!
-//! The algorithm has three phases:
+//! # Algorithm
 //!
 //! 1. **Per-overload expansion**: For each overload, generate optional truncation
 //!    variants and cartesian-product union type alternatives.
 //! 2. **Cross-overload dedup**: Remove expanded signatures with identical concrete
 //!    param lists (e.g. two overloads both truncate to `(callback)`).
-//! 3. **Naming**: Compute `_with_`/`_and_` suffixes across all surviving signatures
-//!    as one cohort, then assign final unique names via the shared `used_names` set.
+//! 3. **Suffix**: Compute `_with_X` / `_with_X_and_Y` suffixes across all surviving
+//!    signatures as one cohort.
 //!
 //! # Expansion Rules
 //!
 //! Given `f(a, b?, c?)`:
-//! - `f(a)` — base signature
-//! - `f_with_b(a, b)` — first optional included
-//! - `f_with_b_and_c(a, b, c)` — all params included
-//!
-//! # Catch Rules
-//!
-//! - **Constructors**: always `catch` (JS constructors can always throw)
-//! - **Methods/Functions**: no `catch` by default; a `try_` prefixed variant
-//!   is generated with `catch` for each expanded signature
+//! - `f(a)`         — base signature, suffix `""`
+//! - `f(a, b)`      — first optional included, suffix `"_with_b"`
+//! - `f(a, b, c)`   — all params included, suffix `"_with_b_and_c"`
 //!
 //! # Variadic
 //!
@@ -39,6 +32,13 @@
 //! Variadic params participate in `_with_`/`_and_` suffix computation — if a
 //! signature differs from its siblings only by having a trailing variadic param,
 //! the param name is used as a suffix (e.g. `_with_args`).
+//!
+//! # `try_` and `async` are not handled here
+//!
+//! The decision to emit `name` + `try_name` (sync, fallible companion) or just a
+//! single `async fn name() -> Result<T, E>` (Promise-returning methods) is per-
+//! callable and depends on return-type analysis. See `emit_callable_variants`
+//! in the parent `codegen` module for that layer.
 
 use std::collections::HashSet;
 
@@ -50,7 +50,14 @@ use crate::ir::{Param, TypeRef};
 use crate::parse::scope::ScopeId;
 use crate::util::naming::to_snake_case;
 
-/// What kind of callable we're expanding.
+/// What kind of callable an emitter is producing — drives default-naming
+/// (`new`, `set_x`, snake-case, …) and which `wasm_bindgen` attributes to
+/// stamp on the binding. Setters and constructors don't generate `try_`
+/// companions or `async fn` forms.
+///
+/// `expand_signatures` itself is kind-agnostic: it only does parameter-axis
+/// work. This enum is the contract between [`base_rust_name`] and the
+/// per-callable emitters in `classes.rs` / `functions.rs`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignatureKind {
     Constructor,
@@ -59,6 +66,35 @@ pub enum SignatureKind {
     Function,
     Setter,
     StaticSetter,
+}
+
+impl SignatureKind {
+    /// Whether this kind can produce a `try_<name>` fallible companion.
+    pub fn allows_try_variant(self) -> bool {
+        !matches!(self, Self::Constructor | Self::Setter | Self::StaticSetter)
+    }
+
+    /// Whether this kind can collapse a `Promise<T>` return into `async fn`.
+    pub fn allows_async(self) -> bool {
+        !matches!(self, Self::Constructor | Self::Setter | Self::StaticSetter)
+    }
+
+    /// Whether the binding always requires `catch` (constructors do).
+    pub fn always_catches(self) -> bool {
+        matches!(self, Self::Constructor)
+    }
+}
+
+/// Compute the default Rust name for a callable's primary variant before
+/// any `_with_X` suffix is appended.
+pub fn base_rust_name(js_name: &str, kind: SignatureKind) -> String {
+    match kind {
+        SignatureKind::Constructor => "new".to_string(),
+        SignatureKind::Setter | SignatureKind::StaticSetter => {
+            format!("set_{}", to_snake_case(js_name))
+        }
+        _ => to_snake_case(js_name),
+    }
 }
 
 /// A single concrete parameter in an expanded signature.
@@ -70,29 +106,49 @@ pub struct ConcreteParam {
     pub variadic: bool,
 }
 
-/// A single expanded, ready-to-codegen signature.
+/// One concrete parameter-list variant produced by overload expansion,
+/// paired with a suffix that disambiguates it from its siblings in Rust.
+///
+/// The caller adds the suffix to a base name of its choosing (`new`,
+/// `set_X`, `to_snake_case(js_name)`, `try_<name>`, etc.) and dedups
+/// against the surrounding extern block's used-name set.
 #[derive(Clone, Debug)]
 pub struct ExpandedSignature {
-    /// Rust function name — unique within the extern block.
-    pub rust_name: String,
-    /// JS function name (the real name on the JS side)
-    pub js_name: String,
-    /// Concrete params (no optional flags — those have been resolved by truncation)
+    /// `_with_X` / `_with_X_and_Y` suffix — empty for the primary
+    /// (most-truncated) variant when only one signature survives, or when
+    /// the variant is the shortest in its cohort.
+    pub name_suffix: String,
+    /// Concrete params (no optional flags — those have been resolved by
+    /// truncation; no union types — those have been cartesian-expanded).
     pub params: Vec<ConcreteParam>,
-    /// Whether to apply `catch` (wrap return in `Result<T, JsValue>`)
+}
+
+/// A fully-resolved emitter input: an [`ExpandedSignature`] augmented with
+/// the per-emit decisions (final Rust name, `catch`, `async`, return type,
+/// doc, error type) that the per-callable layer made.
+///
+/// This is what concrete emitters (`generate_method`, etc.) consume. Build
+/// via [`build_signatures`].
+#[derive(Clone, Debug)]
+pub struct FunctionSignature {
+    /// Final Rust function name — already deduped against the extern block's
+    /// used-names set.
+    pub rust_name: String,
+    /// JS function name, copied from the source for `js_name = "..."`.
+    pub js_name: String,
+    pub params: Vec<ConcreteParam>,
+    /// Wrap return in `Result<T, ErrTy>`.
     pub catch: bool,
-    /// Return type. For `is_async` signatures this is the *unwrapped* `T` from
-    /// the original `Promise<T>` — wasm-bindgen's async fn lowering rewraps it
-    /// as a Promise on the JS side automatically.
-    pub return_type: TypeRef,
-    /// Doc comment (only on the primary/shortest signature)
-    pub doc: Option<String>,
-    /// What kind of callable this is
-    pub kind: SignatureKind,
-    /// Emit as `async fn`. Set when the original return type was `Promise<T>`
-    /// and `kind` permits async (i.e. not a constructor/setter). The
-    /// `return_type` field carries the unwrapped `T`.
+    /// Emit as `async fn`. The `return_type` here carries the *unwrapped*
+    /// `T` — wasm-bindgen rewraps it as `Promise<T>` in the JS shim.
     pub is_async: bool,
+    /// Return type (already Promise-unwrapped when `is_async`).
+    pub return_type: TypeRef,
+    /// Custom error type for the `Result` wrapper. `None` falls back to
+    /// `JsValue` in [`to_return_type`].
+    pub error_type: Option<TypeRef>,
+    /// Doc comment — copied to every signature in the cohort.
+    pub doc: Option<String>,
 }
 
 /// Assign a unique name within the extern block.
@@ -117,43 +173,24 @@ pub fn dedupe_name(candidate: &str, used_names: &mut HashSet<String>) -> String 
     }
 }
 
-/// Expand all overloads of a single JS function into concrete Rust signatures.
+/// Expand all overloads of a single JS callable into concrete Rust parameter
+/// variants, each tagged with a disambiguating suffix.
 ///
-/// Takes ALL overloads (param lists) sharing the same `js_name` and produces
-/// the complete set of bindings. The algorithm:
+/// 1. **Per-overload expansion**: optional truncation + union cartesian product.
+/// 2. **Cross-overload dedup**: drop expansions with identical concrete params.
+/// 3. **Suffix**: assign `_with_X` / `_with_X_and_Y` suffixes across the cohort.
 ///
-/// 1. For each overload: generate optional truncation variants, then expand
-///    union types via cartesian product.
-/// 2. Dedup: remove expanded signatures with identical concrete param lists
-///    across overloads.
-/// 3. Name: compute `_with_`/`_and_` suffixes across all surviving signatures,
-///    then assign final unique names via the shared `used_names` set.
-/// 4. Generate `try_` variants (non-constructors only).
-#[allow(clippy::too_many_arguments)]
+/// The caller is responsible for choosing a base name, applying the suffix,
+/// and deduping the final names against the surrounding extern block.
 pub fn expand_signatures(
-    js_name: &str,
     overloads: &[&[Param]],
-    return_type: &TypeRef,
-    kind: SignatureKind,
-    doc: &Option<String>,
-    used_names: &mut HashSet<String>,
     cgctx: Option<&CodegenContext<'_>>,
     scope: ScopeId,
 ) -> Vec<ExpandedSignature> {
-    let base_rust_name = match kind {
-        SignatureKind::Constructor => "new".to_string(),
-        SignatureKind::Setter | SignatureKind::StaticSetter => {
-            format!("set_{}", to_snake_case(js_name))
-        }
-        _ => to_snake_case(js_name),
-    };
-
     // Phase 1: Per-overload expansion — optional truncation + union cartesian product.
     let mut all_sigs: Vec<Vec<ConcreteParam>> = Vec::new();
-
     for params in overloads {
-        let expanded = expand_single_overload(params, cgctx, scope);
-        all_sigs.extend(expanded);
+        all_sigs.extend(expand_single_overload(params, cgctx, scope));
     }
 
     // Phase 2: Cross-overload dedup — remove identical expanded signatures.
@@ -166,77 +203,133 @@ pub fn expand_signatures(
         }
     }
 
-    // Phase 3: Naming — compute candidate names, then assign final unique names.
-    let candidate_names = compute_rust_names(&base_rust_name, &deduped);
-    let is_constructor = kind == SignatureKind::Constructor;
+    // Phase 3: Suffix — compute `_with_X` disambiguators across the cohort.
+    compute_suffixes(&deduped)
+        .into_iter()
+        .zip(deduped)
+        .map(|(name_suffix, params)| ExpandedSignature {
+            name_suffix,
+            params,
+        })
+        .collect()
+}
 
-    // Promise-returning methods/functions/static-methods collapse into a single
-    // async signature instead of the usual `name` + `try_name` pair. The async
-    // form is fallible (`-> Result<T, JsValue>`) and `.await`-able, which is
-    // strictly more useful than a sync `-> Promise<T>` plus a `try_` variant.
-    // Constructors and setters never become async — they don't return promises.
-    let async_eligible = !matches!(
-        kind,
-        SignatureKind::Constructor | SignatureKind::Setter | SignatureKind::StaticSetter
-    );
-    let (async_unwrapped_ret, is_async) = match return_type {
-        TypeRef::Promise(inner) if async_eligible => (inner.as_ref().clone(), true),
-        _ => (return_type.clone(), false),
+/// Per-callable input describing a JS callable that needs to be emitted as
+/// one or more wasm-bindgen extern signatures. Pairs with [`build_signatures`].
+///
+/// All decisions about `try_` companions, `async fn` collapse, and `catch`
+/// fall out of the kind + return type + error type once these inputs are
+/// available.
+#[derive(Clone, Debug)]
+pub struct CallableSpec<'a> {
+    pub js_name: &'a str,
+    pub kind: SignatureKind,
+    /// All overloads sharing this `js_name` — typically one element, but TS
+    /// allows multiple overloaded declarations.
+    pub overloads: &'a [&'a [Param]],
+    pub return_type: &'a TypeRef,
+    /// Optional error type from `@throws` — `None` means use the default
+    /// `JsValue` for any catching variant.
+    pub error_type: Option<&'a TypeRef>,
+    /// Doc comment to attach to the primary signature only.
+    pub doc: &'a Option<String>,
+}
+
+/// Resolve a [`CallableSpec`] into the full set of [`FunctionSignature`]s
+/// that should be emitted in the surrounding extern block.
+///
+/// Decisions made here:
+///
+/// * **Promise → async**: when [`SignatureKind::allows_async`] and the return
+///   type is `Promise<T>`, collapse to a single `async fn` with `catch: true`,
+///   carrying the unwrapped `T` as `return_type`. No `try_` companion is
+///   emitted in this case (`async + catch` is already the fallible form).
+/// * **`try_` companion**: for sync, non-setter, non-constructor callables,
+///   each primary `name` gets a fallible `try_name` sibling.
+/// * **Constructor catches always**: per JS semantics; the primary signature
+///   is `catch: true` and there's no `try_` variant.
+/// * **Naming**: each surviving expansion gets `base + suffix` deduped against
+///   `used_names`; `try_` variants prepend `try_` and dedup again.
+pub fn build_signatures(
+    spec: &CallableSpec<'_>,
+    used_names: &mut HashSet<String>,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> Vec<FunctionSignature> {
+    let base = base_rust_name(spec.js_name, spec.kind);
+    let expansions = expand_signatures(spec.overloads, cgctx, scope);
+
+    // Promise unwrap is per-callable, not per-overload — every expansion of a
+    // given JS callable shares the same return type.
+    let (is_async, return_type) = match (spec.return_type, spec.kind.allows_async()) {
+        (TypeRef::Promise(inner), true) => (true, inner.as_ref().clone()),
+        (other, _) => (false, other.clone()),
     };
 
-    let mut result = Vec::new();
+    let allow_try = !is_async && spec.kind.allows_try_variant();
+    let mut out = Vec::with_capacity(expansions.len() * if allow_try { 2 } else { 1 });
 
-    for (candidate, concrete_params) in candidate_names.into_iter().zip(deduped) {
-        let rust_name = dedupe_name(&candidate, used_names);
+    for exp in expansions {
+        let primary_candidate = format!("{base}{}", exp.name_suffix);
+        let primary_name = dedupe_name(&primary_candidate, used_names);
 
-        if is_async {
-            // Single async + catch signature; no `try_` companion.
-            result.push(ExpandedSignature {
-                rust_name,
-                js_name: js_name.to_string(),
-                params: concrete_params,
-                catch: true,
-                return_type: async_unwrapped_ret.clone(),
-                doc: doc.clone(),
-                kind,
-                is_async: true,
-            });
-            continue;
-        }
-
-        result.push(ExpandedSignature {
-            rust_name: rust_name.clone(),
-            js_name: js_name.to_string(),
-            params: concrete_params.clone(),
-            catch: is_constructor,
+        // Primary variant: catches if async (the catch encodes async failure)
+        // or if the kind always catches (constructors).
+        let primary_catches = is_async || spec.kind.always_catches();
+        out.push(FunctionSignature {
+            rust_name: primary_name.clone(),
+            js_name: spec.js_name.to_string(),
+            params: exp.params.clone(),
+            catch: primary_catches,
+            is_async,
             return_type: return_type.clone(),
-            doc: doc.clone(),
-            kind,
-            is_async: false,
+            error_type: if primary_catches {
+                spec.error_type.cloned()
+            } else {
+                None
+            },
+            doc: spec.doc.clone(),
         });
 
-        // try_ variant (not for constructors or setters)
-        let emit_try = !matches!(
-            kind,
-            SignatureKind::Constructor | SignatureKind::Setter | SignatureKind::StaticSetter
-        );
-        if emit_try {
-            let try_candidate = format!("try_{rust_name}");
-            let try_name = dedupe_name(&try_candidate, used_names);
-            result.push(ExpandedSignature {
+        if allow_try {
+            let try_name = dedupe_name(&format!("try_{primary_name}"), used_names);
+            out.push(FunctionSignature {
                 rust_name: try_name,
-                js_name: js_name.to_string(),
-                params: concrete_params,
+                js_name: spec.js_name.to_string(),
+                params: exp.params,
                 catch: true,
-                return_type: return_type.clone(),
-                doc: doc.clone(),
-                kind,
                 is_async: false,
+                return_type: return_type.clone(),
+                error_type: spec.error_type.cloned(),
+                doc: spec.doc.clone(),
             });
         }
     }
 
-    result
+    out
+}
+
+/// Compute `_with_X` / `_with_X_and_Y` suffixes across a cohort of expanded
+/// signatures. Returns one suffix string per input. The shortest-arity
+/// variant (or the only one if there's a single signature) gets `""`.
+///
+/// Wraps the existing [`compute_rust_names`] helper, then extracts the
+/// suffixes by stripping a shared base prefix. We compute against a
+/// non-empty placeholder base because `compute_rust_names` was originally
+/// designed to produce full names.
+fn compute_suffixes(expansions: &[Vec<ConcreteParam>]) -> Vec<String> {
+    // Use a placeholder base — `BASE` is just a prefix that won't appear in
+    // any param name, so we can safely strip it back off.
+    const BASE: &str = "BASE";
+    compute_rust_names(BASE, expansions)
+        .into_iter()
+        .map(|name| {
+            // `compute_rust_names` returns either `BASE` (primary, no suffix)
+            // or `BASE_with_X[_and_Y]` (variant). Strip the base; what's
+            // left including the leading `_` is the suffix.
+            name.strip_prefix(BASE).unwrap_or(&name).to_string()
+        })
+        .collect()
 }
 
 /// Check if two expanded concrete param lists are identical.
@@ -650,7 +743,8 @@ mod tests {
         (gctx, scope)
     }
 
-    /// Shorthand: expand a single overload.
+    /// Shorthand: build signatures for a single overload through the full
+    /// per-callable pipeline (`build_signatures`).
     fn expand(
         js: &str,
         params: &[Param],
@@ -658,13 +752,25 @@ mod tests {
         kind: SignatureKind,
         doc: &Option<String>,
         used: &mut HashSet<String>,
-    ) -> Vec<ExpandedSignature> {
+    ) -> Vec<FunctionSignature> {
         let (gctx, scope) = test_ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
-        expand_signatures(js, &[params], ret, kind, doc, used, Some(&cgctx), scope)
+        build_signatures(
+            &CallableSpec {
+                js_name: js,
+                kind,
+                overloads: &[params],
+                return_type: ret,
+                error_type: None,
+                doc,
+            },
+            used,
+            Some(&cgctx),
+            scope,
+        )
     }
 
-    /// Shorthand: expand multiple overloads.
+    /// Shorthand: build signatures for multiple overloads.
     fn expand_overloads(
         js: &str,
         overloads: &[&[Param]],
@@ -672,10 +778,22 @@ mod tests {
         kind: SignatureKind,
         doc: &Option<String>,
         used: &mut HashSet<String>,
-    ) -> Vec<ExpandedSignature> {
+    ) -> Vec<FunctionSignature> {
         let (gctx, scope) = test_ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
-        expand_signatures(js, overloads, ret, kind, doc, used, Some(&cgctx), scope)
+        build_signatures(
+            &CallableSpec {
+                js_name: js,
+                kind,
+                overloads,
+                return_type: ret,
+                error_type: None,
+                doc,
+            },
+            used,
+            Some(&cgctx),
+            scope,
+        )
     }
 
     fn param(name: &str) -> Param {

--- a/src/codegen/subtyping.rs
+++ b/src/codegen/subtyping.rs
@@ -1,0 +1,279 @@
+//! Subtyping lattice — walk parent chains for built-in JS/TS types and
+//! user-declared `class`/`interface` types, and compute the most-specific
+//! common ancestor (LUB) of a set of types.
+//!
+//! This is what powers union simplification (`T1 | T2 | …` → common
+//! ancestor) including the special case of `@throws {T1 | T2 | …}` whose
+//! LUB becomes the `Result<_, ErrTy>` error type. There is nothing
+//! error-specific here; errors just happen to be the most common case
+//! where multiple union members share a meaningful supertype.
+//!
+//! # Builtin coverage
+//!
+//! The static [`BUILTIN_PARENTS`] table captures inheritance for the
+//! JS builtins ts-gen knows about — error types, collections, typed
+//! arrays, DOM exceptions. Anything not listed here falls back to user
+//! `extends` lookup, then to "no known parent" → resolves to `Object`.
+//!
+//! # User type coverage
+//!
+//! User `class`/`interface` declarations carry `extends` directly in the
+//! IR; [`user_parents`] walks that via the codegen scope chain. Multi-
+//! interface `extends` (TypeScript allows interfaces to extend several
+//! other interfaces) takes the first parent — that's a simplification, but
+//! a multi-parent LUB on the user side is rare in `.d.ts` files and would
+//! complicate the algorithm without much benefit.
+
+use crate::codegen::typemap::CodegenContext;
+use crate::ir::{TypeKind, TypeRef};
+use crate::parse::scope::ScopeId;
+
+/// Built-in JS/TS supertype chains, deepest immediate parent first, ending
+/// at `Object`. The chain implicitly extends to `Object` even when not
+/// listed (the LUB algorithm treats anything reachable from `Object` as
+/// having `Object` as a final fallback).
+///
+/// Sources: ECMA-262 Object hierarchy and `lib.dom.d.ts`.
+const BUILTIN_PARENTS: &[(&str, &[&str])] = &[
+    // JS error hierarchy — every named error subclass extends `Error`.
+    ("TypeError", &["Error"]),
+    ("RangeError", &["Error"]),
+    ("SyntaxError", &["Error"]),
+    ("ReferenceError", &["Error"]),
+    ("EvalError", &["Error"]),
+    ("URIError", &["Error"]),
+    ("AggregateError", &["Error"]),
+    // DOM exceptions inherit from `Error` per WebIDL spec.
+    ("DOMException", &["Error"]),
+    // Typed arrays all inherit from a hidden `TypedArray` base in the spec,
+    // exposed as `Object`-extending in JS. Keeping them parallel siblings
+    // here matches what consumers can actually do with the LUB.
+    ("Int8Array", &["Object"]),
+    ("Uint8Array", &["Object"]),
+    ("Uint8ClampedArray", &["Object"]),
+    ("Int16Array", &["Object"]),
+    ("Uint16Array", &["Object"]),
+    ("Int32Array", &["Object"]),
+    ("Uint32Array", &["Object"]),
+    ("Float32Array", &["Object"]),
+    ("Float64Array", &["Object"]),
+    ("BigInt64Array", &["Object"]),
+    ("BigUint64Array", &["Object"]),
+    // Collections.
+    ("Array", &["Object"]),
+    ("Map", &["Object"]),
+    ("Set", &["Object"]),
+    ("WeakMap", &["Object"]),
+    ("WeakSet", &["Object"]),
+    // Misc.
+    ("Date", &["Object"]),
+    ("RegExp", &["Object"]),
+    ("Promise", &["Object"]),
+    ("Error", &["Object"]),
+];
+
+/// Look up the immediate parent chain for a builtin type. Returns `&[]` for
+/// unknown names — callers should then try [`user_parents`] before giving up.
+pub fn builtin_parents(name: &str) -> &'static [&'static str] {
+    for (n, parents) in BUILTIN_PARENTS {
+        if *n == name {
+            return parents;
+        }
+    }
+    &[]
+}
+
+/// Walk the user-declared parent chain for a `Named` type via the scope.
+/// Returns the immediate parent name(s) — typically zero or one for classes,
+/// possibly several for interfaces (which can `extends` multiple).
+fn user_parents(name: &str, ctx: &CodegenContext<'_>, scope: ScopeId) -> Vec<String> {
+    let Some(type_id) = ctx.gctx.scopes.resolve(scope, name) else {
+        return Vec::new();
+    };
+    let decl = ctx.gctx.get_type(type_id);
+    match &decl.kind {
+        TypeKind::Class(c) => match &c.extends {
+            Some(parent) => parent_typeref_to_names(parent),
+            None => Vec::new(),
+        },
+        TypeKind::Interface(i) => i.extends.iter().flat_map(parent_typeref_to_names).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Pull a name out of an `extends` `TypeRef`, ignoring complex shapes
+/// (generic instantiations, unions, etc.) that don't have a single
+/// representative supertype name.
+fn parent_typeref_to_names(ty: &TypeRef) -> Vec<String> {
+    match ty {
+        TypeRef::Named(n) => vec![n.clone()],
+        _ => Vec::new(),
+    }
+}
+
+/// Build the full ancestor chain for a type — starting at the type itself
+/// and walking up via builtin → user lookup until reaching `Object` (or a
+/// dead end). Order: self, immediate parent, …, `Object`. Cycles are
+/// guarded against by tracking visited names.
+pub fn ancestor_chain(name: &str, ctx: &CodegenContext<'_>, scope: ScopeId) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let mut chain = Vec::new();
+    let mut seen = HashSet::new();
+    let mut current = name.to_string();
+
+    while seen.insert(current.clone()) {
+        chain.push(current.clone());
+
+        // Try builtin first, fall through to user.
+        let parents = builtin_parents(&current);
+        if let Some(first) = parents.first() {
+            current = first.to_string();
+            continue;
+        }
+
+        let user = user_parents(&current, ctx, scope);
+        if let Some(first) = user.into_iter().next() {
+            current = first;
+            continue;
+        }
+
+        // No more parents known — stop unless we haven't reached Object.
+        if chain.last().is_some_and(|n| n != "Object") {
+            chain.push("Object".to_string());
+        }
+        break;
+    }
+    chain
+}
+
+/// Compute the most-specific common ancestor of `names`.
+///
+/// Returns `None` for an empty input or when no common ancestor exists more
+/// specific than `Object` (callers typically substitute `JsValue` in that
+/// case — see `to_syn_type` for `TypeRef::Union`).
+///
+/// Returns `Some("Object")` only when `Object` itself is the deepest shared
+/// ancestor; consumers may decide whether that's useful or whether to widen
+/// to `JsValue` for the same reasons unions usually erase.
+pub fn lub_types(names: &[&str], ctx: &CodegenContext<'_>, scope: ScopeId) -> Option<String> {
+    if names.is_empty() {
+        return None;
+    }
+    if names.len() == 1 {
+        return Some(names[0].to_string());
+    }
+
+    // Build each type's ancestor chain (deepest first), then find the first
+    // ancestor that appears in all of them. Using a Vec for the first chain
+    // and HashSets for subsequent ones gives O(n·k) where n = #types and
+    // k = average chain depth — both small in practice.
+    let chains: Vec<Vec<String>> = names
+        .iter()
+        .map(|n| ancestor_chain(n, ctx, scope))
+        .collect();
+
+    let first_chain = &chains[0];
+    for ancestor in first_chain {
+        if chains[1..].iter().all(|c| c.iter().any(|n| n == ancestor)) {
+            return Some(ancestor.clone());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::typemap::CodegenContext;
+    use crate::context::GlobalContext;
+
+    fn ctx() -> (GlobalContext, ScopeId) {
+        let mut gctx = GlobalContext::new();
+        let scope = gctx.create_root_scope();
+        (gctx, scope)
+    }
+
+    #[test]
+    fn builtin_chain_for_type_error() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let chain = ancestor_chain("TypeError", &cgctx, scope);
+        assert_eq!(chain, vec!["TypeError", "Error", "Object"]);
+    }
+
+    #[test]
+    fn builtin_chain_for_dom_exception() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let chain = ancestor_chain("DOMException", &cgctx, scope);
+        assert_eq!(chain, vec!["DOMException", "Error", "Object"]);
+    }
+
+    #[test]
+    fn unknown_name_falls_to_object() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let chain = ancestor_chain("ImagesError", &cgctx, scope);
+        assert_eq!(chain, vec!["ImagesError", "Object"]);
+    }
+
+    #[test]
+    fn lub_two_error_subclasses_is_error() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["TypeError", "RangeError"], &cgctx, scope);
+        assert_eq!(lub, Some("Error".to_string()));
+    }
+
+    #[test]
+    fn lub_three_error_subclasses_is_error() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["TypeError", "RangeError", "DOMException"], &cgctx, scope);
+        assert_eq!(lub, Some("Error".to_string()));
+    }
+
+    #[test]
+    fn lub_error_with_unknown_user_type_is_object() {
+        // The unknown user type's chain only reaches `Object`, so the LUB
+        // collapses to `Object`. Codegen will substitute `JsValue` for that.
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["TypeError", "ImagesError"], &cgctx, scope);
+        assert_eq!(lub, Some("Object".to_string()));
+    }
+
+    #[test]
+    fn lub_array_with_typed_array_is_object() {
+        // Both extend Object directly with no closer common ancestor.
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["Array", "Uint8Array"], &cgctx, scope);
+        assert_eq!(lub, Some("Object".to_string()));
+    }
+
+    #[test]
+    fn lub_single_name_returns_self() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["TypeError"], &cgctx, scope);
+        assert_eq!(lub, Some("TypeError".to_string()));
+    }
+
+    #[test]
+    fn lub_empty_returns_none() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&[], &cgctx, scope);
+        assert!(lub.is_none());
+    }
+
+    #[test]
+    fn lub_same_name_returns_that_name() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let lub = lub_types(&["TypeError", "TypeError"], &cgctx, scope);
+        assert_eq!(lub, Some("TypeError".to_string()));
+    }
+}

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -433,7 +433,18 @@ pub fn to_syn_type(
                 quote! { Option<#inner_ty> }
             }
         }
-        TypeRef::Union(_) => maybe_ref(quote! { JsValue }, borrow),
+        TypeRef::Union(members) => {
+            // Try the subtyping LUB: if every union member is a named type
+            // and they share a common ancestor more specific than `Object`,
+            // emit that ancestor instead of erasing to `JsValue`. Falls back
+            // to `JsValue` for non-named members or when only `Object` is
+            // common (which is no better than `JsValue` in practice).
+            if let Some(lub) = union_lub(members, ctx, scope) {
+                let lub_ty = to_syn_type(&TypeRef::Named(lub), pos, ctx, scope);
+                return lub_ty;
+            }
+            maybe_ref(quote! { JsValue }, borrow)
+        }
         TypeRef::Intersection(_) => maybe_ref(quote! { JsValue }, borrow),
         TypeRef::Tuple(elems) => {
             let base = if elems.is_empty() {
@@ -658,17 +669,52 @@ pub(crate) fn make_ident(name: &str) -> syn::Ident {
     }
 }
 
+/// Try to compute a subtyping LUB across the members of a union. Returns
+/// `Some(name)` only when every member is a `TypeRef::Named` *and* the
+/// resulting LUB is more specific than `Object` (a `Object` LUB is no
+/// better than the default `JsValue` erasure, so we treat it as no LUB).
+fn union_lub(
+    members: &[TypeRef],
+    ctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> Option<String> {
+    let cgctx = ctx?;
+    let names: Vec<&str> = members
+        .iter()
+        .map(|m| match m {
+            TypeRef::Named(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let lub = crate::codegen::subtyping::lub_types(&names, cgctx, scope)?;
+    if lub == "Object" {
+        return None;
+    }
+    Some(lub)
+}
+
 /// Map an IR `TypeRef` to the type used in a wasm_bindgen return position,
-/// wrapping in `Result<T, JsValue>` when `catch` is true.
+/// wrapping in `Result<T, ErrTy>` when `catch` is true.
+///
+/// `error_ty`, when supplied, replaces the default `JsValue` error type —
+/// callers pass the simplified throws union here. Resolution goes through
+/// the same `to_syn_type` path as any other type, so e.g. `js_sys::TypeError`
+/// vs an external mapping is handled uniformly.
 pub fn to_return_type(
     ty: &TypeRef,
     catch: bool,
+    error_ty: Option<&TypeRef>,
     ctx: Option<&CodegenContext<'_>>,
     scope: ScopeId,
 ) -> TokenStream {
     let inner = to_syn_type(ty, TypePosition::RETURN, ctx, scope);
     if catch {
-        quote! { Result<#inner, JsValue> }
+        let err = match error_ty {
+            Some(ty) => to_syn_type(ty, TypePosition::RETURN, ctx, scope),
+            None => quote! { JsValue },
+        };
+        quote! { Result<#inner, #err> }
     } else {
         inner
     }
@@ -874,7 +920,7 @@ mod tests {
     #[test]
     fn test_return_with_catch() {
         let ty = TypeRef::Promise(Box::new(TypeRef::Void));
-        let result = to_return_type(&ty, true, None, ScopeId(0)).to_string();
+        let result = to_return_type(&ty, true, None, None, ScopeId(0)).to_string();
         assert_eq!(result, "Result < Promise < Undefined > , JsValue >");
     }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -279,6 +279,12 @@ pub struct FunctionDecl {
     pub params: Vec<Param>,
     pub return_type: TypeRef,
     pub overloads: Vec<FunctionOverload>,
+    /// Error type captured from `@throws {T}` JSDoc tags, in the same
+    /// representation as any other type — single name as `TypeRef::Named`,
+    /// multiple as `TypeRef::Union(...)`. Codegen runs it through the
+    /// regular type-rendering pipeline, so subtyping LUB rules (see
+    /// `lub_types`) apply uniformly with normal unions.
+    pub throws: Option<TypeRef>,
 }
 
 #[derive(Clone, Debug)]
@@ -363,6 +369,8 @@ pub struct MethodMember {
     pub return_type: TypeRef,
     pub optional: bool,
     pub doc: Option<String>,
+    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
+    pub throws: Option<TypeRef>,
 }
 
 #[derive(Clone, Debug)]
@@ -370,6 +378,8 @@ pub struct MethodMember {
 pub struct ConstructorMember {
     pub params: Vec<Param>,
     pub doc: Option<String>,
+    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
+    pub throws: Option<TypeRef>,
 }
 
 #[derive(Clone, Debug)]
@@ -413,6 +423,8 @@ pub struct StaticMethodMember {
     pub params: Vec<Param>,
     pub return_type: TypeRef,
     pub doc: Option<String>,
+    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
+    pub throws: Option<TypeRef>,
 }
 
 // ─── Type Registry (First Pass) ──────────────────────────────────────

--- a/src/parse/classify.rs
+++ b/src/parse/classify.rs
@@ -74,6 +74,7 @@ mod tests {
             return_type: TypeRef::Void,
             optional: false,
             doc: None,
+            throws: None,
         })
     }
 

--- a/src/parse/docs.rs
+++ b/src/parse/docs.rs
@@ -7,6 +7,53 @@
 
 use oxc_ast::ast::Comment;
 
+/// Structured JSDoc data extracted alongside the rendered doc comment.
+///
+/// Currently carries `@throws` types for callable members; `for_span` keeps
+/// returning a bare `Option<String>` so non-callable callers don't have to
+/// touch this struct.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct JsDocInfo {
+    /// Type names mentioned across all `@throws {T}` lines, deduped while
+    /// preserving source order. Each entry is the raw identifier as written
+    /// in the JSDoc (e.g. `"TypeError"`, `"ImagesError"`).
+    ///
+    /// Use [`Self::throws_typeref`] to convert into the standard `TypeRef`
+    /// representation that the rest of the pipeline understands.
+    ///
+    /// Recognized forms:
+    /// * `@throws {TypeError} when foo` — single type
+    /// * `@throws {TypeError | RangeError} when bar` — union
+    /// * `@throws {@link ImagesError} if upload fails` — JSDoc link form
+    ///
+    /// Pure-prose `@throws Sentence describing condition.` entries with no
+    /// `{T}` annotation are silently ignored.
+    pub throws: Vec<String>,
+}
+
+impl JsDocInfo {
+    /// Lift the `@throws` name list into a `TypeRef`:
+    ///
+    /// * Empty → `None`
+    /// * Single name → `TypeRef::Named(...)`
+    /// * Multiple → `TypeRef::Union(...)` of named entries
+    ///
+    /// The returned `TypeRef` is just a regular type from the pipeline's
+    /// perspective — codegen's union-LUB rules apply uniformly to it.
+    pub fn throws_typeref(&self) -> Option<crate::ir::TypeRef> {
+        match self.throws.len() {
+            0 => None,
+            1 => Some(crate::ir::TypeRef::Named(self.throws[0].clone())),
+            _ => Some(crate::ir::TypeRef::Union(
+                self.throws
+                    .iter()
+                    .map(|n| crate::ir::TypeRef::Named(n.clone()))
+                    .collect(),
+            )),
+        }
+    }
+}
+
 /// Provides JSDoc lookup by span position.
 pub struct DocComments<'a> {
     comments: &'a [Comment],
@@ -23,6 +70,15 @@ impl<'a> DocComments<'a> {
     /// Returns the cleaned doc text (leading `*` and whitespace stripped per line),
     /// or `None` if no JSDoc is attached.
     pub fn for_span(&self, span_start: u32) -> Option<String> {
+        self.info_for_span(span_start).map(|(doc, _)| doc)
+    }
+
+    /// Like [`for_span`] but also returns structured JSDoc info (e.g. `@throws`
+    /// types). Callable converters that build `MethodMember` / `FunctionDecl`
+    /// / `ConstructorMember` use this to capture throws annotations.
+    ///
+    /// [`for_span`]: Self::for_span
+    pub fn info_for_span(&self, span_start: u32) -> Option<(String, JsDocInfo)> {
         // Find the last JSDoc comment attached to this position.
         // (There could be multiple leading comments; we want the JSDoc one closest to the node.)
         let jsdoc = self
@@ -34,7 +90,7 @@ impl<'a> DocComments<'a> {
         let content_span = jsdoc.content_span();
         let raw = &self.source[content_span.start as usize..content_span.end as usize];
 
-        Some(clean_jsdoc(raw))
+        Some(clean_jsdoc_with_info(raw))
     }
 }
 
@@ -45,7 +101,14 @@ impl<'a> DocComments<'a> {
 /// - Converts `@returns desc` → `# Returns` section
 /// - Converts `@example` blocks into fenced ` ```js ` code blocks
 /// - Removes empty leading/trailing lines
+#[cfg(test)]
 fn clean_jsdoc(raw: &str) -> String {
+    clean_jsdoc_with_info(raw).0
+}
+
+/// Like [`clean_jsdoc`] but also collects structured JSDoc info from the
+/// content (currently `@throws` type names).
+fn clean_jsdoc_with_info(raw: &str) -> (String, JsDocInfo) {
     let lines: Vec<&str> = raw.lines().collect();
     let mut cleaned: Vec<&str> = Vec::new();
 
@@ -75,13 +138,16 @@ fn clean_jsdoc(raw: &str) -> String {
 
 /// Convert JSDoc tags in cleaned lines to Rust doc conventions.
 ///
-/// Collects description lines, `@param` entries, `@returns`, and `@example` blocks,
-/// then re-emits them in idiomatic Rust doc order.
-fn convert_jsdoc_tags(lines: &[&str]) -> String {
+/// Collects description lines, `@param` entries, `@returns`, `@throws`, and
+/// `@example` blocks, then re-emits them in idiomatic Rust doc order. Returns
+/// the rendered doc plus structured info pulled from `@throws`.
+fn convert_jsdoc_tags(lines: &[&str]) -> (String, JsDocInfo) {
     let mut description: Vec<String> = Vec::new();
     let mut params: Vec<String> = Vec::new();
     let mut returns: Option<String> = None;
+    let mut throws_lines: Vec<String> = Vec::new();
     let mut examples: Vec<Vec<String>> = Vec::new();
+    let mut info = JsDocInfo::default();
 
     let mut i = 0;
     while i < lines.len() {
@@ -95,6 +161,16 @@ fn convert_jsdoc_tags(lines: &[&str]) -> String {
             .or_else(|| line.strip_prefix("@return "))
         {
             returns = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("@throws ") {
+            // Capture both the structured type info (for `info.throws`) and a
+            // human-readable line for the Errors section in the rendered doc.
+            let (types, prose) = parse_throws_tag(rest);
+            for ty in types {
+                if !info.throws.contains(&ty) {
+                    info.throws.push(ty);
+                }
+            }
+            throws_lines.push(prose);
         } else if line == "@example" {
             // Collect all lines until the next tag or end
             let mut code_lines = Vec::new();
@@ -153,6 +229,19 @@ fn convert_jsdoc_tags(lines: &[&str]) -> String {
         out.push(ret.clone());
     }
 
+    // Errors section — surfaces `@throws` lines so the rendered doc still
+    // captures them even though the structured info is what drives codegen.
+    if !throws_lines.is_empty() {
+        if !out.is_empty() && !out.last().is_none_or(|l| l.is_empty()) {
+            out.push(String::new());
+        }
+        out.push("## Errors".to_string());
+        out.push(String::new());
+        for line in &throws_lines {
+            out.push(format!("* {line}"));
+        }
+    }
+
     // Examples
     for example in &examples {
         if !out.is_empty() && !out.last().is_none_or(|l| l.is_empty()) {
@@ -172,7 +261,80 @@ fn convert_jsdoc_tags(lines: &[&str]) -> String {
         out.pop();
     }
 
-    out.join("\n")
+    (out.join("\n"), info)
+}
+
+/// Parse the contents of an `@throws` tag.
+///
+/// Returns `(type_names, prose)` where:
+/// * `type_names` is the list of identifiers found between `{...}` (preserving
+///   source order). Empty if the tag is pure prose with no braced type.
+/// * `prose` is a short human-readable line for the rendered Errors section.
+///
+/// Per the JSDoc spec, structured types live inside curly braces:
+///
+/// * `{TypeError} when foo` — single type
+/// * `{TypeError | RangeError} when bar` — union
+/// * `{@link ImagesError} if upload fails` — JSDoc link form (linked
+///   identifier is taken as the type)
+/// * `If the X does not exist, an error will be thrown.` — pure prose, no type
+///
+/// Primitive type names (`string`/`number`/etc.) inside `{...}` are *not*
+/// added to `type_names` — they'd widen the LUB to `JsValue` anyway and
+/// aren't resolvable to a Rust error type.
+fn parse_throws_tag(rest: &str) -> (Vec<String>, String) {
+    let trimmed = rest.trim();
+
+    if let Some(stripped) = trimmed.strip_prefix('{') {
+        if let Some(end) = stripped.find('}') {
+            let inner = stripped[..end].trim();
+            let after = stripped[end + 1..].trim();
+
+            // Handle `{@link Foo}` — keep just the linked name.
+            let inner = inner.strip_prefix("@link ").map(str::trim).unwrap_or(inner);
+
+            let names: Vec<String> = inner
+                .split('|')
+                .map(str::trim)
+                .filter(|s| !s.is_empty() && !is_primitive_type_name(s))
+                .map(String::from)
+                .collect();
+
+            // Build a prose line for the rendered Errors section. Use the
+            // raw inner text (with `{@link X}` collapsed to `X`) so unions
+            // and link forms read naturally.
+            let prose = if after.is_empty() {
+                format!("`{inner}`")
+            } else {
+                format!("`{inner}` — {after}")
+            };
+            return (names, prose);
+        }
+    }
+
+    // No braces, or unmatched `{`: treat as pure prose with no structured type.
+    (Vec::new(), trimmed.to_string())
+}
+
+/// Names of TypeScript primitive types that should not be promoted to a
+/// throws "type" — they widen the LUB to `JsValue` anyway and aren't
+/// resolvable to a Rust error type.
+fn is_primitive_type_name(s: &str) -> bool {
+    matches!(
+        s,
+        "string"
+            | "number"
+            | "bigint"
+            | "boolean"
+            | "undefined"
+            | "null"
+            | "void"
+            | "any"
+            | "unknown"
+            | "object"
+            | "symbol"
+            | "never"
+    )
 }
 
 /// Format a `@param` rest string into a Rust-style argument list item.
@@ -291,5 +453,83 @@ mod tests {
             clean_jsdoc(raw),
             "Desc.\n\n## Returns\n\nresult\n\n## Example\n\n```js\ncode();\n```"
         );
+    }
+
+    fn parse(raw: &str) -> (String, JsDocInfo) {
+        clean_jsdoc_with_info(raw)
+    }
+
+    #[test]
+    fn test_throws_single_braced_type() {
+        let raw = "\n * Does X.\n * @throws {TypeError} when foo is bad\n ";
+        let (doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["TypeError"]);
+        // The Errors section appears in the rendered doc with the raw type
+        // and prose preserved.
+        assert!(doc.contains("## Errors"));
+        assert!(doc.contains("`TypeError` — when foo is bad"));
+    }
+
+    #[test]
+    fn test_throws_union() {
+        let raw = "\n * @throws {TypeError | RangeError} on bad input\n ";
+        let (_doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["TypeError", "RangeError"]);
+    }
+
+    #[test]
+    fn test_throws_link_form() {
+        let raw = "\n * @throws {@link ImagesError} if upload fails\n ";
+        let (doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["ImagesError"]);
+        // The rendered doc uses the linked name without the `@link` marker.
+        assert!(doc.contains("`ImagesError` — if upload fails"));
+    }
+
+    #[test]
+    fn test_throws_multiple_lines_dedup_preserves_order() {
+        // Multiple `@throws` lines accumulate into the same union, with
+        // duplicates collapsed but order preserved across lines.
+        let raw = "
+                 * @throws {NotFoundError} if not found
+                 * @throws {BadRequestError} if invalid
+                 * @throws {NotFoundError} again
+                 ";
+        let (_doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["NotFoundError", "BadRequestError"]);
+    }
+
+    #[test]
+    fn test_throws_pure_prose_has_no_types() {
+        let raw = "\n * @throws If the resource does not exist, an error is thrown.\n ";
+        let (doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
+        // Prose still surfaces in the rendered Errors section.
+        assert!(doc.contains("## Errors"));
+        assert!(doc.contains("If the resource does not exist"));
+    }
+
+    #[test]
+    fn test_throws_primitives_filtered() {
+        // Primitive types in the union don't make it into `info.throws`
+        // since they aren't useful as a Rust error type.
+        let raw = "\n * @throws {TypeError | string} bad input\n ";
+        let (_doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["TypeError"]);
+    }
+
+    #[test]
+    fn test_throws_unmatched_brace_falls_back_to_prose() {
+        // If `}` is missing we don't attempt structured parsing.
+        let raw = "\n * @throws {TypeError if oops\n ";
+        let (_doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
+    }
+
+    #[test]
+    fn test_no_throws_yields_empty_info() {
+        let raw = "\n * Just a description.\n ";
+        let (_doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
     }
 }

--- a/src/parse/first_pass/converters.rs
+++ b/src/parse/first_pass/converters.rs
@@ -99,6 +99,7 @@ pub fn convert_interface_decl(
 
 pub fn convert_function_decl(
     func: &ast::Function<'_>,
+    throws: Option<ir::TypeRef>,
     diag: &mut DiagnosticCollector,
 ) -> Option<ir::FunctionDecl> {
     let name = func.id.as_ref()?.name.to_string();
@@ -128,6 +129,7 @@ pub fn convert_function_decl(
         params,
         return_type,
         overloads: vec![],
+        throws,
     })
 }
 

--- a/src/parse/first_pass/mod.rs
+++ b/src/parse/first_pass/mod.rs
@@ -114,6 +114,7 @@ fn register_type(
             params: vec![],
             return_type: ir::TypeRef::Any,
             overloads: vec![],
+            throws: None,
         }),
         ir::RegisteredKind::Variable => ir::TypeKind::Variable(ir::VariableDecl {
             name: name_str.clone(),

--- a/src/parse/first_pass/populate.rs
+++ b/src/parse/first_pass/populate.rs
@@ -209,11 +209,17 @@ impl<'a> PopulateCtx<'a> {
                     }
                 }
                 ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
-                    let doc = self
+                    // Look up structured info on either the export span or the
+                    // function span (JSDoc may be attached to either).
+                    let info = self
                         .docs
-                        .for_span(export.span.start)
-                        .or_else(|| self.docs.for_span(func.span.start));
-                    if let Some(decl) = convert_function_decl(func, self.diag) {
+                        .info_for_span(export.span.start)
+                        .or_else(|| self.docs.info_for_span(func.span.start));
+                    let (doc, throws) = match info {
+                        Some((d, i)) => (Some(d), i.throws_typeref()),
+                        None => (None, None),
+                    };
+                    if let Some(decl) = convert_function_decl(func, throws, self.diag) {
                         declarations.push(ir::TypeDeclaration {
                             kind: ir::TypeKind::Function(decl),
                             module_context: ctx.clone(),
@@ -373,8 +379,8 @@ impl<'a> PopulateCtx<'a> {
         dcx: &DeclCtx<'_>,
         declarations: &mut Vec<ir::TypeDeclaration>,
     ) {
-        let doc = self.lookup_doc(dcx.export_span_start, func.span.start);
-        if let Some(d) = convert_function_decl(func, self.diag) {
+        let (doc, throws) = self.lookup_callable_doc(dcx.export_span_start, func.span.start);
+        if let Some(d) = convert_function_decl(func, throws, self.diag) {
             declarations.push(dcx.decl(ir::TypeKind::Function(d), doc));
         }
     }
@@ -458,6 +464,9 @@ impl<'a> PopulateCtx<'a> {
                             params: sig.params,
                             return_type: *sig.return_type,
                             overloads: vec![],
+                            // Variable-as-function form (`var foo: () => T`) doesn't
+                            // typically carry @throws JSDoc; leave empty.
+                            throws: None,
                         }),
                         doc.clone(),
                     ));
@@ -574,6 +583,26 @@ impl<'a> PopulateCtx<'a> {
         export_span_start
             .and_then(|s| self.docs.for_span(s))
             .or_else(|| self.docs.for_span(inner_span_start))
+    }
+
+    /// Same fallback behavior as [`lookup_doc`], but also returns the
+    /// `@throws` type (already lifted into a `TypeRef`) from the same
+    /// JSDoc block. Used by callable declarations that need both the
+    /// rendered doc and structured throws info.
+    ///
+    /// [`lookup_doc`]: Self::lookup_doc
+    fn lookup_callable_doc(
+        &self,
+        export_span_start: Option<u32>,
+        inner_span_start: u32,
+    ) -> (Option<String>, Option<ir::TypeRef>) {
+        let info = export_span_start
+            .and_then(|s| self.docs.info_for_span(s))
+            .or_else(|| self.docs.info_for_span(inner_span_start));
+        match info {
+            Some((doc, info)) => (Some(doc), info.throws_typeref()),
+            None => (None, None),
+        }
     }
 
     /// Look up the child scope that Phase 1 created for a namespace.

--- a/src/parse/members.rs
+++ b/src/parse/members.rs
@@ -5,11 +5,20 @@ use oxc_ast::ast::*;
 use std::collections::HashSet;
 
 use crate::ir::*;
-use crate::parse::docs::DocComments;
+use crate::parse::docs::{DocComments, JsDocInfo};
 use crate::parse::types::{
     convert_formal_params, convert_ts_type, convert_ts_type_scoped, convert_type_params,
 };
 use crate::util::diagnostics::DiagnosticCollector;
+
+/// Split the result of [`DocComments::info_for_span`] into a `(doc, info)`
+/// pair, defaulting to empty info when no JSDoc is attached.
+fn split_info(opt: Option<(String, JsDocInfo)>) -> (Option<String>, JsDocInfo) {
+    match opt {
+        Some((doc, info)) => (Some(doc), info),
+        None => (None, JsDocInfo::default()),
+    }
+}
 
 /// Convert a `TSSignature` (interface body member) to our IR `Member`(s).
 ///
@@ -104,7 +113,7 @@ fn convert_method_signature(
         Some(n) => n,
         None => return vec![],
     };
-    let doc = docs.for_span(method.span.start);
+    let (doc, info) = split_info(docs.info_for_span(method.span.start));
 
     let type_params = convert_type_params(method.type_parameters.as_ref(), diag);
 
@@ -150,6 +159,7 @@ fn convert_method_signature(
             return_type,
             optional: method.optional,
             doc,
+            throws: info.throws_typeref(),
         })],
     }
 }
@@ -180,8 +190,12 @@ fn convert_construct_signature(
     diag: &mut DiagnosticCollector,
 ) -> Option<Member> {
     let params = convert_formal_params(&ctor.params, diag);
-    let doc = docs.for_span(ctor.span.start);
-    Some(Member::Constructor(ConstructorMember { params, doc }))
+    let (doc, info) = split_info(docs.info_for_span(ctor.span.start));
+    Some(Member::Constructor(ConstructorMember {
+        params,
+        doc,
+        throws: info.throws_typeref(),
+    }))
 }
 
 // ─── Class member conversions ────────────────────────────────────────
@@ -195,7 +209,7 @@ fn convert_class_method(
         Some(n) => n,
         None => return vec![],
     };
-    let doc = docs.for_span(method.span.start);
+    let (doc, info) = split_info(docs.info_for_span(method.span.start));
 
     let func = &method.value;
     let type_params = convert_type_params(func.type_parameters.as_ref(), diag);
@@ -218,7 +232,11 @@ fn convert_class_method(
 
     match method.kind {
         MethodDefinitionKind::Constructor => {
-            vec![Member::Constructor(ConstructorMember { params, doc })]
+            vec![Member::Constructor(ConstructorMember {
+                params,
+                doc,
+                throws: info.throws_typeref(),
+            })]
         }
         MethodDefinitionKind::Get => {
             if is_static {
@@ -265,6 +283,7 @@ fn convert_class_method(
                     params,
                     return_type,
                     doc,
+                    throws: info.throws_typeref(),
                 })]
             } else {
                 vec![Member::Method(MethodMember {
@@ -275,6 +294,7 @@ fn convert_class_method(
                     return_type,
                     optional: method.optional,
                     doc,
+                    throws: info.throws_typeref(),
                 })]
             }
         }

--- a/src/parse/merge.rs
+++ b/src/parse/merge.rs
@@ -56,8 +56,15 @@ pub fn extract_var_members(
         match member {
             TSSignature::TSConstructSignatureDeclaration(ctor) => {
                 let params = convert_formal_params(&ctor.params, diag);
-                let doc = docs.for_span(ctor.span.start);
-                constructor = Some(ConstructorMember { params, doc });
+                let (doc, info) = match docs.info_for_span(ctor.span.start) {
+                    Some((d, i)) => (Some(d), i),
+                    None => (None, crate::parse::docs::JsDocInfo::default()),
+                };
+                constructor = Some(ConstructorMember {
+                    params,
+                    doc,
+                    throws: info.throws_typeref(),
+                });
             }
             TSSignature::TSPropertySignature(prop) => {
                 let js_name = match property_key_name(&prop.key) {
@@ -91,7 +98,10 @@ pub fn extract_var_members(
                     Some(name) => name,
                     None => continue,
                 };
-                let doc = docs.for_span(method.span.start);
+                let (doc, info) = match docs.info_for_span(method.span.start) {
+                    Some((d, i)) => (Some(d), i),
+                    None => (None, crate::parse::docs::JsDocInfo::default()),
+                };
                 let name = to_snake_case(&js_name);
                 let type_params = convert_type_params(method.type_parameters.as_ref(), diag);
                 let params = convert_formal_params(&method.params, diag);
@@ -107,6 +117,7 @@ pub fn extract_var_members(
                     params,
                     return_type,
                     doc,
+                    throws: info.throws_typeref(),
                 }));
             }
             TSSignature::TSCallSignatureDeclaration(_) => {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -683,6 +683,7 @@ mod tests {
             return_type: TypeRef::Void,
             optional: false,
             doc: None,
+            throws: None,
         })
     }
 

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -615,25 +615,26 @@ pub mod web_assembly {
     }
     #[wasm_bindgen]
     extern "C" {
-        # [wasm_bindgen (extends = Object , js_namespace = "WebAssembly")]
+        # [wasm_bindgen (extends = Object , js_name = "Global" , js_namespace = "WebAssembly")]
         #[derive(Debug, Clone, PartialEq, Eq)]
-        pub type Global;
+        pub type Global_;
         #[wasm_bindgen(constructor, catch)]
-        pub fn new(descriptor: &GlobalDescriptor) -> Result<Global, JsValue>;
+        pub fn new(descriptor: &GlobalDescriptor) -> Result<Global_, JsValue>;
         #[wasm_bindgen(constructor, catch, js_name = "Global")]
         pub fn new_with_value(
             descriptor: &GlobalDescriptor,
             value: &JsValue,
-        ) -> Result<Global, JsValue>;
+        ) -> Result<Global_, JsValue>;
         #[wasm_bindgen(method, getter)]
-        pub fn value(this: &Global) -> JsValue;
+        pub fn value(this: &Global_) -> JsValue;
         #[wasm_bindgen(method, setter)]
-        pub fn set_value(this: &Global, val: &JsValue);
+        pub fn set_value(this: &Global_, val: &JsValue);
         #[wasm_bindgen(method, js_name = "valueOf")]
-        pub fn value_of(this: &Global) -> JsValue;
+        pub fn value_of(this: &Global_) -> JsValue;
         #[wasm_bindgen(method, catch, js_name = "valueOf")]
-        pub fn try_value_of(this: &Global) -> Result<JsValue, JsValue>;
+        pub fn try_value_of(this: &Global_) -> Result<JsValue, JsValue>;
     }
+    pub use Global_ as Global;
     #[wasm_bindgen]
     extern "C" {
         # [wasm_bindgen (extends = Object , js_namespace = "WebAssembly")]
@@ -9647,15 +9648,15 @@ extern "C" {
         this: &R2Bucket,
         key: &str,
         options: &JsValue,
-    ) -> Result<Option<JsValue>, JsValue>;
+    ) -> Result<Option<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
-    pub async fn get_1(this: &R2Bucket, key: &str) -> Result<Option<JsValue>, JsValue>;
+    pub async fn get_1(this: &R2Bucket, key: &str) -> Result<Option<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_r_2_get_options(
         this: &R2Bucket,
         key: &str,
         options: &R2GetOptions,
-    ) -> Result<Option<JsValue>, JsValue>;
+    ) -> Result<Option<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch)]
     pub async fn put(
         this: &R2Bucket,
@@ -31765,7 +31766,6 @@ extern "C" {
         image_id: &str,
     ) -> Result<Option<ReadableStream>, JsValue>;
     #[doc = " Upload a new hosted image"]
-    #[doc = " @throws {@link ImagesError} if upload fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31775,13 +31775,16 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " Metadata for the uploaded image"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if upload fails"]
     #[wasm_bindgen(method, catch)]
     pub async fn upload(
         this: &HostedImagesBinding,
         image: &ReadableStream,
-    ) -> Result<ImageMetadata, JsValue>;
+    ) -> Result<ImageMetadata, ImagesError>;
     #[doc = " Upload a new hosted image"]
-    #[doc = " @throws {@link ImagesError} if upload fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31791,13 +31794,16 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " Metadata for the uploaded image"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if upload fails"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
     pub async fn upload_with_array_buffer(
         this: &HostedImagesBinding,
         image: &ArrayBuffer,
-    ) -> Result<ImageMetadata, JsValue>;
+    ) -> Result<ImageMetadata, ImagesError>;
     #[doc = " Upload a new hosted image"]
-    #[doc = " @throws {@link ImagesError} if upload fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31807,14 +31813,17 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " Metadata for the uploaded image"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if upload fails"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
     pub async fn upload_with_js_value_and_options(
         this: &HostedImagesBinding,
         image: &ReadableStream,
         options: &ImageUploadOptions,
-    ) -> Result<ImageMetadata, JsValue>;
+    ) -> Result<ImageMetadata, ImagesError>;
     #[doc = " Upload a new hosted image"]
-    #[doc = " @throws {@link ImagesError} if upload fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31824,14 +31833,17 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " Metadata for the uploaded image"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if upload fails"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
     pub async fn upload_with_array_buffer_and_options(
         this: &HostedImagesBinding,
         image: &ArrayBuffer,
         options: &ImageUploadOptions,
-    ) -> Result<ImageMetadata, JsValue>;
+    ) -> Result<ImageMetadata, ImagesError>;
     #[doc = " Update hosted image metadata"]
-    #[doc = " @throws {@link ImagesError} if update fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31841,12 +31853,16 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " Updated image metadata"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if update fails"]
     #[wasm_bindgen(method, catch)]
     pub async fn update(
         this: &HostedImagesBinding,
         image_id: &str,
         options: &ImageUpdateOptions,
-    ) -> Result<ImageMetadata, JsValue>;
+    ) -> Result<ImageMetadata, ImagesError>;
     #[doc = " Delete a hosted image"]
     #[doc = " "]
     #[doc = " ## Arguments"]
@@ -31859,7 +31875,6 @@ extern "C" {
     #[wasm_bindgen(method, catch)]
     pub async fn delete(this: &HostedImagesBinding, image_id: &str) -> Result<bool, JsValue>;
     #[doc = " List hosted images with pagination"]
-    #[doc = " @throws {@link ImagesError} if list fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31868,10 +31883,13 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " List of images with pagination info"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if list fails"]
     #[wasm_bindgen(method, catch)]
-    pub async fn list(this: &HostedImagesBinding) -> Result<ImageList, JsValue>;
+    pub async fn list(this: &HostedImagesBinding) -> Result<ImageList, ImagesError>;
     #[doc = " List hosted images with pagination"]
-    #[doc = " @throws {@link ImagesError} if list fails"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -31880,11 +31898,15 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " List of images with pagination info"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — if list fails"]
     #[wasm_bindgen(method, catch, js_name = "list")]
     pub async fn list_with_options(
         this: &HostedImagesBinding,
         options: &ImageListOptions,
-    ) -> Result<ImageList, JsValue>;
+    ) -> Result<ImageList, ImagesError>;
 }
 #[wasm_bindgen]
 extern "C" {
@@ -31892,25 +31914,34 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ImagesBinding;
     #[doc = " Get image metadata (type, width and height)"]
-    #[doc = " @throws {@link ImagesError} with code 9412 if input is not an image"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `stream` - The image bytes"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — with code 9412 if input is not an image"]
     #[wasm_bindgen(method, catch)]
-    pub async fn info(this: &ImagesBinding, stream: &ReadableStream) -> Result<JsValue, JsValue>;
+    pub async fn info(
+        this: &ImagesBinding,
+        stream: &ReadableStream,
+    ) -> Result<JsValue, ImagesError>;
     #[doc = " Get image metadata (type, width and height)"]
-    #[doc = " @throws {@link ImagesError} with code 9412 if input is not an image"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `stream` - The image bytes"]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `ImagesError` — with code 9412 if input is not an image"]
     #[wasm_bindgen(method, catch, js_name = "info")]
     pub async fn info_with_options(
         this: &ImagesBinding,
         stream: &ReadableStream,
         options: &Object,
-    ) -> Result<JsValue, JsValue>;
+    ) -> Result<JsValue, ImagesError>;
     #[doc = " Begin applying a series of transformations to an image"]
     #[doc = " "]
     #[doc = " ## Arguments"]
@@ -33080,11 +33111,6 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "video")]
     pub fn try_video(this: &StreamBinding, id: &str) -> Result<StreamVideoHandle, JsValue>;
     #[doc = " Uploads a new video from a File."]
-    #[doc = " @throws {BadRequestError} if the upload parameter is invalid"]
-    #[doc = " @throws {QuotaReachedError} if the account storage capacity is exceeded"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {RateLimitedError} if the server received too many requests"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33093,14 +33119,17 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The uploaded video details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the upload parameter is invalid"]
+    #[doc = " * `QuotaReachedError` — if the account storage capacity is exceeded"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `RateLimitedError` — if the server received too many requests"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn upload(this: &StreamBinding, file: &File) -> Result<StreamVideo, JsValue>;
+    pub async fn upload(this: &StreamBinding, file: &File) -> Result<StreamVideo, StreamError>;
     #[doc = " Uploads a new video from a File."]
-    #[doc = " @throws {BadRequestError} if the upload parameter is invalid"]
-    #[doc = " @throws {QuotaReachedError} if the account storage capacity is exceeded"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {RateLimitedError} if the server received too many requests"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33109,14 +33138,20 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The uploaded video details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the upload parameter is invalid"]
+    #[doc = " * `QuotaReachedError` — if the account storage capacity is exceeded"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `RateLimitedError` — if the server received too many requests"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
-    pub async fn upload_with_url(this: &StreamBinding, url: &str) -> Result<StreamVideo, JsValue>;
+    pub async fn upload_with_url(
+        this: &StreamBinding,
+        url: &str,
+    ) -> Result<StreamVideo, StreamError>;
     #[doc = " Uploads a new video from a File."]
-    #[doc = " @throws {BadRequestError} if the upload parameter is invalid"]
-    #[doc = " @throws {QuotaReachedError} if the account storage capacity is exceeded"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {RateLimitedError} if the server received too many requests"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33125,16 +33160,21 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The uploaded video details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the upload parameter is invalid"]
+    #[doc = " * `QuotaReachedError` — if the account storage capacity is exceeded"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `RateLimitedError` — if the server received too many requests"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
     pub async fn upload_with_url_and_params(
         this: &StreamBinding,
         url: &str,
         params: &Object,
-    ) -> Result<StreamVideo, JsValue>;
+    ) -> Result<StreamVideo, StreamError>;
     #[doc = " Creates a direct upload that allows video uploads without an API key."]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {RateLimitedError} if the server received too many requests"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33143,11 +33183,17 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The direct upload details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `RateLimitedError` — if the server received too many requests"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "createDirectUpload")]
     pub async fn create_direct_upload(
         this: &StreamBinding,
         params: &Object,
-    ) -> Result<Object, JsValue>;
+    ) -> Result<Object, StreamError>;
     #[wasm_bindgen(method, getter)]
     pub fn videos(this: &StreamBinding) -> StreamVideos;
     #[wasm_bindgen(method, setter)]
@@ -33168,18 +33214,18 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &StreamVideoHandle, val: &str);
     #[doc = " Get a full videos details"]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The full video details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn details(this: &StreamVideoHandle) -> Result<StreamVideo, JsValue>;
+    pub async fn details(this: &StreamVideoHandle) -> Result<StreamVideo, StreamError>;
     #[doc = " Update details for a single video."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33188,25 +33234,40 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The updated video details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn update(this: &StreamVideoHandle, params: &Object) -> Result<StreamVideo, JsValue>;
+    pub async fn update(
+        this: &StreamVideoHandle,
+        params: &Object,
+    ) -> Result<StreamVideo, StreamError>;
     #[doc = " Deletes a video and its copies from Cloudflare Stream."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A promise that resolves when deletion completes."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn delete(this: &StreamVideoHandle) -> Result<(), JsValue>;
+    pub async fn delete(this: &StreamVideoHandle) -> Result<(), StreamError>;
     #[doc = " Creates a signed URL token for a video."]
-    #[doc = " @throws {InternalError} if the signing key cannot be retrieved or the token cannot be signed"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The signed token that was created."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `InternalError` — if the signing key cannot be retrieved or the token cannot be signed"]
     #[wasm_bindgen(method, catch, js_name = "generateToken")]
-    pub async fn generate_token(this: &StreamVideoHandle) -> Result<String, JsValue>;
+    pub async fn generate_token(this: &StreamVideoHandle) -> Result<String, InternalError>;
     #[wasm_bindgen(method, getter)]
     pub fn downloads(this: &StreamVideoHandle) -> StreamScopedDownloads;
     #[wasm_bindgen(method, setter)]
@@ -33700,10 +33761,6 @@ extern "C" {
     pub type StreamScopedCaptions;
     #[doc = " Uploads the caption or subtitle file to the endpoint for a specific BCP47 language."]
     #[doc = " One caption or subtitle file per language is allowed."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {BadRequestError} if the language or file is invalid"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33713,20 +33770,20 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The created caption entry."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `BadRequestError` — if the language or file is invalid"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
     pub async fn upload(
         this: &StreamScopedCaptions,
         language: &str,
         file: &File,
-    ) -> Result<Object, JsValue>;
+    ) -> Result<Object, StreamError>;
     #[doc = " Generate captions or subtitles for the provided language via AI."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {BadRequestError} if the language is invalid"]
-    #[doc = " @throws {StreamError} if a generated caption already exists"]
-    #[doc = " @throws {StreamError} if the video duration is too long"]
-    #[doc = " @throws {StreamError} if the video is missing audio"]
-    #[doc = " @throws {StreamError} if the requested language is not supported"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33735,12 +33792,23 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The generated caption entry."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `BadRequestError` — if the language is invalid"]
+    #[doc = " * `StreamError` — if a generated caption already exists"]
+    #[doc = " * `StreamError` — if the video duration is too long"]
+    #[doc = " * `StreamError` — if the video is missing audio"]
+    #[doc = " * `StreamError` — if the requested language is not supported"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn generate(this: &StreamScopedCaptions, language: &str) -> Result<Object, JsValue>;
+    pub async fn generate(
+        this: &StreamScopedCaptions,
+        language: &str,
+    ) -> Result<Object, StreamError>;
     #[doc = " Lists the captions or subtitles."]
     #[doc = " Use the language parameter to filter by a specific language."]
-    #[doc = " @throws {NotFoundError} if the video or caption is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33749,12 +33817,15 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The list of captions or subtitles."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or caption is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn list(this: &StreamScopedCaptions) -> Result<Array<Object>, JsValue>;
+    pub async fn list(this: &StreamScopedCaptions) -> Result<Array<Object>, StreamError>;
     #[doc = " Lists the captions or subtitles."]
     #[doc = " Use the language parameter to filter by a specific language."]
-    #[doc = " @throws {NotFoundError} if the video or caption is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33763,14 +33834,17 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The list of captions or subtitles."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or caption is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "list")]
     pub async fn list_with_language(
         this: &StreamScopedCaptions,
         language: &str,
-    ) -> Result<Array<Object>, JsValue>;
+    ) -> Result<Array<Object>, StreamError>;
     #[doc = " Removes the captions or subtitles from a video."]
-    #[doc = " @throws {NotFoundError} if the video or caption is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33779,8 +33853,13 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A promise that resolves when deletion completes."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or caption is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn delete(this: &StreamScopedCaptions, language: &str) -> Result<(), JsValue>;
+    pub async fn delete(this: &StreamScopedCaptions, language: &str) -> Result<(), StreamError>;
 }
 #[wasm_bindgen]
 extern "C" {
@@ -33789,11 +33868,6 @@ extern "C" {
     pub type StreamScopedDownloads;
     #[doc = " Generates a download for a video when a video is ready to view. Available"]
     #[doc = " types are `default` and `audio`. Defaults to `default` when omitted."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {BadRequestError} if the download type is invalid"]
-    #[doc = " @throws {StreamError} if the video duration is too long to generate a download"]
-    #[doc = " @throws {StreamError} if the video is not ready to stream"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33802,15 +33876,18 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The current downloads for the video."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `BadRequestError` — if the download type is invalid"]
+    #[doc = " * `StreamError` — if the video duration is too long to generate a download"]
+    #[doc = " * `StreamError` — if the video is not ready to stream"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn generate(this: &StreamScopedDownloads) -> Result<Object, JsValue>;
+    pub async fn generate(this: &StreamScopedDownloads) -> Result<Object, StreamError>;
     #[doc = " Generates a download for a video when a video is ready to view. Available"]
     #[doc = " types are `default` and `audio`. Defaults to `default` when omitted."]
-    #[doc = " @throws {NotFoundError} if the video is not found"]
-    #[doc = " @throws {BadRequestError} if the download type is invalid"]
-    #[doc = " @throws {StreamError} if the video duration is too long to generate a download"]
-    #[doc = " @throws {StreamError} if the video is not ready to stream"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33819,24 +33896,33 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The current downloads for the video."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video is not found"]
+    #[doc = " * `BadRequestError` — if the download type is invalid"]
+    #[doc = " * `StreamError` — if the video duration is too long to generate a download"]
+    #[doc = " * `StreamError` — if the video is not ready to stream"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "generate")]
     pub async fn generate_with_download_type(
         this: &StreamScopedDownloads,
         download_type: &StreamDownloadType,
-    ) -> Result<Object, JsValue>;
+    ) -> Result<Object, StreamError>;
     #[doc = " Lists the downloads created for a video."]
-    #[doc = " @throws {NotFoundError} if the video or downloads are not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The current downloads for the video."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or downloads are not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn get(this: &StreamScopedDownloads) -> Result<Object, JsValue>;
+    pub async fn get(this: &StreamScopedDownloads) -> Result<Object, StreamError>;
     #[doc = " Delete the downloads for a video. Available types are `default` and `audio`."]
     #[doc = " Defaults to `default` when omitted."]
-    #[doc = " @throws {NotFoundError} if the video or downloads are not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33845,12 +33931,15 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A promise that resolves when deletion completes."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or downloads are not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn delete(this: &StreamScopedDownloads) -> Result<(), JsValue>;
+    pub async fn delete(this: &StreamScopedDownloads) -> Result<(), StreamError>;
     #[doc = " Delete the downloads for a video. Available types are `default` and `audio`."]
     #[doc = " Defaults to `default` when omitted."]
-    #[doc = " @throws {NotFoundError} if the video or downloads are not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33859,11 +33948,16 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A promise that resolves when deletion completes."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the video or downloads are not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "delete")]
     pub async fn delete_with_download_type(
         this: &StreamScopedDownloads,
         download_type: &StreamDownloadType,
-    ) -> Result<(), JsValue>;
+    ) -> Result<(), StreamError>;
 }
 #[wasm_bindgen]
 extern "C" {
@@ -33871,26 +33965,32 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type StreamVideos;
     #[doc = " Lists all videos in a users account."]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The list of videos."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn list(this: &StreamVideos) -> Result<Array<StreamVideo>, JsValue>;
+    pub async fn list(this: &StreamVideos) -> Result<Array<StreamVideo>, StreamError>;
     #[doc = " Lists all videos in a users account."]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The list of videos."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "list")]
     pub async fn list_with_params(
         this: &StreamVideos,
         params: &Object,
-    ) -> Result<Array<StreamVideo>, JsValue>;
+    ) -> Result<Array<StreamVideo>, StreamError>;
 }
 #[wasm_bindgen]
 extern "C" {
@@ -33898,11 +33998,6 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type StreamWatermarks;
     #[doc = " Generate a new watermark profile"]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {InvalidURLError} if the URL is invalid"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {TooManyWatermarksError} if the number of allowed watermarks is reached"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33912,18 +34007,21 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The created watermark profile."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `InvalidURLError` — if the URL is invalid"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `TooManyWatermarksError` — if the number of allowed watermarks is reached"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
     pub async fn generate(
         this: &StreamWatermarks,
         file: &File,
         params: &Object,
-    ) -> Result<Object, JsValue>;
+    ) -> Result<Object, StreamError>;
     #[doc = " Generate a new watermark profile"]
-    #[doc = " @throws {BadRequestError} if the parameters are invalid"]
-    #[doc = " @throws {InvalidURLError} if the URL is invalid"]
-    #[doc = " @throws {MaxFileSizeError} if the file size is too large"]
-    #[doc = " @throws {TooManyWatermarksError} if the number of allowed watermarks is reached"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33933,23 +34031,32 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The created watermark profile."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `BadRequestError` — if the parameters are invalid"]
+    #[doc = " * `InvalidURLError` — if the URL is invalid"]
+    #[doc = " * `MaxFileSizeError` — if the file size is too large"]
+    #[doc = " * `TooManyWatermarksError` — if the number of allowed watermarks is reached"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch, js_name = "generate")]
     pub async fn generate_with_url(
         this: &StreamWatermarks,
         url: &str,
         params: &Object,
-    ) -> Result<Object, JsValue>;
+    ) -> Result<Object, StreamError>;
     #[doc = " Lists all watermark profiles for an account."]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The list of watermark profiles."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn list(this: &StreamWatermarks) -> Result<Array<Object>, JsValue>;
+    pub async fn list(this: &StreamWatermarks) -> Result<Array<Object>, InternalError>;
     #[doc = " Retrieves details for a single watermark profile."]
-    #[doc = " @throws {NotFoundError} if the watermark is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33958,11 +34065,14 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " The watermark profile details."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the watermark is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn get(this: &StreamWatermarks, watermark_id: &str) -> Result<Object, JsValue>;
+    pub async fn get(this: &StreamWatermarks, watermark_id: &str) -> Result<Object, StreamError>;
     #[doc = " Deletes a watermark profile."]
-    #[doc = " @throws {NotFoundError} if the watermark is not found"]
-    #[doc = " @throws {InternalError} if an unexpected error occurs"]
     #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
@@ -33971,8 +34081,13 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A promise that resolves when deletion completes."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * `NotFoundError` — if the watermark is not found"]
+    #[doc = " * `InternalError` — if an unexpected error occurs"]
     #[wasm_bindgen(method, catch)]
-    pub async fn delete(this: &StreamWatermarks, watermark_id: &str) -> Result<(), JsValue>;
+    pub async fn delete(this: &StreamWatermarks, watermark_id: &str) -> Result<(), StreamError>;
 }
 #[allow(dead_code)]
 pub type StreamUpdateVideoParams = Object;
@@ -36316,8 +36431,6 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type DispatchNamespace;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36327,10 +36440,12 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method)]
     pub fn get(this: &DispatchNamespace, name: &str) -> JsValue;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36340,10 +36455,12 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub fn try_get(this: &DispatchNamespace, name: &str) -> Result<JsValue, JsValue>;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36353,10 +36470,12 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method, js_name = "get")]
     pub fn get_with_args(this: &DispatchNamespace, name: &str, args: &Object) -> JsValue;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36366,14 +36485,16 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub fn try_get_with_args(
         this: &DispatchNamespace,
         name: &str,
         args: &Object,
     ) -> Result<JsValue, JsValue>;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36383,6 +36504,10 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method, js_name = "get")]
     pub fn get_with_args_and_options(
         this: &DispatchNamespace,
@@ -36390,8 +36515,6 @@ extern "C" {
         args: &Object,
         options: &DynamicDispatchOptions,
     ) -> JsValue;
-    #[doc = " @throws If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
-    #[doc = " "]
     #[doc = " ## Arguments"]
     #[doc = " "]
     #[doc = " * `name` - Name of the Worker script."]
@@ -36401,6 +36524,10 @@ extern "C" {
     #[doc = " ## Returns"]
     #[doc = " "]
     #[doc = " A Fetcher object that allows you to send requests to the Worker script."]
+    #[doc = " "]
+    #[doc = " ## Errors"]
+    #[doc = " "]
+    #[doc = " * If the Worker script does not exist in this dispatch namespace, an error will be thrown."]
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub fn try_get_with_args_and_options(
         this: &DispatchNamespace,


### PR DESCRIPTION
Three intertwined changes that ship together because each motivated the next while plumbing email types into `workers-rs`.

## `@throws` JSDoc → typed `Result<_, ErrTy>`

Methods, free functions, static methods, and constructors now harvest `@throws {T}` annotations from their JSDoc and use them to type the error half of any catching variant.

```ts
/**
 * @throws {ImagesError} if upload fails
 */
upload(file: File): Promise<ImageMetadata>;
```

becomes

```rust
#[wasm_bindgen(method, catch)]
pub async fn upload(this: &…, file: &File) -> Result<ImageMetadata, ImagesError>;
```

instead of `Result<_, JsValue>`. Recognised forms:

* `@throws {TypeError} when foo` — single type
* `@throws {TypeError | RangeError} when bar` — union
* `@throws {@link ImagesError} if upload fails` — `{@link X}` collapsed to `X`
* `@throws If the resource exists, ...` — pure prose, no structured type

The rendered doc gains an `## Errors` section listing every `@throws` line so the prose isn't lost.

`@throws` flows through the IR as `Option<TypeRef>` on `MethodMember` / `StaticMethodMember` / `FunctionDecl` / `ConstructorMember` — the same shape the rest of the type pipeline already understands. Resolution to a single error `TypeRef` is a regular union simplification, see below.

## Subtyping lattice + universal union LUB

`TypeRef::Union` codegen used to erase to `JsValue`. Now it computes the most-specific common ancestor across the union members and emits that. Driven by a new `codegen::subtyping` module:

* A static `BUILTIN_PARENTS` table for JS Error / DOM / collection / typed-array hierarchies — `TypeError extends Error`, `DOMException extends Error`, etc.
* `user_parents` walks `ClassDecl::extends` / `InterfaceDecl::extends` through the codegen scope.
* `ancestor_chain(name)` builds `[self, parent, …, Object]` for any type, builtin or user-declared.
* `lub_types(names)` returns the deepest ancestor that appears in every chain — `None` when only `Object` is shared (callers fall back to the existing `JsValue` erasure since `Object` is no improvement).

This is a universal concept, not throws-specific. Any TS union benefits — `string | TypeError | RangeError` no longer flattens to `JsValue` if the user-side LUB is meaningful, and `@throws` falls out for free as just another union-of-named-types.

Concrete result on `@cloudflare/workers-types`:

```rust
// `@throws {BadRequestError | QuotaReachedError | MaxFileSizeError | ...}` —
// all five extend `StreamError` in the d.ts, so the LUB is StreamError:
pub async fn upload(this: &StreamBinding, file: &File)
    -> Result<StreamVideo, StreamError>;

// `@throws {InternalError}` — single name, used directly:
pub async fn generate_token(this: &StreamVideoHandle)
    -> Result<String, InternalError>;
```

## Slim signature pipeline

`expand_signatures` was carrying everything: params, name, catch, doc, return type, async-ness, kind. Most of those are invariant across all outputs of a single call — only `params` and the disambiguating name suffix are genuinely per-output.

* `ExpandedSignature` is now `{ name_suffix, params }` — a focused parameter-axis result.
* `expand_signatures(overloads, cgctx, scope)` does only the parameter work: optional truncation, union cartesian product, cross-overload dedup, suffix assignment.
* `CallableSpec` describes a JS callable (`js_name`, `kind`, `overloads`, `return_type`, `error_type`, `doc`).
* `build_signatures(spec, used_names, …)` is the per-callable layer: resolves Promise → async, decides `try_` companions, picks the base name, and emits a `Vec<FunctionSignature>` ready for the emitters.
* `FunctionSignature` is the fully-resolved emitter input (`rust_name`, `js_name`, `params`, `catch`, `is_async`, `return_type`, `error_type`, `doc`).

This makes throws fall out cleanly: `error_type` lives where it belongs — in `FunctionSignature` — and emitters thread it through `to_return_type(ty, catch, error_ty, …)` rather than juggling per-overload state.

## Drive-by: collision-renamed types now public-aliased

When a local class collides with a `js_sys::*` glob-imported name (`Global`, in `WebAssembly.Global`), `resolve_collisions` chose a suffixed Rust ident (`Global_`) to avoid the ambiguity. That suffix was leaking into the public Rust path consumers see — they'd write `web_assembly::Global_` instead of `web_assembly::Global`.

Fixed by emitting `pub use Global_ as Global;` after the extern block, keeping the suffix purely internal:

```rust
pub mod web_assembly {
    use js_sys::*;
    #[wasm_bindgen]
    extern "C" {
        #[wasm_bindgen(extends = Object, js_name = "Global", js_namespace = "WebAssembly")]
        pub type Global_;        // disambiguates against js_sys::Global
        #[wasm_bindgen(constructor, catch, js_name = "Global")]
        pub fn new(...) -> Result<Global_, JsValue>;
    }
    pub use Global_ as Global;   // public face
}
```

`web_assembly::Global` works again from outside the module.

## Tests

* 18 new unit tests across `parse::docs` (8 — throws parsing edge cases including `{@link X}`, unions, primitives, prose) and `codegen::subtyping` (10 — builtin chains, user `extends` walking, multi-level LUB, single/empty inputs).
* All 9 fixture snapshots re-blessed; the workers-types diff shows precisely the expected wins (`Stream*` methods now `Result<_, StreamError>`, `Images*` now `Result<_, ImagesError>`, etc.) plus the `Global_ → pub use Global` collision alias.
* Integration tests (`just test-integration`) pass: 6 (`es_module_lexer`) + 12 (`node_console`).
