### PR TITLE
Collapse Record<K, Union> per-arm explosion to a single binding

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -643,36 +643,6 @@ pub fn show_with_value_a_and_opts(value: f64, opts: &ShowOpts);
 disambiguation, including readability adjustments when the same
 parameter name appears in multiple alternatives.
 
-### Carve-out: union-typed `Record` values don't fan out
-
-`Record<K, U>` where `U` is a union (e.g. `Record<string, string | number
-| boolean>`) emits a single binding rather than one per union arm:
-
-```rust
-// Single Record(K, Union) lowers to plain `&Object` via the existing
-// JsValue-erasure path for unions in argument position.
-pub fn set_metadata(this: &Foo, val: &Object);
-```
-
-instead of
-
-```rust
-pub fn set_metadata(this: &Foo, val: &Object<JsString>);
-pub fn set_metadata_with_record_1(this: &Foo, val: &Object<Number>);
-pub fn set_metadata_with_record_2(this: &Foo, val: &Object<Boolean>);
-```
-
-The phantom `<T>` on `Object<T>` is purely a compile-time tag — at
-runtime every typed-Record arm is the same JS object. Cartesian-expanding
-the value-side union just clones the method per arm and forces callers
-to pick one of N siblings whose only difference is a phantom that
-nothing checks. The carve-out lives in `flatten_type` for `Record(K, V)`
-and only kicks in when `V` flattens to more than one alternative.
-
-Single-typed Records (`Record<string, string>`) still emit
-`&Object<JsString>` — the typed phantom is meaningful when the value
-side is monomorphic.
-
 ### Why a single pipeline
 
 Treating optional, union, overload, and variadic as one parameter-axis
@@ -762,6 +732,27 @@ The lattice is built from:
 When the deepest common ancestor is `Object` (no useful narrowing), the
 union erases to `JsValue` — the existing default. This rule is universal:
 it applies to `@throws` unions and to any TS union return type.
+
+The same LUB rule also runs at flatten-time for the inner type of
+generic containers (`Array<T>`, `Set<T>`, `Promise<T>`, `Map<K, V>`,
+`Record<K, V>`). When the inner type fans out to multiple alternatives,
+they collapse to either:
+
+* their LUB (when every alt is `TypeRef::Named` and they share an
+  ancestor more specific than `Object`) — e.g. `Array<TypeError |
+  RangeError>` emits `Array<Error>` rather than two phantom-sibling
+  `Array<TypeError>` / `Array<RangeError>` bindings; or
+* the original union (otherwise) — `Record<string, string | number |
+  boolean>` lowers to bare `&Object` via the existing `is_jsvalue_arg`
+  elision in `to_syn_type`.
+
+This keeps one binding per outer container shape rather than fanning
+out per inner-arm phantom. The phantom on `Array<T>`, `Object<T>`, etc.
+is a compile-time tag — at runtime every arm is the same JS object, so
+the explosion was pure API-surface noise. Single-typed containers
+(`Record<string, string>` → `&Object<JsString>`) keep their meaningful
+phantom because flatten produces a single alternative and the collapse
+step is a no-op.
 
 ## Module declarations and namespace nesting
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -643,6 +643,36 @@ pub fn show_with_value_a_and_opts(value: f64, opts: &ShowOpts);
 disambiguation, including readability adjustments when the same
 parameter name appears in multiple alternatives.
 
+### Carve-out: union-typed `Record` values don't fan out
+
+`Record<K, U>` where `U` is a union (e.g. `Record<string, string | number
+| boolean>`) emits a single binding rather than one per union arm:
+
+```rust
+// Single Record(K, Union) lowers to plain `&Object` via the existing
+// JsValue-erasure path for unions in argument position.
+pub fn set_metadata(this: &Foo, val: &Object);
+```
+
+instead of
+
+```rust
+pub fn set_metadata(this: &Foo, val: &Object<JsString>);
+pub fn set_metadata_with_record_1(this: &Foo, val: &Object<Number>);
+pub fn set_metadata_with_record_2(this: &Foo, val: &Object<Boolean>);
+```
+
+The phantom `<T>` on `Object<T>` is purely a compile-time tag — at
+runtime every typed-Record arm is the same JS object. Cartesian-expanding
+the value-side union just clones the method per arm and forces callers
+to pick one of N siblings whose only difference is a phantom that
+nothing checks. The carve-out lives in `flatten_type` for `Record(K, V)`
+and only kicks in when `V` flattens to more than one alternative.
+
+Single-typed Records (`Record<string, string>`) still emit
+`&Object<JsString>` — the typed phantom is meaningful when the value
+side is monomorphic.
+
 ### Why a single pipeline
 
 Treating optional, union, overload, and variadic as one parameter-axis

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -65,6 +65,9 @@ borrowed by reference; return-position container types are owned.
 * `T | undefined` and `T | null | undefined` → also `Option<T>`. We coalesce
   at parse time; the rendered union has no separate `null`/`undefined`
   arm.
+* Inside generic containers, `T | null` → `JsOption<T>` unless `T` already
+  erases to `JsValue`; `JsOption<JsValue>` collapses to `JsValue` so the
+  container can use its bare default type.
 * `T?` on a property → `Option<T>`. The setter takes `Option<T>` too, so
   callers can clear the property by passing `None`.
 * `f(x?: T)` (optional parameter) → produces an overload pair, *not* an

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -65,9 +65,8 @@ borrowed by reference; return-position container types are owned.
 * `T | undefined` and `T | null | undefined` → also `Option<T>`. We coalesce
   at parse time; the rendered union has no separate `null`/`undefined`
   arm.
-* Inside generic containers, `T | null` → `JsOption<T>` unless `T` already
-  erases to `JsValue`; `JsOption<JsValue>` collapses to `JsValue` so the
-  container can use its bare default type.
+* In inner type positions, `T | null` → `JsOption<T>` unless `T` already
+  erases to `JsValue`; `JsOption<JsValue>` simplifies to `JsValue`.
 * `T?` on a property → `Option<T>`. The setter takes `Option<T>` too, so
   callers can clear the property by passing `None`.
 * `f(x?: T)` (optional parameter) → produces an overload pair, *not* an
@@ -584,6 +583,9 @@ For every JS callable, `ts-gen`:
    variants (one per prefix `[(a), (a, b), (a, b, c)]`); union params
    expand via cartesian product (`(string | ArrayBuffer)` →
    `[(string), (ArrayBuffer)]`); a trailing variadic stays trailing.
+   Unions inside generic type arguments do not distribute:
+   `Array<A | B>` and `Record<K, A | B>` are each one parameter shape,
+   not `Array<A> | Array<B>` or `Record<K, A> | Record<K, B>`.
 2. **Cross-overload dedup**: When multiple overloads expand to the same
    concrete parameter list, drop the duplicates. Two overloads that
    both truncate to `(callback)` produce only one binding.
@@ -736,26 +738,11 @@ When the deepest common ancestor is `Object` (no useful narrowing), the
 union erases to `JsValue` — the existing default. This rule is universal:
 it applies to `@throws` unions and to any TS union return type.
 
-The same LUB rule also runs at flatten-time for the inner type of
-generic containers (`Array<T>`, `Set<T>`, `Promise<T>`, `Map<K, V>`,
-`Record<K, V>`). When the inner type fans out to multiple alternatives,
-they collapse to either:
-
-* their LUB (when every alt is `TypeRef::Named` and they share an
-  ancestor more specific than `Object`) — e.g. `Array<TypeError |
-  RangeError>` emits `Array<Error>` rather than two phantom-sibling
-  `Array<TypeError>` / `Array<RangeError>` bindings; or
-* the original union (otherwise) — `Record<string, string | number |
-  boolean>` lowers to bare `&Object` via the existing `is_jsvalue_arg`
-  elision in `to_syn_type`.
-
-This keeps one binding per outer container shape rather than fanning
-out per inner-arm phantom. The phantom on `Array<T>`, `Object<T>`, etc.
-is a compile-time tag — at runtime every arm is the same JS object, so
-the explosion was pure API-surface noise. Single-typed containers
-(`Record<string, string>` → `&Object<JsString>`) keep their meaningful
-phantom because flatten produces a single alternative and the collapse
-step is a no-op.
+This LUB rule applies when lowering an actual union type. It does not
+make generic containers distributive: `Array<TypeError | RangeError>`
+is still a single `Array<Error>` type, and `Record<string, string |
+number | boolean>` lowers as one `Object` binding rather than separate
+record overloads for each value type.
 
 ## Module declarations and namespace nesting
 

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -441,42 +441,12 @@ fn expand_single_overload(
     sigs
 }
 
-/// Collapse a list of flattened alternatives into a single representative
-/// type, using the same subtyping LUB rule as `TypeRef::Union` lowering.
-///
-/// * 0 or 1 alternatives → pass through.
-/// * Multiple alternatives sharing a `Named` ancestor more specific than
-///   `Object` (per [`crate::codegen::typemap::lub_named`]) → return the
-///   ancestor.
-/// * Otherwise → return `original`. `to_syn_type`'s `is_jsvalue_arg`
-///   elision then lowers e.g. `Record<K, string | number | boolean>` to
-///   bare `&Object` via the JsValue path.
-///
-/// `original` is the unflattened element type — the caller's source of
-/// truth when no LUB applies, avoiding a reconstruction of the union
-/// from the flattened alternatives.
-fn lub_collapse(
-    alts: Vec<TypeRef>,
-    original: &TypeRef,
-    cgctx: Option<&CodegenContext<'_>>,
-    scope: ScopeId,
-) -> TypeRef {
-    match alts.len() {
-        0 => TypeRef::Any,
-        1 => alts.into_iter().next().unwrap(),
-        _ => crate::codegen::typemap::lub_named(&alts, cgctx, scope)
-            .map(TypeRef::Named)
-            .unwrap_or_else(|| original.clone()),
-    }
-}
-
 /// Recursively flatten a type into its concrete alternatives.
 ///
 /// - `Union([A, B])` → flatten(A) ++ flatten(B)
 /// - `Nullable(T)` → flatten(T) wrapped in Nullable
 /// - `Named("Foo")` → resolve alias; if alias is a union, flatten it
-/// - `Promise(T)` → for each flatten(T), wrap in Promise
-/// - `Array(T)` → for each flatten(T), wrap in Array
+/// - Generic container type arguments do not flatten
 /// - Everything else → single leaf
 fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId) -> Vec<TypeRef> {
     match ty {
@@ -507,53 +477,8 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
             alts
         }
 
-        // Generic containers: flatten the inner type, then collapse the
-        // alternatives via subtyping LUB before wrapping. This keeps one
-        // binding per outer container shape rather than fanning out per
-        // inner-arm phantom — at the wasm-bindgen ABI the phantom `T`
-        // on `Array<T>`, `Object<T>`, etc. is a compile-time tag, so a
-        // union value in element position is pure API-surface noise.
-        // Falls back to the original union when no useful LUB exists,
-        // letting `to_syn_type`'s `is_jsvalue_arg` elision lower it to
-        // the bare base type. See the LUB convention in `CONVENTIONS.md`.
-        TypeRef::Promise(inner) => vec![TypeRef::Promise(Box::new(lub_collapse(
-            flatten_type(inner, cgctx, scope),
-            inner,
-            cgctx,
-            scope,
-        )))],
-        TypeRef::Array(inner) => vec![TypeRef::Array(Box::new(lub_collapse(
-            flatten_type(inner, cgctx, scope),
-            inner,
-            cgctx,
-            scope,
-        )))],
-        TypeRef::Set(inner) => vec![TypeRef::Set(Box::new(lub_collapse(
-            flatten_type(inner, cgctx, scope),
-            inner,
-            cgctx,
-            scope,
-        )))],
-        // Two-arg containers: collapse each side independently via LUB,
-        // then fan out the cartesian product across the (now single-arm)
-        // collapsed sides — `Record<string, string | number | boolean>`
-        // becomes one binding, `Record<string | number, T>` with a key
-        // union (rare in TS) still produces two bindings keyed by the
-        // collapsed key alts.
-        TypeRef::Record(k, v) => {
-            let ks = flatten_type(k, cgctx, scope);
-            let v = lub_collapse(flatten_type(v, cgctx, scope), v, cgctx, scope);
-            ks.into_iter()
-                .map(|k| TypeRef::Record(Box::new(k), Box::new(v.clone())))
-                .collect()
-        }
-        TypeRef::Map(k, v) => {
-            let k = lub_collapse(flatten_type(k, cgctx, scope), k, cgctx, scope);
-            let v = lub_collapse(flatten_type(v, cgctx, scope), v, cgctx, scope);
-            vec![TypeRef::Map(Box::new(k), Box::new(v))]
-        }
-
-        // Leaf types: no expansion
+        // Generic containers are not distributive: `Array<A | B>` and
+        // `Record<K, A | B>` are single parameter shapes, not overloads.
         _ => vec![ty.clone()],
     }
 }
@@ -1321,7 +1246,7 @@ mod tests {
         assert_eq!(non_try[2].params.len(), 2);
     }
 
-    // ─── lub_collapse / generic-container fan-in ────────────────────
+    // Generic containers are opaque to signature flattening.
 
     fn flatten_no_ctx(ty: &TypeRef) -> Vec<TypeRef> {
         let (gctx, scope) = test_ctx();
@@ -1330,10 +1255,7 @@ mod tests {
     }
 
     #[test]
-    fn record_with_mixed_primitive_union_collapses_to_single_alternative() {
-        // Record<string, string | number | boolean> — no useful LUB
-        // across primitives, so collapse to one Record carrying the
-        // original union. Lowering elides the value-side phantom.
+    fn record_with_mixed_primitive_union_does_not_distribute() {
         let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number, TypeRef::Boolean]);
         let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(union_v.clone()));
         let alts = flatten_no_ctx(&ty);
@@ -1345,8 +1267,19 @@ mod tests {
     }
 
     #[test]
+    fn record_with_union_key_does_not_distribute() {
+        let union_k = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
+        let ty = TypeRef::Record(Box::new(union_k.clone()), Box::new(TypeRef::String));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Record(k, _) => assert_eq!(**k, union_k),
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn record_with_single_typed_value_keeps_typed_phantom() {
-        // Record<string, string> — single alternative survives untouched.
         let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(TypeRef::String));
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
@@ -1357,8 +1290,7 @@ mod tests {
     }
 
     #[test]
-    fn array_with_mixed_primitive_union_collapses_to_single_alternative() {
-        // Array<string | number> — same rule as Record.
+    fn array_with_mixed_primitive_union_does_not_distribute() {
         let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
         let ty = TypeRef::Array(Box::new(union_v.clone()));
         let alts = flatten_no_ctx(&ty);
@@ -1370,9 +1302,7 @@ mod tests {
     }
 
     #[test]
-    fn map_collapses_both_sides_independently() {
-        // Map<string | number, string | boolean> — both sides collapse
-        // to single alternatives, producing one Map binding.
+    fn map_with_union_type_args_does_not_distribute() {
         let k = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
         let v = TypeRef::Union(vec![TypeRef::String, TypeRef::Boolean]);
         let ty = TypeRef::Map(Box::new(k.clone()), Box::new(v.clone()));
@@ -1388,8 +1318,7 @@ mod tests {
     }
 
     #[test]
-    fn promise_with_union_collapses() {
-        // Promise<string | number> — collapses to a single Promise.
+    fn promise_with_union_does_not_distribute() {
         let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
         let ty = TypeRef::Promise(Box::new(union_v.clone()));
         let alts = flatten_no_ctx(&ty);
@@ -1398,42 +1327,5 @@ mod tests {
             TypeRef::Promise(inner) => assert_eq!(**inner, union_v),
             other => panic!("expected Promise, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn lub_collapse_picks_meaningful_named_ancestor() {
-        // Two error subtypes share `Error` via the builtin lattice — the
-        // helper should collapse to that ancestor rather than falling
-        // back to the original union.
-        let alts = vec![
-            TypeRef::Named("TypeError".into()),
-            TypeRef::Named("RangeError".into()),
-        ];
-        let original = TypeRef::Union(alts.clone());
-        let (gctx, scope) = test_ctx();
-        let cgctx = CodegenContext::empty(&gctx, scope);
-        let collapsed = lub_collapse(alts, &original, Some(&cgctx), scope);
-        assert_eq!(collapsed, TypeRef::Named("Error".into()));
-    }
-
-    #[test]
-    fn lub_collapse_falls_back_when_only_object_is_shared() {
-        // Mixed primitives have no Named representation, so the helper
-        // skips the LUB attempt and returns the original union.
-        let alts = vec![TypeRef::String, TypeRef::Number];
-        let original = TypeRef::Union(alts.clone());
-        let (gctx, scope) = test_ctx();
-        let cgctx = CodegenContext::empty(&gctx, scope);
-        let collapsed = lub_collapse(alts, &original, Some(&cgctx), scope);
-        assert_eq!(collapsed, original);
-    }
-
-    #[test]
-    fn lub_collapse_passes_through_single_alt() {
-        let alts = vec![TypeRef::String];
-        let (gctx, scope) = test_ctx();
-        let cgctx = CodegenContext::empty(&gctx, scope);
-        let collapsed = lub_collapse(alts, &TypeRef::String, Some(&cgctx), scope);
-        assert_eq!(collapsed, TypeRef::String);
     }
 }

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -441,6 +441,35 @@ fn expand_single_overload(
     sigs
 }
 
+/// Collapse a list of flattened alternatives into a single representative
+/// type, using the same subtyping LUB rule as `TypeRef::Union` lowering.
+///
+/// * 0 or 1 alternatives → pass through.
+/// * Multiple alternatives sharing a `Named` ancestor more specific than
+///   `Object` (per [`crate::codegen::typemap::lub_named`]) → return the
+///   ancestor.
+/// * Otherwise → return `original`. `to_syn_type`'s `is_jsvalue_arg`
+///   elision then lowers e.g. `Record<K, string | number | boolean>` to
+///   bare `&Object` via the JsValue path.
+///
+/// `original` is the unflattened element type — the caller's source of
+/// truth when no LUB applies, avoiding a reconstruction of the union
+/// from the flattened alternatives.
+fn lub_collapse(
+    alts: Vec<TypeRef>,
+    original: &TypeRef,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> TypeRef {
+    match alts.len() {
+        0 => TypeRef::Any,
+        1 => alts.into_iter().next().unwrap(),
+        _ => crate::codegen::typemap::lub_named(&alts, cgctx, scope)
+            .map(TypeRef::Named)
+            .unwrap_or_else(|| original.clone()),
+    }
+}
+
 /// Recursively flatten a type into its concrete alternatives.
 ///
 /// - `Union([A, B])` → flatten(A) ++ flatten(B)
@@ -478,56 +507,50 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
             alts
         }
 
-        // Generic containers: flatten inner, wrap each
-        TypeRef::Promise(inner) => flatten_type(inner, cgctx, scope)
-            .into_iter()
-            .map(|t| TypeRef::Promise(Box::new(t)))
-            .collect(),
-        TypeRef::Array(inner) => flatten_type(inner, cgctx, scope)
-            .into_iter()
-            .map(|t| TypeRef::Array(Box::new(t)))
-            .collect(),
-        TypeRef::Set(inner) => flatten_type(inner, cgctx, scope)
-            .into_iter()
-            .map(|t| TypeRef::Set(Box::new(t)))
-            .collect(),
-        // Two-arg containers: cartesian product, with one carve-out — when
-        // the value side is a union (flattens to >1 alternative), emit a
-        // single Record carrying the original union instead of cloning the
-        // method per arm. The arms would each lower to a distinct
-        // `Object<JsString>` / `Object<Number>` / `Object<Boolean>`
-        // signature whose phantom `T` is purely a compile-time tag — at
-        // runtime they're the same JS object, so the explosion is pure
-        // API-surface noise. Folding the union back at this layer leaves
-        // typemap to lower `Record<K, Union>` to plain `&Object` via its
-        // existing JsValue-erasure path.
+        // Generic containers: flatten the inner type, then collapse the
+        // alternatives via subtyping LUB before wrapping. This keeps one
+        // binding per outer container shape rather than fanning out per
+        // inner-arm phantom — at the wasm-bindgen ABI the phantom `T`
+        // on `Array<T>`, `Object<T>`, etc. is a compile-time tag, so a
+        // union value in element position is pure API-surface noise.
+        // Falls back to the original union when no useful LUB exists,
+        // letting `to_syn_type`'s `is_jsvalue_arg` elision lower it to
+        // the bare base type. See the LUB convention in `CONVENTIONS.md`.
+        TypeRef::Promise(inner) => vec![TypeRef::Promise(Box::new(lub_collapse(
+            flatten_type(inner, cgctx, scope),
+            inner,
+            cgctx,
+            scope,
+        )))],
+        TypeRef::Array(inner) => vec![TypeRef::Array(Box::new(lub_collapse(
+            flatten_type(inner, cgctx, scope),
+            inner,
+            cgctx,
+            scope,
+        )))],
+        TypeRef::Set(inner) => vec![TypeRef::Set(Box::new(lub_collapse(
+            flatten_type(inner, cgctx, scope),
+            inner,
+            cgctx,
+            scope,
+        )))],
+        // Two-arg containers: collapse each side independently via LUB,
+        // then fan out the cartesian product across the (now single-arm)
+        // collapsed sides — `Record<string, string | number | boolean>`
+        // becomes one binding, `Record<string | number, T>` with a key
+        // union (rare in TS) still produces two bindings keyed by the
+        // collapsed key alts.
         TypeRef::Record(k, v) => {
             let ks = flatten_type(k, cgctx, scope);
-            let vs = flatten_type(v, cgctx, scope);
-            if vs.len() > 1 {
-                return ks
-                    .into_iter()
-                    .map(|k| TypeRef::Record(Box::new(k), v.clone()))
-                    .collect();
-            }
-            let mut result = Vec::new();
-            for k in &ks {
-                for v in &vs {
-                    result.push(TypeRef::Record(Box::new(k.clone()), Box::new(v.clone())));
-                }
-            }
-            result
+            let v = lub_collapse(flatten_type(v, cgctx, scope), v, cgctx, scope);
+            ks.into_iter()
+                .map(|k| TypeRef::Record(Box::new(k), Box::new(v.clone())))
+                .collect()
         }
         TypeRef::Map(k, v) => {
-            let ks = flatten_type(k, cgctx, scope);
-            let vs = flatten_type(v, cgctx, scope);
-            let mut result = Vec::new();
-            for k in &ks {
-                for v in &vs {
-                    result.push(TypeRef::Map(Box::new(k.clone()), Box::new(v.clone())));
-                }
-            }
-            result
+            let k = lub_collapse(flatten_type(k, cgctx, scope), k, cgctx, scope);
+            let v = lub_collapse(flatten_type(v, cgctx, scope), v, cgctx, scope);
+            vec![TypeRef::Map(Box::new(k), Box::new(v))]
         }
 
         // Leaf types: no expansion
@@ -1296,5 +1319,121 @@ mod tests {
         assert_eq!(non_try[1].params.len(), 2);
         assert_eq!(non_try[2].rust_name, "foo_with_c");
         assert_eq!(non_try[2].params.len(), 2);
+    }
+
+    // ─── lub_collapse / generic-container fan-in ────────────────────
+
+    fn flatten_no_ctx(ty: &TypeRef) -> Vec<TypeRef> {
+        let (gctx, scope) = test_ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        flatten_type(ty, Some(&cgctx), scope)
+    }
+
+    #[test]
+    fn record_with_mixed_primitive_union_collapses_to_single_alternative() {
+        // Record<string, string | number | boolean> — no useful LUB
+        // across primitives, so collapse to one Record carrying the
+        // original union. Lowering elides the value-side phantom.
+        let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number, TypeRef::Boolean]);
+        let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(union_v.clone()));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Record(_, v) => assert_eq!(**v, union_v),
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_with_single_typed_value_keeps_typed_phantom() {
+        // Record<string, string> — single alternative survives untouched.
+        let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(TypeRef::String));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Record(_, v) => assert_eq!(**v, TypeRef::String),
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_with_mixed_primitive_union_collapses_to_single_alternative() {
+        // Array<string | number> — same rule as Record.
+        let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
+        let ty = TypeRef::Array(Box::new(union_v.clone()));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Array(inner) => assert_eq!(**inner, union_v),
+            other => panic!("expected Array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_collapses_both_sides_independently() {
+        // Map<string | number, string | boolean> — both sides collapse
+        // to single alternatives, producing one Map binding.
+        let k = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
+        let v = TypeRef::Union(vec![TypeRef::String, TypeRef::Boolean]);
+        let ty = TypeRef::Map(Box::new(k.clone()), Box::new(v.clone()));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Map(map_k, map_v) => {
+                assert_eq!(**map_k, k);
+                assert_eq!(**map_v, v);
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn promise_with_union_collapses() {
+        // Promise<string | number> — collapses to a single Promise.
+        let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
+        let ty = TypeRef::Promise(Box::new(union_v.clone()));
+        let alts = flatten_no_ctx(&ty);
+        assert_eq!(alts.len(), 1);
+        match &alts[0] {
+            TypeRef::Promise(inner) => assert_eq!(**inner, union_v),
+            other => panic!("expected Promise, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lub_collapse_picks_meaningful_named_ancestor() {
+        // Two error subtypes share `Error` via the builtin lattice — the
+        // helper should collapse to that ancestor rather than falling
+        // back to the original union.
+        let alts = vec![
+            TypeRef::Named("TypeError".into()),
+            TypeRef::Named("RangeError".into()),
+        ];
+        let original = TypeRef::Union(alts.clone());
+        let (gctx, scope) = test_ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let collapsed = lub_collapse(alts, &original, Some(&cgctx), scope);
+        assert_eq!(collapsed, TypeRef::Named("Error".into()));
+    }
+
+    #[test]
+    fn lub_collapse_falls_back_when_only_object_is_shared() {
+        // Mixed primitives have no Named representation, so the helper
+        // skips the LUB attempt and returns the original union.
+        let alts = vec![TypeRef::String, TypeRef::Number];
+        let original = TypeRef::Union(alts.clone());
+        let (gctx, scope) = test_ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let collapsed = lub_collapse(alts, &original, Some(&cgctx), scope);
+        assert_eq!(collapsed, original);
+    }
+
+    #[test]
+    fn lub_collapse_passes_through_single_alt() {
+        let alts = vec![TypeRef::String];
+        let (gctx, scope) = test_ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let collapsed = lub_collapse(alts, &TypeRef::String, Some(&cgctx), scope);
+        assert_eq!(collapsed, TypeRef::String);
     }
 }

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -491,10 +491,25 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
             .into_iter()
             .map(|t| TypeRef::Set(Box::new(t)))
             .collect(),
-        // Two-arg containers: cartesian product
+        // Two-arg containers: cartesian product, with one carve-out — when
+        // the value side is a union (flattens to >1 alternative), emit a
+        // single Record carrying the original union instead of cloning the
+        // method per arm. The arms would each lower to a distinct
+        // `Object<JsString>` / `Object<Number>` / `Object<Boolean>`
+        // signature whose phantom `T` is purely a compile-time tag — at
+        // runtime they're the same JS object, so the explosion is pure
+        // API-surface noise. Folding the union back at this layer leaves
+        // typemap to lower `Record<K, Union>` to plain `&Object` via its
+        // existing JsValue-erasure path.
         TypeRef::Record(k, v) => {
             let ks = flatten_type(k, cgctx, scope);
             let vs = flatten_type(v, cgctx, scope);
+            if vs.len() > 1 {
+                return ks
+                    .into_iter()
+                    .map(|k| TypeRef::Record(Box::new(k), v.clone()))
+                    .collect();
+            }
             let mut result = Vec::new();
             for k in &ks {
                 for v in &vs {

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -426,7 +426,7 @@ pub fn to_syn_type(
             TypeRef::Void | TypeRef::Undefined => return quote! { Undefined },
             TypeRef::Nullable(inner) => {
                 let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
-                return quote! { JsOption<#inner_ty> };
+                return js_option_or_js_value(inner_ty);
             }
             _ => {}
         }
@@ -506,7 +506,7 @@ pub fn to_syn_type(
         TypeRef::Nullable(inner) => {
             if pos.inner {
                 let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
-                quote! { JsOption<#inner_ty> }
+                js_option_or_js_value(inner_ty)
             } else {
                 let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
                 quote! { Option<#inner_ty> }
@@ -643,6 +643,14 @@ fn generic_container(
         base
     } else {
         quote! { #base<#arg> }
+    }
+}
+
+fn js_option_or_js_value(inner_ty: TokenStream) -> TokenStream {
+    if is_jsvalue_arg(&inner_ty) {
+        quote! { JsValue }
+    } else {
+        quote! { JsOption<#inner_ty> }
     }
 }
 
@@ -983,6 +991,12 @@ mod tests {
     }
 
     #[test]
+    fn test_nullable_inner_jsvalue_collapses() {
+        let ty = TypeRef::Nullable(Box::new(TypeRef::Any));
+        assert_eq!(inner_type(&ty), "JsValue");
+    }
+
+    #[test]
     fn test_promise_with_string() {
         let ty = TypeRef::Promise(Box::new(TypeRef::String));
         let result = ret_type(&ty);
@@ -1054,11 +1068,30 @@ mod tests {
     }
 
     #[test]
+    fn test_record_nullable_jsvalue_elides_generic() {
+        let ty = TypeRef::Record(
+            Box::new(TypeRef::String),
+            Box::new(TypeRef::Nullable(Box::new(TypeRef::Union(vec![
+                TypeRef::String,
+                TypeRef::Number,
+                TypeRef::Boolean,
+            ])))),
+        );
+        assert_eq!(ret_type(&ty), "Object");
+    }
+
+    #[test]
     fn test_promise_nullable_inner() {
         // Promise<string | null> → Promise<JsOption<JsString>>
         let ty = TypeRef::Promise(Box::new(TypeRef::Nullable(Box::new(TypeRef::String))));
         let result = ret_type(&ty);
         assert_eq!(result, "Promise < JsOption < JsString > >");
+    }
+
+    #[test]
+    fn test_promise_nullable_jsvalue_elides_generic() {
+        let ty = TypeRef::Promise(Box::new(TypeRef::Nullable(Box::new(TypeRef::Any))));
+        assert_eq!(ret_type(&ty), "Promise");
     }
 
     #[test]

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -518,7 +518,7 @@ pub fn to_syn_type(
             // emit that ancestor instead of erasing to `JsValue`. Falls back
             // to `JsValue` for non-named members or when only `Object` is
             // common (which is no better than `JsValue` in practice).
-            if let Some(lub) = union_lub(members, ctx, scope) {
+            if let Some(lub) = lub_named(members, ctx, scope) {
                 let lub_ty = to_syn_type(&TypeRef::Named(lub), pos, ctx, scope, from_module);
                 return lub_ty;
             }
@@ -828,11 +828,19 @@ pub(crate) fn make_ident(name: &str) -> syn::Ident {
     }
 }
 
-/// Try to compute a subtyping LUB across the members of a union. Returns
+/// Try to compute a subtyping LUB across a list of `TypeRef`s. Returns
 /// `Some(name)` only when every member is a `TypeRef::Named` *and* the
 /// resulting LUB is more specific than `Object` (a `Object` LUB is no
 /// better than the default `JsValue` erasure, so we treat it as no LUB).
-fn union_lub(
+///
+/// Used by:
+/// * `TypeRef::Union` lowering — collapses unions of named subtypes to
+///   their shared ancestor instead of erasing to `JsValue`.
+/// * `signatures::flatten_type` — collapses generic-container element
+///   alternatives so e.g. `Array<TypeError | RangeError>` emits one
+///   `Array<Error>` rather than two phantom-sibling `Array<TypeError>`
+///   / `Array<RangeError>` bindings.
+pub(crate) fn lub_named(
     members: &[TypeRef],
     ctx: Option<&CodegenContext<'_>>,
     scope: ScopeId,

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -2603,27 +2603,24 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type DurableObjectTransaction;
     #[wasm_bindgen(method, catch)]
-    pub async fn get(
-        this: &DurableObjectTransaction,
-        key: &str,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    pub async fn get(this: &DurableObjectTransaction, key: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_key_and_options(
         this: &DurableObjectTransaction,
         key: &str,
         options: &DurableObjectGetOptions,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_keys(
         this: &DurableObjectTransaction,
         keys: &Array<JsString>,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_keys_and_options(
         this: &DurableObjectTransaction,
         keys: &Array<JsString>,
         options: &DurableObjectGetOptions,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch)]
     pub async fn list(this: &DurableObjectTransaction) -> Result<Map<JsString, JsValue>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "list")]
@@ -2721,24 +2718,24 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type DurableObjectStorage;
     #[wasm_bindgen(method, catch)]
-    pub async fn get(this: &DurableObjectStorage, key: &str) -> Result<JsOption<JsValue>, JsValue>;
+    pub async fn get(this: &DurableObjectStorage, key: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_key_and_options(
         this: &DurableObjectStorage,
         key: &str,
         options: &DurableObjectGetOptions,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_keys(
         this: &DurableObjectStorage,
         keys: &Array<JsString>,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_with_keys_and_options(
         this: &DurableObjectStorage,
         keys: &Array<JsString>,
         options: &DurableObjectGetOptions,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    ) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch)]
     pub async fn list(this: &DurableObjectStorage) -> Result<Map<JsString, JsValue>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "list")]
@@ -64044,12 +64041,9 @@ extern "C" {
         values: &[JsValue],
     ) -> Result<D1PreparedStatement, JsValue>;
     #[wasm_bindgen(method, catch)]
-    pub async fn first(
-        this: &D1PreparedStatement,
-        col_name: &str,
-    ) -> Result<JsOption<JsValue>, JsValue>;
+    pub async fn first(this: &D1PreparedStatement, col_name: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "first")]
-    pub async fn first_1(this: &D1PreparedStatement) -> Result<JsOption<JsValue>, JsValue>;
+    pub async fn first_1(this: &D1PreparedStatement) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, catch)]
     pub async fn run(this: &D1PreparedStatement) -> Result<D1Result, JsValue>;
     #[wasm_bindgen(method, catch)]

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -3150,11 +3150,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn indexes(this: &AnalyticsEngineDataPoint) -> Option<Array<JsOption<JsValue>>>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_indexes(this: &AnalyticsEngineDataPoint, val: &Array<ArrayBuffer>);
-    #[wasm_bindgen(method, setter, js_name = "indexes")]
-    pub fn set_indexes_with_array(this: &AnalyticsEngineDataPoint, val: &Array<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "indexes")]
-    pub fn set_indexes_with_array_1(this: &AnalyticsEngineDataPoint, val: &Array<Null>);
+    pub fn set_indexes(this: &AnalyticsEngineDataPoint, val: &Array<JsOption<JsValue>>);
     #[wasm_bindgen(method, getter)]
     pub fn doubles(this: &AnalyticsEngineDataPoint) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
@@ -3162,11 +3158,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn blobs(this: &AnalyticsEngineDataPoint) -> Option<Array<JsOption<JsValue>>>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_blobs(this: &AnalyticsEngineDataPoint, val: &Array<ArrayBuffer>);
-    #[wasm_bindgen(method, setter, js_name = "blobs")]
-    pub fn set_blobs_with_array(this: &AnalyticsEngineDataPoint, val: &Array<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "blobs")]
-    pub fn set_blobs_with_array_1(this: &AnalyticsEngineDataPoint, val: &Array<Null>);
+    pub fn set_blobs(this: &AnalyticsEngineDataPoint, val: &Array<JsOption<JsValue>>);
 }
 impl AnalyticsEngineDataPoint {
     pub fn new() -> AnalyticsEngineDataPoint {
@@ -3182,32 +3174,16 @@ pub struct AnalyticsEngineDataPointBuilder {
     inner: AnalyticsEngineDataPoint,
 }
 impl AnalyticsEngineDataPointBuilder {
-    pub fn indexes(self, val: &Array<ArrayBuffer>) -> Self {
+    pub fn indexes(self, val: &Array<JsOption<JsValue>>) -> Self {
         self.inner.set_indexes(val);
-        self
-    }
-    pub fn indexes_with_array(self, val: &Array<JsString>) -> Self {
-        self.inner.set_indexes_with_array(val);
-        self
-    }
-    pub fn indexes_with_array_1(self, val: &Array<Null>) -> Self {
-        self.inner.set_indexes_with_array_1(val);
         self
     }
     pub fn doubles(self, val: &Array<Number>) -> Self {
         self.inner.set_doubles(val);
         self
     }
-    pub fn blobs(self, val: &Array<ArrayBuffer>) -> Self {
+    pub fn blobs(self, val: &Array<JsOption<JsValue>>) -> Self {
         self.inner.set_blobs(val);
-        self
-    }
-    pub fn blobs_with_array(self, val: &Array<JsString>) -> Self {
-        self.inner.set_blobs_with_array(val);
-        self
-    }
-    pub fn blobs_with_array_1(self, val: &Array<Null>) -> Self {
-        self.inner.set_blobs_with_array_1(val);
         self
     }
     pub fn build(self) -> AnalyticsEngineDataPoint {
@@ -3922,31 +3898,10 @@ extern "C" {
     #[wasm_bindgen(constructor, catch)]
     pub fn new() -> Result<Blob, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array(r#type: &Array<ArrayBuffer>) -> Result<Blob, JsValue>;
+    pub fn new_with_type(r#type: &Array) -> Result<Blob, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_1(r#type: &Array<Object>) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_2(r#type: &Array<JsString>) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_3(r#type: &Array<Blob>) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_and_options(
-        r#type: &Array<ArrayBuffer>,
-        options: &BlobOptions,
-    ) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_and_options_1(
-        r#type: &Array<Object>,
-        options: &BlobOptions,
-    ) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_and_options_2(
-        r#type: &Array<JsString>,
-        options: &BlobOptions,
-    ) -> Result<Blob, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "Blob")]
-    pub fn new_with_array_and_options_3(
-        r#type: &Array<Blob>,
+    pub fn new_with_type_and_options(
+        r#type: &Array,
         options: &BlobOptions,
     ) -> Result<Blob, JsValue>;
     #[doc = " The **`size`** read-only property of the Blob interface returns the size of the Blob or File in bytes."]
@@ -4074,36 +4029,12 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type File;
     #[wasm_bindgen(constructor, catch)]
-    pub fn new(bits: &Array<ArrayBuffer>, name: &str) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array(bits: &Array<Object>, name: &str) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array_1(bits: &Array<JsString>, name: &str) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array_2(bits: &Array<Blob>, name: &str) -> Result<File, JsValue>;
+    pub fn new(bits: &Array, name: &str) -> Result<File, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "File")]
     pub fn new_with_null(bits: &Null, name: &str) -> Result<File, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "File")]
     pub fn new_with_array_and_options(
-        bits: &Array<ArrayBuffer>,
-        name: &str,
-        options: &FileOptions,
-    ) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array_and_options_1(
-        bits: &Array<Object>,
-        name: &str,
-        options: &FileOptions,
-    ) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array_and_options_2(
-        bits: &Array<JsString>,
-        name: &str,
-        options: &FileOptions,
-    ) -> Result<File, JsValue>;
-    #[wasm_bindgen(constructor, catch, js_name = "File")]
-    pub fn new_with_array_and_options_3(
-        bits: &Array<Blob>,
+        bits: &Array,
         name: &str,
         options: &FileOptions,
     ) -> Result<File, JsValue>;
@@ -9219,9 +9150,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn include(this: &R2ListOptions) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_include(this: &R2ListOptions, val: &Array<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "include")]
-    pub fn set_include_with_array(this: &R2ListOptions, val: &Array<JsString>);
+    pub fn set_include(this: &R2ListOptions, val: &Array);
 }
 impl R2ListOptions {
     pub fn new() -> R2ListOptions {
@@ -9257,12 +9186,8 @@ impl R2ListOptionsBuilder {
         self.inner.set_start_after(val);
         self
     }
-    pub fn include(self, val: &Array<JsString>) -> Self {
+    pub fn include(self, val: &Array) -> Self {
         self.inner.set_include(val);
-        self
-    }
-    pub fn include_with_array(self, val: &Array<JsString>) -> Self {
-        self.inner.set_include_with_array(val);
         self
     }
     pub fn build(self) -> R2ListOptions {
@@ -12954,9 +12879,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn inputs(this: &URLPatternResult) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_inputs(this: &URLPatternResult, val: &Array<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_array(this: &URLPatternResult, val: &Array<URLPatternInit>);
+    pub fn set_inputs(this: &URLPatternResult, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn protocol(this: &URLPatternResult) -> URLPatternComponentResult;
     #[wasm_bindgen(method, setter)]
@@ -16898,20 +16821,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_input(this: &ResponsesInput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array(this: &ResponsesInput, val: &Array<EasyInputMessage>);
-    #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array_1(this: &ResponsesInput, val: &Array<ResponseInputItemMessage>);
-    #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array_2(this: &ResponsesInput, val: &Array<ResponseOutputMessage>);
-    #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array_3(this: &ResponsesInput, val: &Array<ResponseFunctionToolCall>);
-    #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array_4(
-        this: &ResponsesInput,
-        val: &Array<ResponseInputItemFunctionCallOutput>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "input")]
-    pub fn set_input_with_array_5(this: &ResponsesInput, val: &Array<ResponseReasoningItem>);
+    pub fn set_input_with_array(this: &ResponsesInput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn instructions(this: &ResponsesInput) -> Option<String>;
     #[wasm_bindgen(method, setter)]
@@ -17064,28 +16974,8 @@ impl ResponsesInputBuilder {
         self.inner.set_input(val);
         self
     }
-    pub fn input_with_array(self, val: &Array<EasyInputMessage>) -> Self {
+    pub fn input_with_array(self, val: &Array) -> Self {
         self.inner.set_input_with_array(val);
-        self
-    }
-    pub fn input_with_array_1(self, val: &Array<ResponseInputItemMessage>) -> Self {
-        self.inner.set_input_with_array_1(val);
-        self
-    }
-    pub fn input_with_array_2(self, val: &Array<ResponseOutputMessage>) -> Self {
-        self.inner.set_input_with_array_2(val);
-        self
-    }
-    pub fn input_with_array_3(self, val: &Array<ResponseFunctionToolCall>) -> Self {
-        self.inner.set_input_with_array_3(val);
-        self
-    }
-    pub fn input_with_array_4(self, val: &Array<ResponseInputItemFunctionCallOutput>) -> Self {
-        self.inner.set_input_with_array_4(val);
-        self
-    }
-    pub fn input_with_array_5(self, val: &Array<ResponseReasoningItem>) -> Self {
-        self.inner.set_input_with_array_5(val);
         self
     }
     pub fn instructions(self, val: &str) -> Self {
@@ -17258,32 +17148,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_instructions(this: &ResponsesOutput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array(this: &ResponsesOutput, val: &Array<EasyInputMessage>);
-    #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array_1(
-        this: &ResponsesOutput,
-        val: &Array<ResponseInputItemMessage>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array_2(
-        this: &ResponsesOutput,
-        val: &Array<ResponseOutputMessage>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array_3(
-        this: &ResponsesOutput,
-        val: &Array<ResponseFunctionToolCall>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array_4(
-        this: &ResponsesOutput,
-        val: &Array<ResponseInputItemFunctionCallOutput>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "instructions")]
-    pub fn set_instructions_with_array_5(
-        this: &ResponsesOutput,
-        val: &Array<ResponseReasoningItem>,
-    );
+    pub fn set_instructions_with_array(this: &ResponsesOutput, val: &Array);
     #[wasm_bindgen(method, setter, js_name = "instructions")]
     pub fn set_instructions_with_null(this: &ResponsesOutput, val: &Null);
     #[wasm_bindgen(method, getter)]
@@ -17293,11 +17158,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn output(this: &ResponsesOutput) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_output(this: &ResponsesOutput, val: &Array<ResponseOutputMessage>);
-    #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array(this: &ResponsesOutput, val: &Array<ResponseFunctionToolCall>);
-    #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array_1(this: &ResponsesOutput, val: &Array<ResponseReasoningItem>);
+    pub fn set_output(this: &ResponsesOutput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn parallel_tool_calls(this: &ResponsesOutput) -> Option<bool>;
     #[wasm_bindgen(method, setter)]
@@ -17436,31 +17297,8 @@ impl ResponsesOutputBuilder {
         self.inner.set_instructions(val);
         self
     }
-    pub fn instructions_with_array(self, val: &Array<EasyInputMessage>) -> Self {
+    pub fn instructions_with_array(self, val: &Array) -> Self {
         self.inner.set_instructions_with_array(val);
-        self
-    }
-    pub fn instructions_with_array_1(self, val: &Array<ResponseInputItemMessage>) -> Self {
-        self.inner.set_instructions_with_array_1(val);
-        self
-    }
-    pub fn instructions_with_array_2(self, val: &Array<ResponseOutputMessage>) -> Self {
-        self.inner.set_instructions_with_array_2(val);
-        self
-    }
-    pub fn instructions_with_array_3(self, val: &Array<ResponseFunctionToolCall>) -> Self {
-        self.inner.set_instructions_with_array_3(val);
-        self
-    }
-    pub fn instructions_with_array_4(
-        self,
-        val: &Array<ResponseInputItemFunctionCallOutput>,
-    ) -> Self {
-        self.inner.set_instructions_with_array_4(val);
-        self
-    }
-    pub fn instructions_with_array_5(self, val: &Array<ResponseReasoningItem>) -> Self {
-        self.inner.set_instructions_with_array_5(val);
         self
     }
     pub fn instructions_with_null(self, val: &Null) -> Self {
@@ -17471,16 +17309,8 @@ impl ResponsesOutputBuilder {
         self.inner.set_object(val);
         self
     }
-    pub fn output(self, val: &Array<ResponseOutputMessage>) -> Self {
+    pub fn output(self, val: &Array) -> Self {
         self.inner.set_output(val);
-        self
-    }
-    pub fn output_with_array(self, val: &Array<ResponseFunctionToolCall>) -> Self {
-        self.inner.set_output_with_array(val);
-        self
-    }
-    pub fn output_with_array_1(self, val: &Array<ResponseReasoningItem>) -> Self {
-        self.inner.set_output_with_array_1(val);
         self
     }
     pub fn parallel_tool_calls(self, val: bool) -> Self {
@@ -17613,9 +17443,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_content(this: &EasyInputMessage, val: &str);
     #[wasm_bindgen(method, setter, js_name = "content")]
-    pub fn set_content_with_array(this: &EasyInputMessage, val: &Array<ResponseInputText>);
-    #[wasm_bindgen(method, setter, js_name = "content")]
-    pub fn set_content_with_array_1(this: &EasyInputMessage, val: &Array<ResponseInputImage>);
+    pub fn set_content_with_array(this: &EasyInputMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &EasyInputMessage) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -18292,15 +18120,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseCustomToolCallOutput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array(
-        this: &ResponseCustomToolCallOutput,
-        val: &Array<ResponseInputText>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array_1(
-        this: &ResponseCustomToolCallOutput,
-        val: &Array<ResponseInputImage>,
-    );
+    pub fn set_output_with_array(this: &ResponseCustomToolCallOutput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn r#type(this: &ResponseCustomToolCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
@@ -18371,7 +18191,7 @@ impl ResponseCustomToolCallOutput {
     ) -> ResponseCustomToolCallOutputBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_call_id(call_id);
-        inner.set_output(output);
+        inner.set_output_with_array(output);
         inner.set_type("custom_tool_call_output");
         ResponseCustomToolCallOutputBuilder { inner }
     }
@@ -19479,15 +19299,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseFunctionToolCallOutputItem, val: &str);
     #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array(
-        this: &ResponseFunctionToolCallOutputItem,
-        val: &Array<ResponseInputText>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array_1(
-        this: &ResponseFunctionToolCallOutputItem,
-        val: &Array<ResponseInputImage>,
-    );
+    pub fn set_output_with_array(this: &ResponseFunctionToolCallOutputItem, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn r#type(this: &ResponseFunctionToolCallOutputItem) -> String;
     #[wasm_bindgen(method, setter)]
@@ -19572,7 +19384,7 @@ impl ResponseFunctionToolCallOutputItem {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_call_id(call_id);
-        inner.set_output(output);
+        inner.set_output_with_array(output);
         inner.set_type("function_call_output");
         ResponseFunctionToolCallOutputItemBuilder { inner }
     }
@@ -19854,15 +19666,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseInputItemFunctionCallOutput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array(
-        this: &ResponseInputItemFunctionCallOutput,
-        val: &Array<ResponseInputTextContent>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "output")]
-    pub fn set_output_with_array_1(
-        this: &ResponseInputItemFunctionCallOutput,
-        val: &Array<ResponseInputImageContent>,
-    );
+    pub fn set_output_with_array(this: &ResponseInputItemFunctionCallOutput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn r#type(this: &ResponseInputItemFunctionCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
@@ -19993,9 +19797,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &ResponseInputItemMessage) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_content(this: &ResponseInputItemMessage, val: &Array<ResponseInputText>);
-    #[wasm_bindgen(method, setter, js_name = "content")]
-    pub fn set_content_with_array(this: &ResponseInputItemMessage, val: &Array<ResponseInputImage>);
+    pub fn set_content(this: &ResponseInputItemMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseInputItemMessage) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -20126,9 +19928,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &ResponseInputMessageItem) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_content(this: &ResponseInputMessageItem, val: &Array<ResponseInputText>);
-    #[wasm_bindgen(method, setter, js_name = "content")]
-    pub fn set_content_with_array(this: &ResponseInputMessageItem, val: &Array<ResponseInputImage>);
+    pub fn set_content(this: &ResponseInputMessageItem, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseInputMessageItem) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -20522,9 +20322,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &ResponseOutputMessage) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_content(this: &ResponseOutputMessage, val: &Array<ResponseOutputText>);
-    #[wasm_bindgen(method, setter, js_name = "content")]
-    pub fn set_content_with_array(this: &ResponseOutputMessage, val: &Array<ResponseOutputRefusal>);
+    pub fn set_content(this: &ResponseOutputMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseOutputMessage) -> String;
     #[wasm_bindgen(method, setter)]
@@ -23536,7 +23334,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages, val: &Array);
     #[doc = " If true, the response will be streamed back incrementally."]
     #[wasm_bindgen(method, getter)]
     pub fn stream(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<bool>;
@@ -23629,7 +23427,7 @@ impl Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -23991,10 +23789,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages,
@@ -24096,7 +23891,7 @@ impl Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -24830,7 +24625,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages,
@@ -24918,7 +24713,7 @@ impl Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -25255,7 +25050,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwq_32B_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Qwen_Qwq_32B_Messages, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Qwen_Qwq_32B_Messages, val: &Array);
     #[doc = " JSON schema that should be fulfilled for the response."]
     #[wasm_bindgen(method, getter)]
     pub fn guided_json(this: &Ai_Cf_Qwen_Qwq_32B_Messages) -> Option<Object>;
@@ -25336,7 +25131,7 @@ impl Ai_Cf_Qwen_Qwq_32B_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -25648,10 +25443,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages, val: &Array);
     #[doc = " JSON schema that should be fulfilled for the response."]
     #[wasm_bindgen(method, getter)]
     pub fn guided_json(
@@ -25763,7 +25555,7 @@ impl Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -26054,7 +25846,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages, val: &Array);
     #[doc = " JSON schema that should be fulfilled for the response."]
     #[wasm_bindgen(method, getter)]
     pub fn guided_json(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages) -> Option<Object>;
@@ -26135,7 +25927,7 @@ impl Ai_Cf_Google_Gemma_3_12B_It_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -26507,10 +26299,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages,
@@ -26618,7 +26407,7 @@ impl Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -26685,15 +26474,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_requests(
-        this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch,
-        val: &Array<Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "requests")]
-    pub fn set_requests_with_array(
-        this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch,
-        val: &Array<Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner>,
-    );
+    pub fn set_requests(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch, val: &Array);
 }
 impl Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch {
     #[doc = " ## Arguments"]
@@ -26922,10 +26703,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner,
@@ -27049,7 +26827,7 @@ impl Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_InnerBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -27411,7 +27189,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages,
@@ -27496,7 +27274,7 @@ impl Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -27602,15 +27380,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_requests(
-        this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch,
-        val: &Array<Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "requests")]
-    pub fn set_requests_with_array(
-        this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch,
-        val: &Array<Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1>,
-    );
+    pub fn set_requests(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch, val: &Array);
 }
 impl Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch {
     #[doc = " ## Arguments"]
@@ -27847,7 +27617,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1, val: &Array<Object>);
+    pub fn set_tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1,
@@ -27932,7 +27702,7 @@ impl Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1Builder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -31739,10 +31509,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages,
@@ -31844,7 +31611,7 @@ impl Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_MessagesBuilder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -31962,15 +31729,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
-    pub fn set_requests(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch,
-        val: &Array<Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1>,
-    );
-    #[wasm_bindgen(method, setter, js_name = "requests")]
-    pub fn set_requests_with_array(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch,
-        val: &Array<Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1>,
-    );
+    pub fn set_requests(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch, val: &Array);
 }
 impl Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch {
     #[doc = " ## Arguments"]
@@ -32244,10 +32003,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_tools(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1,
-        val: &Array<Object>,
-    );
+    pub fn set_tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn response_format(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1,
@@ -32350,7 +32106,7 @@ impl Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1Builder {
         self.inner.set_functions(val);
         self
     }
-    pub fn tools(self, val: &Array<Object>) -> Self {
+    pub fn tools(self, val: &Array) -> Self {
         self.inner.set_tools(val);
         self
     }

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -14338,9 +14338,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn modules(this: &WorkerLoaderWorkerCode) -> Object;
     #[wasm_bindgen(method, setter)]
-    pub fn set_modules(this: &WorkerLoaderWorkerCode, val: &Object<WorkerLoaderModule>);
-    #[wasm_bindgen(method, setter, js_name = "modules")]
-    pub fn set_modules_with_record(this: &WorkerLoaderWorkerCode, val: &Object<JsString>);
+    pub fn set_modules(this: &WorkerLoaderWorkerCode, val: &Object);
     #[wasm_bindgen(method, getter)]
     pub fn env(this: &WorkerLoaderWorkerCode) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -35312,15 +35310,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &GatewayOptions) -> Option<Object<JsOption<JsValue>>>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &GatewayOptions, val: &Object<Number>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record(this: &GatewayOptions, val: &Object<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_1(this: &GatewayOptions, val: &Object<Boolean>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_2(this: &GatewayOptions, val: &Object<BigInt>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_3(this: &GatewayOptions, val: &Object<Null>);
+    pub fn set_metadata(this: &GatewayOptions, val: &Object<JsOption<JsValue>>);
     #[wasm_bindgen(method, getter, js_name = "collectLog")]
     pub fn collect_log(this: &GatewayOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "collectLog")]
@@ -35370,24 +35360,8 @@ impl GatewayOptionsBuilder {
         self.inner.set_skip_cache(val);
         self
     }
-    pub fn metadata(self, val: &Object<Number>) -> Self {
+    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
         self.inner.set_metadata(val);
-        self
-    }
-    pub fn metadata_with_record(self, val: &Object<JsString>) -> Self {
-        self.inner.set_metadata_with_record(val);
-        self
-    }
-    pub fn metadata_with_record_1(self, val: &Object<Boolean>) -> Self {
-        self.inner.set_metadata_with_record_1(val);
-        self
-    }
-    pub fn metadata_with_record_2(self, val: &Object<BigInt>) -> Self {
-        self.inner.set_metadata_with_record_2(val);
-        self
-    }
-    pub fn metadata_with_record_3(self, val: &Object<Null>) -> Self {
-        self.inner.set_metadata_with_record_3(val);
         self
     }
     pub fn collect_log(self, val: bool) -> Self {
@@ -35434,15 +35408,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &AiGatewayPatchLog) -> Option<Object<JsOption<JsValue>>>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &AiGatewayPatchLog, val: &Object<Number>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record(this: &AiGatewayPatchLog, val: &Object<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_1(this: &AiGatewayPatchLog, val: &Object<Boolean>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_2(this: &AiGatewayPatchLog, val: &Object<BigInt>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_3(this: &AiGatewayPatchLog, val: &Object<Null>);
+    pub fn set_metadata(this: &AiGatewayPatchLog, val: &Object<JsOption<JsValue>>);
     #[wasm_bindgen(method, setter, js_name = "metadata")]
     pub fn set_metadata_with_null(this: &AiGatewayPatchLog, val: &Null);
 }
@@ -35480,24 +35446,8 @@ impl AiGatewayPatchLogBuilder {
         self.inner.set_feedback_with_null(val);
         self
     }
-    pub fn metadata(self, val: &Object<Number>) -> Self {
+    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
         self.inner.set_metadata(val);
-        self
-    }
-    pub fn metadata_with_record(self, val: &Object<JsString>) -> Self {
-        self.inner.set_metadata_with_record(val);
-        self
-    }
-    pub fn metadata_with_record_1(self, val: &Object<Boolean>) -> Self {
-        self.inner.set_metadata_with_record_1(val);
-        self
-    }
-    pub fn metadata_with_record_2(self, val: &Object<BigInt>) -> Self {
-        self.inner.set_metadata_with_record_2(val);
-        self
-    }
-    pub fn metadata_with_record_3(self, val: &Object<Null>) -> Self {
-        self.inner.set_metadata_with_record_3(val);
         self
     }
     pub fn metadata_with_null(self, val: &Null) -> Self {
@@ -35572,15 +35522,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &AiGatewayLog) -> Option<Object<JsOption<JsValue>>>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &AiGatewayLog, val: &Object<Number>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record(this: &AiGatewayLog, val: &Object<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_1(this: &AiGatewayLog, val: &Object<Boolean>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_2(this: &AiGatewayLog, val: &Object<BigInt>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_3(this: &AiGatewayLog, val: &Object<Null>);
+    pub fn set_metadata(this: &AiGatewayLog, val: &Object<JsOption<JsValue>>);
     #[wasm_bindgen(method, getter)]
     pub fn step(this: &AiGatewayLog) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
@@ -35745,24 +35687,8 @@ impl AiGatewayLogBuilder {
         self.inner.set_tokens_out(val);
         self
     }
-    pub fn metadata(self, val: &Object<Number>) -> Self {
+    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
         self.inner.set_metadata(val);
-        self
-    }
-    pub fn metadata_with_record(self, val: &Object<JsString>) -> Self {
-        self.inner.set_metadata_with_record(val);
-        self
-    }
-    pub fn metadata_with_record_1(self, val: &Object<Boolean>) -> Self {
-        self.inner.set_metadata_with_record_1(val);
-        self
-    }
-    pub fn metadata_with_record_2(self, val: &Object<BigInt>) -> Self {
-        self.inner.set_metadata_with_record_2(val);
-        self
-    }
-    pub fn metadata_with_record_3(self, val: &Object<Null>) -> Self {
-        self.inner.set_metadata_with_record_3(val);
         self
     }
     pub fn step(self, val: f64) -> Self {
@@ -35841,15 +35767,7 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = "cf-aig-metadata")]
     pub fn cf_aig_metadata(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata(this: &AIGatewayHeaders, val: &Object<Number>);
-    #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata_with_record(this: &AIGatewayHeaders, val: &Object<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata_with_record_1(this: &AIGatewayHeaders, val: &Object<Boolean>);
-    #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata_with_record_2(this: &AIGatewayHeaders, val: &Object<BigInt>);
-    #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata_with_record_3(this: &AIGatewayHeaders, val: &Object<Null>);
+    pub fn set_cf_aig_metadata(this: &AIGatewayHeaders, val: &Object<JsOption<JsValue>>);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
     pub fn set_cf_aig_metadata_with_str(this: &AIGatewayHeaders, val: &str);
     #[wasm_bindgen(method, getter, js_name = "cf-aig-custom-cost")]
@@ -71997,24 +71915,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &VectorizeVector) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &VectorizeVector, val: &Object<JsString>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record(this: &VectorizeVector, val: &Object<Number>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_1(this: &VectorizeVector, val: &Object<Boolean>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_2(this: &VectorizeVector, val: &Object<Array<JsString>>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_3(this: &VectorizeVector, val: &Object<Object<JsString>>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_4(this: &VectorizeVector, val: &Object<Object<Number>>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_5(this: &VectorizeVector, val: &Object<Object<Boolean>>);
-    #[wasm_bindgen(method, setter, js_name = "metadata")]
-    pub fn set_metadata_with_record_6(
-        this: &VectorizeVector,
-        val: &Object<Object<Array<JsString>>>,
-    );
+    pub fn set_metadata(this: &VectorizeVector, val: &Object);
 }
 impl VectorizeVector {
     #[doc = " ## Arguments"]
@@ -72060,36 +71961,8 @@ impl VectorizeVectorBuilder {
         self.inner.set_namespace(val);
         self
     }
-    pub fn metadata(self, val: &Object<JsString>) -> Self {
+    pub fn metadata(self, val: &Object) -> Self {
         self.inner.set_metadata(val);
-        self
-    }
-    pub fn metadata_with_record(self, val: &Object<Number>) -> Self {
-        self.inner.set_metadata_with_record(val);
-        self
-    }
-    pub fn metadata_with_record_1(self, val: &Object<Boolean>) -> Self {
-        self.inner.set_metadata_with_record_1(val);
-        self
-    }
-    pub fn metadata_with_record_2(self, val: &Object<Array<JsString>>) -> Self {
-        self.inner.set_metadata_with_record_2(val);
-        self
-    }
-    pub fn metadata_with_record_3(self, val: &Object<Object<JsString>>) -> Self {
-        self.inner.set_metadata_with_record_3(val);
-        self
-    }
-    pub fn metadata_with_record_4(self, val: &Object<Object<Number>>) -> Self {
-        self.inner.set_metadata_with_record_4(val);
-        self
-    }
-    pub fn metadata_with_record_5(self, val: &Object<Object<Boolean>>) -> Self {
-        self.inner.set_metadata_with_record_5(val);
-        self
-    }
-    pub fn metadata_with_record_6(self, val: &Object<Object<Array<JsString>>>) -> Self {
-        self.inner.set_metadata_with_record_6(val);
         self
     }
     pub fn build(self) -> VectorizeVector {

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -3148,17 +3148,17 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AnalyticsEngineDataPoint;
     #[wasm_bindgen(method, getter)]
-    pub fn indexes(this: &AnalyticsEngineDataPoint) -> Option<Array<JsOption<JsValue>>>;
+    pub fn indexes(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_indexes(this: &AnalyticsEngineDataPoint, val: &Array<JsOption<JsValue>>);
+    pub fn set_indexes(this: &AnalyticsEngineDataPoint, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn doubles(this: &AnalyticsEngineDataPoint) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_doubles(this: &AnalyticsEngineDataPoint, val: &Array<Number>);
     #[wasm_bindgen(method, getter)]
-    pub fn blobs(this: &AnalyticsEngineDataPoint) -> Option<Array<JsOption<JsValue>>>;
+    pub fn blobs(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_blobs(this: &AnalyticsEngineDataPoint, val: &Array<JsOption<JsValue>>);
+    pub fn set_blobs(this: &AnalyticsEngineDataPoint, val: &Array);
 }
 impl AnalyticsEngineDataPoint {
     pub fn new() -> AnalyticsEngineDataPoint {
@@ -3174,7 +3174,7 @@ pub struct AnalyticsEngineDataPointBuilder {
     inner: AnalyticsEngineDataPoint,
 }
 impl AnalyticsEngineDataPointBuilder {
-    pub fn indexes(self, val: &Array<JsOption<JsValue>>) -> Self {
+    pub fn indexes(self, val: &Array) -> Self {
         self.inner.set_indexes(val);
         self
     }
@@ -3182,7 +3182,7 @@ impl AnalyticsEngineDataPointBuilder {
         self.inner.set_doubles(val);
         self
     }
-    pub fn blobs(self, val: &Array<JsOption<JsValue>>) -> Self {
+    pub fn blobs(self, val: &Array) -> Self {
         self.inner.set_blobs(val);
         self
     }
@@ -3612,29 +3612,22 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type EventTargetHandlerObject;
     #[wasm_bindgen(method, getter, js_name = "handleEvent")]
-    pub fn handle_event(
-        this: &EventTargetHandlerObject,
-    ) -> Function<fn(Event) -> JsOption<JsValue>>;
+    pub fn handle_event(this: &EventTargetHandlerObject) -> Function<fn(Event) -> JsValue>;
     #[wasm_bindgen(method, setter, js_name = "handleEvent")]
-    pub fn set_handle_event(
-        this: &EventTargetHandlerObject,
-        val: &Function<fn(Event) -> JsOption<JsValue>>,
-    );
+    pub fn set_handle_event(this: &EventTargetHandlerObject, val: &Function<fn(Event) -> JsValue>);
 }
 impl EventTargetHandlerObject {
     #[doc = " ## Arguments"]
     #[doc = ""]
     #[doc = " * `handle_event`"]
-    pub fn new(
-        handle_event: &Function<fn(Event) -> JsOption<JsValue>>,
-    ) -> EventTargetHandlerObject {
+    pub fn new(handle_event: &Function<fn(Event) -> JsValue>) -> EventTargetHandlerObject {
         Self::builder(handle_event).build()
     }
     #[doc = " ## Arguments"]
     #[doc = ""]
     #[doc = " * `handle_event`"]
     pub fn builder(
-        handle_event: &Function<fn(Event) -> JsOption<JsValue>>,
+        handle_event: &Function<fn(Event) -> JsValue>,
     ) -> EventTargetHandlerObjectBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_handle_event(handle_event);
@@ -13384,7 +13377,7 @@ extern "C" {
     pub type SqlStorageStatement;
 }
 #[allow(dead_code)]
-pub type SqlStorageValue = JsOption<JsValue>;
+pub type SqlStorageValue = JsValue;
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = Object)]
@@ -21692,7 +21685,7 @@ pub enum ToolChoiceOptions {
     None,
 }
 #[allow(dead_code)]
-pub type ReasoningEffort = JsOption<JsValue>;
+pub type ReasoningEffort = JsValue;
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = Object)]
@@ -35064,9 +35057,9 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "skipCache")]
     pub fn set_skip_cache(this: &GatewayOptions, val: bool);
     #[wasm_bindgen(method, getter)]
-    pub fn metadata(this: &GatewayOptions) -> Option<Object<JsOption<JsValue>>>;
+    pub fn metadata(this: &GatewayOptions) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &GatewayOptions, val: &Object<JsOption<JsValue>>);
+    pub fn set_metadata(this: &GatewayOptions, val: &Object);
     #[wasm_bindgen(method, getter, js_name = "collectLog")]
     pub fn collect_log(this: &GatewayOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "collectLog")]
@@ -35116,7 +35109,7 @@ impl GatewayOptionsBuilder {
         self.inner.set_skip_cache(val);
         self
     }
-    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
+    pub fn metadata(self, val: &Object) -> Self {
         self.inner.set_metadata(val);
         self
     }
@@ -35162,9 +35155,9 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "feedback")]
     pub fn set_feedback_with_null(this: &AiGatewayPatchLog, val: &Null);
     #[wasm_bindgen(method, getter)]
-    pub fn metadata(this: &AiGatewayPatchLog) -> Option<Object<JsOption<JsValue>>>;
+    pub fn metadata(this: &AiGatewayPatchLog) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &AiGatewayPatchLog, val: &Object<JsOption<JsValue>>);
+    pub fn set_metadata(this: &AiGatewayPatchLog, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "metadata")]
     pub fn set_metadata_with_null(this: &AiGatewayPatchLog, val: &Null);
 }
@@ -35202,7 +35195,7 @@ impl AiGatewayPatchLogBuilder {
         self.inner.set_feedback_with_null(val);
         self
     }
-    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
+    pub fn metadata(self, val: &Object) -> Self {
         self.inner.set_metadata(val);
         self
     }
@@ -35276,9 +35269,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_tokens_out(this: &AiGatewayLog, val: f64);
     #[wasm_bindgen(method, getter)]
-    pub fn metadata(this: &AiGatewayLog) -> Option<Object<JsOption<JsValue>>>;
+    pub fn metadata(this: &AiGatewayLog) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
-    pub fn set_metadata(this: &AiGatewayLog, val: &Object<JsOption<JsValue>>);
+    pub fn set_metadata(this: &AiGatewayLog, val: &Object);
     #[wasm_bindgen(method, getter)]
     pub fn step(this: &AiGatewayLog) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
@@ -35443,7 +35436,7 @@ impl AiGatewayLogBuilder {
         self.inner.set_tokens_out(val);
         self
     }
-    pub fn metadata(self, val: &Object<JsOption<JsValue>>) -> Self {
+    pub fn metadata(self, val: &Object) -> Self {
         self.inner.set_metadata(val);
         self
     }
@@ -35523,7 +35516,7 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = "cf-aig-metadata")]
     pub fn cf_aig_metadata(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
-    pub fn set_cf_aig_metadata(this: &AIGatewayHeaders, val: &Object<JsOption<JsValue>>);
+    pub fn set_cf_aig_metadata(this: &AIGatewayHeaders, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
     pub fn set_cf_aig_metadata_with_str(this: &AIGatewayHeaders, val: &str);
     #[wasm_bindgen(method, getter, js_name = "cf-aig-custom-cost")]
@@ -35606,7 +35599,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35653,7 +35646,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35700,7 +35693,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35747,7 +35740,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35794,7 +35787,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35841,7 +35834,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35888,7 +35881,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35935,7 +35928,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -35982,7 +35975,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36029,7 +36022,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36076,7 +36069,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36123,7 +36116,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36170,7 +36163,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36217,7 +36210,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36264,7 +36257,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36311,7 +36304,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -36358,7 +36351,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36405,7 +36398,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36452,7 +36445,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36499,7 +36492,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36546,7 +36539,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36593,7 +36586,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36640,7 +36633,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36687,7 +36680,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36734,7 +36727,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36781,7 +36774,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36828,7 +36821,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36875,7 +36868,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36922,7 +36915,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -36969,7 +36962,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -37016,7 +37009,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -37063,7 +37056,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -37110,7 +37103,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37157,7 +37150,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37204,7 +37197,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37251,7 +37244,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37298,7 +37291,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37345,7 +37338,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37392,7 +37385,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37439,7 +37432,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37486,7 +37479,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37533,7 +37526,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37580,7 +37573,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37627,7 +37620,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37674,7 +37667,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37721,7 +37714,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37768,7 +37761,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37815,7 +37808,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -37862,7 +37855,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -37909,7 +37902,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -37956,7 +37949,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38003,7 +37996,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38050,7 +38043,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38097,7 +38090,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38144,7 +38137,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38191,7 +38184,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38238,7 +38231,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38285,7 +38278,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38332,7 +38325,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38379,7 +38372,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38426,7 +38419,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38473,7 +38466,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38520,7 +38513,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38567,7 +38560,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -38614,7 +38607,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38661,7 +38654,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38708,7 +38701,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38755,7 +38748,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38802,7 +38795,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38849,7 +38842,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38896,7 +38889,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38943,7 +38936,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -38990,7 +38983,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39037,7 +39030,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39084,7 +39077,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39131,7 +39124,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39178,7 +39171,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39225,7 +39218,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39272,7 +39265,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39319,7 +39312,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39366,7 +39359,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -39413,7 +39406,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39460,7 +39453,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39507,7 +39500,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39554,7 +39547,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39601,7 +39594,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39648,7 +39641,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39695,7 +39688,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39742,7 +39735,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39789,7 +39782,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39836,7 +39829,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39883,7 +39876,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39930,7 +39923,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -39977,7 +39970,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -40024,7 +40017,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -40071,7 +40064,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -40118,7 +40111,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -40165,7 +40158,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40212,7 +40205,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40259,7 +40252,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40306,7 +40299,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40353,7 +40346,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40400,7 +40393,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40447,7 +40440,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40494,7 +40487,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40541,7 +40534,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40588,7 +40581,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40635,7 +40628,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40682,7 +40675,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40729,7 +40722,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40776,7 +40769,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40823,7 +40816,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40870,7 +40863,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -40917,7 +40910,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -40964,7 +40957,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41011,7 +41004,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41058,7 +41051,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41105,7 +41098,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41152,7 +41145,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41199,7 +41192,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41246,7 +41239,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41293,7 +41286,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41340,7 +41333,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41387,7 +41380,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41434,7 +41427,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41481,7 +41474,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41528,7 +41521,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41575,7 +41568,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -41622,7 +41615,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -47685,7 +47678,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47731,7 +47724,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47777,7 +47770,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47823,7 +47816,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47869,7 +47862,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47915,7 +47908,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -47961,7 +47954,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48007,7 +48000,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48053,7 +48046,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48099,7 +48092,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48145,7 +48138,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48191,7 +48184,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48237,7 +48230,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48283,7 +48276,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48329,7 +48322,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48375,7 +48368,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -48421,7 +48414,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48467,7 +48460,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48513,7 +48506,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48559,7 +48552,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48605,7 +48598,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48651,7 +48644,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48697,7 +48690,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48743,7 +48736,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48789,7 +48782,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48835,7 +48828,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48881,7 +48874,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48927,7 +48920,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -48973,7 +48966,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -49019,7 +49012,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -49065,7 +49058,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -49111,7 +49104,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -49157,7 +49150,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49203,7 +49196,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49249,7 +49242,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49295,7 +49288,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49341,7 +49334,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49387,7 +49380,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49433,7 +49426,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49479,7 +49472,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49525,7 +49518,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49571,7 +49564,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49617,7 +49610,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49663,7 +49656,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49709,7 +49702,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49755,7 +49748,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49801,7 +49794,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49847,7 +49840,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -49893,7 +49886,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -49939,7 +49932,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -49985,7 +49978,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50031,7 +50024,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50077,7 +50070,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50123,7 +50116,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50169,7 +50162,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50215,7 +50208,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50261,7 +50254,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50307,7 +50300,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50353,7 +50346,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50399,7 +50392,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50445,7 +50438,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50491,7 +50484,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50537,7 +50530,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50583,7 +50576,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -50629,7 +50622,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &Object,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50675,7 +50668,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50721,7 +50714,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50767,7 +50760,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50813,7 +50806,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50859,7 +50852,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50905,7 +50898,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50951,7 +50944,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -50997,7 +50990,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51043,7 +51036,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51089,7 +51082,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51135,7 +51128,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51181,7 +51174,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51227,7 +51220,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51273,7 +51266,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51319,7 +51312,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51365,7 +51358,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: bool,
@@ -51411,7 +51404,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51457,7 +51450,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51503,7 +51496,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51549,7 +51542,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51595,7 +51588,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51641,7 +51634,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51687,7 +51680,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51733,7 +51726,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51779,7 +51772,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51825,7 +51818,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51871,7 +51864,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51917,7 +51910,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -51963,7 +51956,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -52009,7 +52002,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -52055,7 +52048,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -52101,7 +52094,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: f64,
         cf_aig_skip_cache: &str,
@@ -52147,7 +52140,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52193,7 +52186,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52239,7 +52232,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52285,7 +52278,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52331,7 +52324,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52377,7 +52370,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52423,7 +52416,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52469,7 +52462,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52515,7 +52508,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52561,7 +52554,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52607,7 +52600,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52653,7 +52646,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52699,7 +52692,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52745,7 +52738,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52791,7 +52784,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52837,7 +52830,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: bool,
@@ -52883,7 +52876,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -52929,7 +52922,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -52975,7 +52968,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53021,7 +53014,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53067,7 +53060,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53113,7 +53106,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53159,7 +53152,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53205,7 +53198,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53251,7 +53244,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53297,7 +53290,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53343,7 +53336,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53389,7 +53382,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53435,7 +53428,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53481,7 +53474,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53527,7 +53520,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,
@@ -53573,7 +53566,7 @@ impl AIGatewayHeaders {
     #[doc = " * `authorization`"]
     #[doc = " * `content_type`"]
     pub fn builder_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object<JsOption<JsValue>>,
+        cf_aig_metadata: &Object,
         cf_aig_custom_cost: &str,
         cf_aig_cache_ttl: &str,
         cf_aig_skip_cache: &str,


### PR DESCRIPTION
`Record<K, U>` where `U` is a union (flattens to >1 alternative) now emits one binding carrying the original union, instead of one binding per arm. The arms each lower to a distinct `Object<JsString>` / `Object<Number>` / `Object<Boolean>` whose phantom is a compile-time tag the runtime never sees, so the cartesian-expanded variants were pure API-surface noise — every caller had to pick one of N siblings backed by the same JS object.

Folding the union back at `flatten_type` time leaves the existing JsValue-erasure path in `to_syn_type` to lower `Record<K, Union>` to plain `&Object`. Single-typed Records (`Record<string, string>`) still emit `&Object<JsString>` — the typed phantom is meaningful when the value side is monomorphic.

Snapshot impact: workers-types' `WorkerLoaderWorkerCode.modules` (2 arms → 1), `GatewayOptions.metadata` (5 → 1), `VectorizeVector.metadata` (7 → 1) collapse to single bindings. Auto-gen suffix logic also picks the param-name-derived suffix (`_with_context`) instead of the type-derived one (`_with_record`), since there's no longer ambiguity to disambiguate against.