### PR TITLE
Recognize @throws {never} JSDoc to opt out of fallible variants

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -732,11 +732,78 @@ JsValue>`. Recognised forms:
 * `@throws {TypeError} when foo` — single type
 * `@throws {TypeError | RangeError} when bar` — inline union
 * `@throws {@link ImagesError} if foo` — `{@link X}` collapses to `X`
+* `@throws {never}` — declares the callable never throws (see below)
 * Multiple `@throws` lines aggregate into one effective union
 * `@throws Sentence describing condition.` — pure prose, no structured
   type extracted
 
 The original prose surfaces in the rendered doc as an `## Errors` section.
+
+### `@throws {never}` — opting out of fallible variants
+
+`@throws {never}` is the explicit "this never throws" annotation. It
+combines TypeScript's bottom type with JSDoc to tell ts-gen to skip
+the fallible variants for the callable:
+
+```ts
+class NeverThrows {
+  /**
+   * @throws {never}
+   */
+  safeOp(x: number): string;
+
+  /**
+   * @throws {never}
+   */
+  loaded(): Promise<Loaded>;
+}
+
+/**
+ * @throws {never}
+ */
+declare function pureCompute(x: number): number;
+```
+
+emits:
+
+```rust
+// Sync methods/functions: no `try_<name>` companion.
+#[wasm_bindgen(method, js_name = "safeOp")]
+pub fn safe_op(this: &NeverThrows, x: f64) -> String;
+
+// Async methods/functions: no `Result` wrapper, no `catch`.
+#[wasm_bindgen(method)]
+pub async fn loaded(this: &NeverThrows) -> Loaded;
+
+#[wasm_bindgen(js_name = "pureCompute")]
+pub fn pure_compute(x: f64) -> f64;
+```
+
+Compare to a plain sync method, which emits both forms:
+
+```rust
+pub fn frobnicate(this: &Foo) -> String;             // panic on throw
+pub fn try_frobnicate(this: &Foo) -> Result<String, JsValue>;
+```
+
+#### Rules
+
+* **Sync callables** with `@throws {never}` get *only* the primary
+  binding — no `try_<name>` companion is emitted.
+* **Async callables** (returning `Promise<T>`) drop the `Result<T, _>`
+  wrapper and the `catch` attribute. The binding becomes
+  `pub async fn foo() -> T`.
+* **Constructors** always catch per JS `new` semantics —
+  `@throws {never}` on a constructor is silently ignored.
+* **Setters** never throw and never get `try_` variants regardless,
+  so the annotation is a no-op there too.
+* **Mixed annotations** like `@throws {never | TypeError}` collapse to
+  `@throws {TypeError}` (since `T | never` is just `T` in TS) — the
+  `never` arm is absorbed and the residual type drives codegen as
+  usual.
+* **Rendered doc**: `@throws {never}` lines do *not* contribute to
+  the `## Errors` section. By definition there are no errors to
+  document.
 
 ## Subtyping LUB across unions
 

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -319,7 +319,7 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
                 kind: SignatureKind::Setter,
                 overloads: &setter_overloads,
                 return_type: &void,
-                error_type: None,
+                throws: &crate::ir::Throws::None,
                 doc: &None,
             },
             &mut setter_used,
@@ -789,9 +789,14 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                 // Use the first overload's `@throws` (if any) as the error
                 // type for the constructor — TS overloads conventionally
                 // share semantics, and the first one carries the doc.
+                // Constructors always catch per JS `new` semantics, so
+                // `Throws::Never` here is a no-op — `build_signatures` still
+                // emits `catch` with the default `JsValue` error type.
+                let empty_throws = crate::ir::Throws::None;
                 let throws = constructor_overloads
                     .first()
-                    .and_then(|c| c.throws.as_ref());
+                    .map(|c| &c.throws)
+                    .unwrap_or(&empty_throws);
                 let return_type = TypeRef::Named(config.rust_name.clone());
                 let sigs = build_signatures(
                     &CallableSpec {
@@ -799,7 +804,7 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                         kind: SignatureKind::Constructor,
                         overloads: &overloads,
                         return_type: &return_type,
-                        error_type: throws,
+                        throws,
                         doc: &doc,
                     },
                     &mut used_names,
@@ -820,14 +825,15 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                 let overloads: Vec<&[Param]> = group.iter().map(|m| m.params.as_slice()).collect();
                 let doc = group.first().and_then(|m| m.doc.clone());
                 let return_type = &group[0].return_type;
-                let throws = group.first().and_then(|m| m.throws.as_ref());
+                let empty_throws = crate::ir::Throws::None;
+                let throws = group.first().map(|m| &m.throws).unwrap_or(&empty_throws);
                 let sigs = build_signatures(
                     &CallableSpec {
                         js_name: &m.js_name,
                         kind: SignatureKind::Method,
                         overloads: &overloads,
                         return_type,
-                        error_type: throws,
+                        throws,
                         doc: &doc,
                     },
                     &mut used_names,
@@ -848,14 +854,15 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                 let overloads: Vec<&[Param]> = group.iter().map(|m| m.params.as_slice()).collect();
                 let doc = group.first().and_then(|m| m.doc.clone());
                 let return_type = &group[0].return_type;
-                let throws = group.first().and_then(|m| m.throws.as_ref());
+                let empty_throws = crate::ir::Throws::None;
+                let throws = group.first().map(|m| &m.throws).unwrap_or(&empty_throws);
                 let sigs = build_signatures(
                     &CallableSpec {
                         js_name: &m.js_name,
                         kind: SignatureKind::StaticMethod,
                         overloads: &overloads,
                         return_type,
-                        error_type: throws,
+                        throws,
                         doc: &doc,
                     },
                     &mut used_names,
@@ -1207,7 +1214,7 @@ fn generate_setter(
             kind: SignatureKind::Setter,
             overloads: &overloads,
             return_type: &void,
-            error_type: None,
+            throws: &crate::ir::Throws::None,
             doc: &doc,
         },
         used_names,
@@ -1302,7 +1309,7 @@ fn generate_static_setter(
             kind: SignatureKind::StaticSetter,
             overloads: &overloads,
             return_type: &void,
-            error_type: None,
+            throws: &crate::ir::Throws::None,
             doc: &doc,
         },
         used_names,

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -55,7 +55,7 @@ fn emit_function(
             kind: SignatureKind::Function,
             overloads: &[overloads[0]],
             return_type: &decl.return_type,
-            error_type: decl.throws.as_ref(),
+            throws: &decl.throws,
             doc,
         },
         &mut used_names,

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -46,7 +46,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::codegen::typemap::{self, CodegenContext, TypePosition};
-use crate::ir::{Param, TypeRef};
+use crate::ir::{Param, Throws, TypeRef};
 use crate::parse::scope::ScopeId;
 use crate::util::naming::to_snake_case;
 
@@ -318,8 +318,8 @@ pub fn expand_signatures(
 /// one or more wasm-bindgen extern signatures. Pairs with [`build_signatures`].
 ///
 /// All decisions about `try_` companions, `async fn` collapse, and `catch`
-/// fall out of the kind + return type + error type once these inputs are
-/// available.
+/// fall out of the kind + return type + throws annotation once these inputs
+/// are available.
 #[derive(Clone, Debug)]
 pub struct CallableSpec<'a> {
     pub js_name: &'a str,
@@ -328,9 +328,19 @@ pub struct CallableSpec<'a> {
     /// allows multiple overloaded declarations.
     pub overloads: &'a [&'a [Param]],
     pub return_type: &'a TypeRef,
-    /// Optional error type from `@throws` — `None` means use the default
-    /// `JsValue` for any catching variant.
-    pub error_type: Option<&'a TypeRef>,
+    /// Failure-mode info from `@throws` JSDoc — see [`Throws`].
+    ///
+    /// Drives three orthogonal decisions:
+    /// * `Throws::None` → catching variants use the default `JsValue`
+    ///   error type. Sync callables get a `try_<name>` companion.
+    /// * `Throws::Type(T)` → catching variants use `Result<_, T>`. Sync
+    ///   callables still get the `try_<name>` companion (with the typed
+    ///   error).
+    /// * `Throws::Never` → caller declares the callable never throws.
+    ///   Sync callables get *no* `try_` companion; async callables drop
+    ///   `catch` and return `T` directly. Constructors ignore this and
+    ///   still catch (per JS `new` semantics).
+    pub throws: &'a Throws,
     /// Doc comment to attach to the primary signature only.
     pub doc: &'a Option<String>,
 }
@@ -348,6 +358,10 @@ pub struct CallableSpec<'a> {
 ///   each primary `name` gets a fallible `try_name` sibling.
 /// * **Constructor catches always**: per JS semantics; the primary signature
 ///   is `catch: true` and there's no `try_` variant.
+/// * **`Throws::Never`**: the caller declared the callable never throws
+///   (`@throws {never}`). Sync callables get *no* `try_` companion; async
+///   callables drop `catch` and return `T` directly. Constructors ignore
+///   this — they always catch per JS `new` semantics.
 /// * **Naming**: each surviving expansion gets `base + suffix` deduped against
 ///   `used_names`; `try_` variants prepend `try_` and dedup again.
 pub fn build_signatures(
@@ -366,16 +380,22 @@ pub fn build_signatures(
         (other, _) => (false, other.clone()),
     };
 
-    let allow_try = !is_async && spec.kind.allows_try_variant();
+    // `Throws::Never` suppresses every fallible form — except for
+    // constructors, which always catch (`new` can always throw in JS).
+    let nothrow = spec.throws.is_never() && !spec.kind.always_catches();
+    let error_type = spec.throws.as_type();
+
+    let allow_try = !is_async && !nothrow && spec.kind.allows_try_variant();
     let mut out = Vec::with_capacity(expansions.len() * if allow_try { 2 } else { 1 });
 
     for exp in expansions {
         let primary_candidate = public_rust_name(&format!("{base}{}", exp.name_suffix));
         let primary_name = dedupe_name(&primary_candidate, used_names);
 
-        // Primary variant: catches if async (the catch encodes async failure)
-        // or if the kind always catches (constructors).
-        let primary_catches = is_async || spec.kind.always_catches();
+        // Primary variant catches when:
+        // * the kind always catches (constructors), OR
+        // * it's async — *unless* `Throws::Never` opts out.
+        let primary_catches = spec.kind.always_catches() || (is_async && !nothrow);
         out.push(FunctionSignature {
             rust_name: primary_name.clone(),
             js_name: spec.js_name.to_string(),
@@ -384,7 +404,7 @@ pub fn build_signatures(
             is_async,
             return_type: return_type.clone(),
             error_type: if primary_catches {
-                spec.error_type.cloned()
+                error_type.cloned()
             } else {
                 None
             },
@@ -400,7 +420,7 @@ pub fn build_signatures(
                 catch: true,
                 is_async: false,
                 return_type: return_type.clone(),
-                error_type: spec.error_type.cloned(),
+                error_type: error_type.cloned(),
                 doc: spec.doc.clone(),
             });
         }
@@ -895,6 +915,19 @@ mod tests {
         doc: &Option<String>,
         used: &mut HashSet<String>,
     ) -> Vec<FunctionSignature> {
+        expand_throws(js, params, ret, kind, &Throws::None, doc, used)
+    }
+
+    /// Like [`expand`] but with an explicit [`Throws`] state.
+    fn expand_throws(
+        js: &str,
+        params: &[Param],
+        ret: &TypeRef,
+        kind: SignatureKind,
+        throws: &Throws,
+        doc: &Option<String>,
+        used: &mut HashSet<String>,
+    ) -> Vec<FunctionSignature> {
         let (gctx, scope) = test_ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
         build_signatures(
@@ -903,7 +936,7 @@ mod tests {
                 kind,
                 overloads: &[params],
                 return_type: ret,
-                error_type: None,
+                throws,
                 doc,
             },
             used,
@@ -929,7 +962,7 @@ mod tests {
                 kind,
                 overloads,
                 return_type: ret,
-                error_type: None,
+                throws: &Throws::None,
                 doc,
             },
             used,
@@ -1289,6 +1322,153 @@ mod tests {
         assert_eq!(sigs[1].doc, Some("Hello".to_string())); // try_count
         assert_eq!(sigs[2].doc, Some("Hello".to_string())); // count_with_label
         assert_eq!(sigs[3].doc, Some("Hello".to_string())); // try_count_with_label
+    }
+
+    #[test]
+    fn test_throws_never_suppresses_try_variant() {
+        // `@throws {never}` on a sync method: only the primary signature is
+        // emitted — no `try_count` companion. The primary stays non-catching.
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "count",
+            &[],
+            &TypeRef::Void,
+            SignatureKind::Method,
+            &Throws::Never,
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 1, "nothrow methods get no try_ companion");
+        assert_eq!(sigs[0].rust_name, "count");
+        assert!(!sigs[0].catch);
+        assert!(!sigs[0].is_async);
+    }
+
+    #[test]
+    fn test_throws_never_suppresses_try_for_function() {
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "id",
+            &[param("x")],
+            &TypeRef::Any,
+            SignatureKind::Function,
+            &Throws::Never,
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].rust_name, "id");
+        assert!(!sigs[0].catch);
+    }
+
+    #[test]
+    fn test_throws_never_async_drops_catch() {
+        // `@throws {never}` on a Promise-returning method: emit
+        // `async fn -> T` (no `Result`, no `catch`).
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "loaded",
+            &[],
+            &TypeRef::Promise(Box::new(TypeRef::String)),
+            SignatureKind::Method,
+            &Throws::Never,
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].rust_name, "loaded");
+        assert!(sigs[0].is_async);
+        assert!(
+            !sigs[0].catch,
+            "nothrow async drops catch — return type is T directly"
+        );
+        assert!(sigs[0].error_type.is_none());
+        assert_eq!(sigs[0].return_type, TypeRef::String);
+    }
+
+    #[test]
+    fn test_throws_never_optional_method_no_try_pairs() {
+        // Optional params still expand the parameter axis, but each
+        // expansion has no `try_` sibling.
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "count",
+            &[opt_param("label")],
+            &TypeRef::Void,
+            SignatureKind::Method,
+            &Throws::Never,
+            &None,
+            &mut used,
+        );
+        // Two expansions × 1 (no try_) = 2
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].rust_name, "count");
+        assert_eq!(sigs[1].rust_name, "count_with_label");
+        assert!(sigs.iter().all(|s| !s.catch));
+        assert!(sigs.iter().all(|s| !s.rust_name.starts_with("try_")));
+    }
+
+    #[test]
+    fn test_throws_never_constructor_still_catches() {
+        // Constructors always catch per JS `new` semantics — `@throws
+        // {never}` is silently ignored on them. The resulting signature
+        // is the same as for any other constructor.
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "Foo",
+            &[param("x")],
+            &TypeRef::Named("Foo".into()),
+            SignatureKind::Constructor,
+            &Throws::Never,
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].rust_name, "new");
+        assert!(sigs[0].catch, "constructors always catch even with nothrow");
+        assert!(!sigs[0].is_async);
+    }
+
+    #[test]
+    fn test_throws_typed_keeps_try_pair() {
+        // Typed `Throws::Type(...)` behaves like the existing `@throws {T}`
+        // — sync still gets the `try_` companion, with the typed error.
+        let err = TypeRef::Named("ImagesError".into());
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "upload",
+            &[param("file")],
+            &TypeRef::Void,
+            SignatureKind::Method,
+            &Throws::Type(err.clone()),
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].rust_name, "upload");
+        assert!(!sigs[0].catch);
+        assert_eq!(sigs[1].rust_name, "try_upload");
+        assert!(sigs[1].catch);
+        assert_eq!(sigs[1].error_type.as_ref(), Some(&err));
+    }
+
+    #[test]
+    fn test_throws_typed_async_carries_error_type() {
+        let err = TypeRef::Named("ImagesError".into());
+        let mut used = no_used();
+        let sigs = expand_throws(
+            "upload",
+            &[],
+            &TypeRef::Promise(Box::new(TypeRef::String)),
+            SignatureKind::Method,
+            &Throws::Type(err.clone()),
+            &None,
+            &mut used,
+        );
+        assert_eq!(sigs.len(), 1);
+        assert!(sigs[0].is_async);
+        assert!(sigs[0].catch);
+        assert_eq!(sigs[0].error_type.as_ref(), Some(&err));
     }
 
     #[test]

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -270,6 +270,50 @@ pub struct NumericEnumVariant {
 
 // ─── Function ────────────────────────────────────────────────────────
 
+/// What `@throws` JSDoc says about a callable's failure modes.
+///
+/// The three states are mutually exclusive and drive different codegen
+/// decisions:
+///
+/// * [`Throws::None`] — no `@throws` annotation. Sync callables get a
+///   `try_<name>` companion returning `Result<T, JsValue>`; async ones
+///   wrap as `Result<T, JsValue>` directly.
+/// * [`Throws::Type`] — typed throws. Sync gets `try_<name>` returning
+///   `Result<T, ErrTy>`; async wraps as `Result<T, ErrTy>`. The carried
+///   `TypeRef` runs through the regular type pipeline, so subtyping
+///   LUB rules (see `lub_types`) apply when multiple types are listed.
+/// * [`Throws::Never`] — `@throws {never}`. The callable is declared
+///   never to throw. Sync gets *no* `try_` companion; async drops
+///   `catch` and returns `T` directly (no `Result` wrapper).
+///
+/// `Throws::Never` only fires when `never` is the *sole* type listed
+/// across all `@throws` lines — `@throws {never | OtherError}` is
+/// treated as `Throws::Type(OtherError)` (the `never` is ignored).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum Throws {
+    #[default]
+    None,
+    Type(TypeRef),
+    Never,
+}
+
+impl Throws {
+    /// Returns the error `TypeRef` for codegen, if any. `Never` and
+    /// `None` both yield `None` here — callers separately consult
+    /// `is_never()` to decide whether to suppress catching entirely.
+    pub fn as_type(&self) -> Option<&TypeRef> {
+        match self {
+            Throws::Type(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    /// Whether this is the explicit "never throws" annotation.
+    pub fn is_never(&self) -> bool {
+        matches!(self, Throws::Never)
+    }
+}
+
 #[derive(Clone, Debug)]
 
 pub struct FunctionDecl {
@@ -279,12 +323,8 @@ pub struct FunctionDecl {
     pub params: Vec<Param>,
     pub return_type: TypeRef,
     pub overloads: Vec<FunctionOverload>,
-    /// Error type captured from `@throws {T}` JSDoc tags, in the same
-    /// representation as any other type — single name as `TypeRef::Named`,
-    /// multiple as `TypeRef::Union(...)`. Codegen runs it through the
-    /// regular type-rendering pipeline, so subtyping LUB rules (see
-    /// `lub_types`) apply uniformly with normal unions.
-    pub throws: Option<TypeRef>,
+    /// Failure-mode info from `@throws` JSDoc. See [`Throws`].
+    pub throws: Throws,
 }
 
 #[derive(Clone, Debug)]
@@ -369,8 +409,8 @@ pub struct MethodMember {
     pub return_type: TypeRef,
     pub optional: bool,
     pub doc: Option<String>,
-    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
-    pub throws: Option<TypeRef>,
+    /// Failure-mode info from `@throws` — see [`Throws`].
+    pub throws: Throws,
 }
 
 #[derive(Clone, Debug)]
@@ -378,8 +418,12 @@ pub struct MethodMember {
 pub struct ConstructorMember {
     pub params: Vec<Param>,
     pub doc: Option<String>,
-    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
-    pub throws: Option<TypeRef>,
+    /// Failure-mode info from `@throws` — see [`Throws`].
+    ///
+    /// Note: constructors always emit `catch` per JS `new` semantics, so
+    /// `Throws::Never` here is effectively a no-op for codegen — only
+    /// `Throws::Type` (custom error type) changes behavior.
+    pub throws: Throws,
 }
 
 #[derive(Clone, Debug)]
@@ -423,8 +467,8 @@ pub struct StaticMethodMember {
     pub params: Vec<Param>,
     pub return_type: TypeRef,
     pub doc: Option<String>,
-    /// Error type from `@throws {T}` — see `FunctionDecl::throws`.
-    pub throws: Option<TypeRef>,
+    /// Failure-mode info from `@throws` — see [`Throws`].
+    pub throws: Throws,
 }
 
 // ─── Type Registry (First Pass) ──────────────────────────────────────

--- a/src/parse/classify.rs
+++ b/src/parse/classify.rs
@@ -74,7 +74,7 @@ mod tests {
             return_type: TypeRef::Void,
             optional: false,
             doc: None,
-            throws: None,
+            throws: crate::ir::Throws::None,
         })
     }
 

--- a/src/parse/docs.rs
+++ b/src/parse/docs.rs
@@ -18,36 +18,54 @@ pub struct JsDocInfo {
     /// preserving source order. Each entry is the raw identifier as written
     /// in the JSDoc (e.g. `"TypeError"`, `"ImagesError"`).
     ///
-    /// Use [`Self::throws_typeref`] to convert into the standard `TypeRef`
-    /// representation that the rest of the pipeline understands.
+    /// Use [`Self::throws`] to convert into the standard pipeline
+    /// representation ([`crate::ir::Throws`]) that codegen consumes.
     ///
     /// Recognized forms:
     /// * `@throws {TypeError} when foo` — single type
     /// * `@throws {TypeError | RangeError} when bar` — union
     /// * `@throws {@link ImagesError} if upload fails` — JSDoc link form
+    /// * `@throws {never}` — declares the callable never throws (sets
+    ///   [`Self::nothrow`]; the name itself is *not* added to this list)
     ///
     /// Pure-prose `@throws Sentence describing condition.` entries with no
     /// `{T}` annotation are silently ignored.
     pub throws: Vec<String>,
+
+    /// `true` when an `@throws {never}` annotation was seen. Combined with
+    /// an empty `throws` list this maps to [`crate::ir::Throws::Never`];
+    /// if other named types also appeared, the `never` is ignored and the
+    /// other types win (see [`Self::throws`]).
+    pub nothrow: bool,
 }
 
 impl JsDocInfo {
-    /// Lift the `@throws` name list into a `TypeRef`:
+    /// Convert the structured `@throws` info into a [`crate::ir::Throws`]
+    /// for the IR.
     ///
-    /// * Empty → `None`
-    /// * Single name → `TypeRef::Named(...)`
-    /// * Multiple → `TypeRef::Union(...)` of named entries
+    /// * No `@throws` info at all → [`Throws::None`]
+    /// * `@throws {never}` alone → [`Throws::Never`]
+    /// * Single named type → [`Throws::Type`] with `TypeRef::Named`
+    /// * Multiple names → [`Throws::Type`] with `TypeRef::Union(...)`
     ///
-    /// The returned `TypeRef` is just a regular type from the pipeline's
-    /// perspective — codegen's union-LUB rules apply uniformly to it.
-    pub fn throws_typeref(&self) -> Option<crate::ir::TypeRef> {
+    /// `@throws {never | OtherError}` resolves to `Throws::Type(OtherError)`
+    /// — the `never` is dropped during parsing and only the residual
+    /// type(s) drive codegen. This matches the principle that `T | never`
+    /// is just `T` in the TypeScript type system.
+    ///
+    /// [`Throws::None`]: crate::ir::Throws::None
+    /// [`Throws::Type`]: crate::ir::Throws::Type
+    /// [`Throws::Never`]: crate::ir::Throws::Never
+    pub fn throws(&self) -> crate::ir::Throws {
+        use crate::ir::{Throws, TypeRef};
         match self.throws.len() {
-            0 => None,
-            1 => Some(crate::ir::TypeRef::Named(self.throws[0].clone())),
-            _ => Some(crate::ir::TypeRef::Union(
+            0 if self.nothrow => Throws::Never,
+            0 => Throws::None,
+            1 => Throws::Type(TypeRef::Named(self.throws[0].clone())),
+            _ => Throws::Type(TypeRef::Union(
                 self.throws
                     .iter()
-                    .map(|n| crate::ir::TypeRef::Named(n.clone()))
+                    .map(|n| TypeRef::Named(n.clone()))
                     .collect(),
             )),
         }
@@ -164,13 +182,22 @@ fn convert_jsdoc_tags(lines: &[&str]) -> (String, JsDocInfo) {
         } else if let Some(rest) = line.strip_prefix("@throws ") {
             // Capture both the structured type info (for `info.throws`) and a
             // human-readable line for the Errors section in the rendered doc.
-            let (types, prose) = parse_throws_tag(rest);
-            for ty in types {
+            //
+            // `@throws {never}` lines never contribute to the rendered
+            // `## Errors` section — by definition there are no errors to
+            // document. The structured `nothrow` flag still gets set so
+            // codegen can drop the fallible variants.
+            let parsed = parse_throws_tag(rest);
+            for ty in parsed.types {
                 if !info.throws.contains(&ty) {
                     info.throws.push(ty);
                 }
             }
-            throws_lines.push(prose);
+            if parsed.nothrow {
+                info.nothrow = true;
+            } else {
+                throws_lines.push(parsed.prose);
+            }
         } else if line == "@example" {
             // Collect all lines until the next tag or end
             let mut code_lines = Vec::new();
@@ -259,12 +286,20 @@ fn convert_jsdoc_tags(lines: &[&str]) -> (String, JsDocInfo) {
     (out.join("\n"), info)
 }
 
+/// Result of parsing one `@throws` tag's contents.
+struct ParsedThrows {
+    /// Named identifiers extracted from `{...}`, in source order. Empty if
+    /// the tag was pure prose, only listed primitives, or only `never`.
+    types: Vec<String>,
+    /// `true` when the tag contained `never` and *no* other non-primitive
+    /// type. `@throws {never | TypeError}` does *not* set this — the
+    /// resulting throws is just `TypeError` (the `never` is absorbed).
+    nothrow: bool,
+    /// Human-readable line for the rendered Errors section.
+    prose: String,
+}
+
 /// Parse the contents of an `@throws` tag.
-///
-/// Returns `(type_names, prose)` where:
-/// * `type_names` is the list of identifiers found between `{...}` (preserving
-///   source order). Empty if the tag is pure prose with no braced type.
-/// * `prose` is a short human-readable line for the rendered Errors section.
 ///
 /// Per the JSDoc spec, structured types live inside curly braces:
 ///
@@ -272,12 +307,14 @@ fn convert_jsdoc_tags(lines: &[&str]) -> (String, JsDocInfo) {
 /// * `{TypeError | RangeError} when bar` — union
 /// * `{@link ImagesError} if upload fails` — JSDoc link form (linked
 ///   identifier is taken as the type)
+/// * `{never}` — declares the callable never throws (sets `nothrow`)
 /// * `If the X does not exist, an error will be thrown.` — pure prose, no type
 ///
 /// Primitive type names (`string`/`number`/etc.) inside `{...}` are *not*
-/// added to `type_names` — they'd widen the LUB to `JsValue` anyway and
-/// aren't resolvable to a Rust error type.
-fn parse_throws_tag(rest: &str) -> (Vec<String>, String) {
+/// added to `types` — they'd widen the LUB to `JsValue` anyway and aren't
+/// resolvable to a Rust error type. `never` is its own special case: it
+/// sets `nothrow` instead of contributing a type.
+fn parse_throws_tag(rest: &str) -> ParsedThrows {
     let trimmed = rest.trim();
 
     if let Some(stripped) = trimmed.strip_prefix('{') {
@@ -288,12 +325,26 @@ fn parse_throws_tag(rest: &str) -> (Vec<String>, String) {
             // Handle `{@link Foo}` — keep just the linked name.
             let inner = inner.strip_prefix("@link ").map(str::trim).unwrap_or(inner);
 
-            let names: Vec<String> = inner
-                .split('|')
-                .map(str::trim)
-                .filter(|s| !s.is_empty() && !is_primitive_type_name(s))
-                .map(String::from)
-                .collect();
+            let mut names: Vec<String> = Vec::new();
+            let mut saw_never = false;
+            for raw in inner.split('|').map(str::trim) {
+                if raw.is_empty() {
+                    continue;
+                }
+                if raw == "never" {
+                    saw_never = true;
+                    continue;
+                }
+                if is_primitive_type_name(raw) {
+                    continue;
+                }
+                names.push(raw.to_string());
+            }
+
+            // `nothrow` only fires when `never` was the sole non-empty arm.
+            // `@throws {never | TypeError}` is just `@throws {TypeError}` —
+            // `T | never` collapses to `T` in TS, and we mirror that.
+            let nothrow = saw_never && names.is_empty();
 
             // Build a prose line for the rendered Errors section. Use the
             // raw inner text (with `{@link X}` collapsed to `X`) so unions
@@ -303,12 +354,20 @@ fn parse_throws_tag(rest: &str) -> (Vec<String>, String) {
             } else {
                 format!("`{inner}` — {after}")
             };
-            return (names, prose);
+            return ParsedThrows {
+                types: names,
+                nothrow,
+                prose,
+            };
         }
     }
 
     // No braces, or unmatched `{`: treat as pure prose with no structured type.
-    (Vec::new(), trimmed.to_string())
+    ParsedThrows {
+        types: Vec::new(),
+        nothrow: false,
+        prose: trimmed.to_string(),
+    }
 }
 
 /// Names of TypeScript primitive types that should not be promoted to a
@@ -511,6 +570,7 @@ mod tests {
         let raw = "\n * @throws {TypeError | string} bad input\n ";
         let (_doc, info) = parse(raw);
         assert_eq!(info.throws, vec!["TypeError"]);
+        assert!(!info.nothrow);
     }
 
     #[test]
@@ -519,6 +579,7 @@ mod tests {
         let raw = "\n * @throws {TypeError if oops\n ";
         let (_doc, info) = parse(raw);
         assert!(info.throws.is_empty());
+        assert!(!info.nothrow);
     }
 
     #[test]
@@ -526,5 +587,74 @@ mod tests {
         let raw = "\n * Just a description.\n ";
         let (_doc, info) = parse(raw);
         assert!(info.throws.is_empty());
+        assert!(!info.nothrow);
+    }
+
+    #[test]
+    fn test_throws_never_sets_nothrow() {
+        // `@throws {never}` is the explicit "this never throws" annotation —
+        // it sets `nothrow` and contributes no named type.
+        let raw = "\n * Always succeeds.\n * @throws {never}\n ";
+        let (_doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
+        assert!(info.nothrow);
+        assert_eq!(info.throws(), crate::ir::Throws::Never);
+    }
+
+    #[test]
+    fn test_throws_never_omits_errors_section() {
+        // `@throws {never}` is a "negative" annotation — it documents the
+        // absence of failure modes. Surfacing it under an `## Errors`
+        // heading would read backwards, so the rendered doc has no
+        // Errors section at all.
+        let raw = "\n * Always succeeds.\n * @throws {never} guaranteed by construction\n ";
+        let (doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
+        assert!(info.nothrow);
+        assert!(!doc.contains("## Errors"));
+        assert!(!doc.contains("never"));
+    }
+
+    #[test]
+    fn test_throws_never_alongside_typed_throws_keeps_errors_section() {
+        // If a callable has *both* `@throws {never}` and `@throws {T}`
+        // lines (a degenerate but possible JSDoc), the typed one still
+        // surfaces in the Errors section. The `never` line is dropped
+        // from the prose, but only the never line — typed throws win.
+        let raw = "
+            * @throws {never} this branch never fires
+            * @throws {TypeError} when foo is bad
+            ";
+        let (doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["TypeError"]);
+        assert!(info.nothrow); // we still saw the never marker
+        assert!(doc.contains("## Errors"));
+        assert!(doc.contains("`TypeError`"));
+        assert!(!doc.contains("this branch never fires"));
+    }
+
+    #[test]
+    fn test_throws_never_in_union_is_absorbed() {
+        // `T | never` is just `T` in the TS type system — we mirror that
+        // here. The `never` arm is silently dropped and the residual type
+        // wins, with `nothrow` staying false.
+        let raw = "\n * @throws {never | TypeError} sometimes\n ";
+        let (_doc, info) = parse(raw);
+        assert_eq!(info.throws, vec!["TypeError"]);
+        assert!(!info.nothrow);
+        assert_eq!(
+            info.throws(),
+            crate::ir::Throws::Type(crate::ir::TypeRef::Named("TypeError".into()))
+        );
+    }
+
+    #[test]
+    fn test_throws_never_only_after_primitives_filtered() {
+        // `{never | string}` filters `string` and leaves `never` alone —
+        // since no real types remain, this is treated as nothrow.
+        let raw = "\n * @throws {never | string} dead code\n ";
+        let (_doc, info) = parse(raw);
+        assert!(info.throws.is_empty());
+        assert!(info.nothrow);
     }
 }

--- a/src/parse/first_pass/converters.rs
+++ b/src/parse/first_pass/converters.rs
@@ -139,7 +139,7 @@ pub fn interface_from_signatures(
 
 pub fn convert_function_decl(
     func: &ast::Function<'_>,
-    throws: Option<ir::TypeRef>,
+    throws: ir::Throws,
     diag: &mut DiagnosticCollector,
 ) -> Option<ir::FunctionDecl> {
     let name = func.id.as_ref()?.name.to_string();

--- a/src/parse/first_pass/mod.rs
+++ b/src/parse/first_pass/mod.rs
@@ -114,7 +114,7 @@ fn register_type(
             params: vec![],
             return_type: ir::TypeRef::Any,
             overloads: vec![],
-            throws: None,
+            throws: ir::Throws::None,
         }),
         ir::RegisteredKind::Variable => ir::TypeKind::Variable(ir::VariableDecl {
             name: name_str.clone(),

--- a/src/parse/first_pass/populate.rs
+++ b/src/parse/first_pass/populate.rs
@@ -241,8 +241,8 @@ impl<'a> PopulateCtx<'a> {
                         .info_for_span(export.span.start)
                         .or_else(|| self.docs.info_for_span(func.span.start));
                     let (doc, throws) = match info {
-                        Some((d, i)) => (Some(d), i.throws_typeref()),
-                        None => (None, None),
+                        Some((d, i)) => (Some(d), i.throws()),
+                        None => (None, ir::Throws::None),
                     };
                     if let Some(decl) = convert_function_decl(func, throws, self.diag) {
                         declarations.push(ir::TypeDeclaration {
@@ -622,7 +622,7 @@ impl<'a> PopulateCtx<'a> {
                             overloads: vec![],
                             // Variable-as-function form (`var foo: () => T`) doesn't
                             // typically carry @throws JSDoc; leave empty.
-                            throws: None,
+                            throws: ir::Throws::None,
                         }),
                         doc.clone(),
                     ));
@@ -751,13 +751,13 @@ impl<'a> PopulateCtx<'a> {
         &self,
         export_span_start: Option<u32>,
         inner_span_start: u32,
-    ) -> (Option<String>, Option<ir::TypeRef>) {
+    ) -> (Option<String>, ir::Throws) {
         let info = export_span_start
             .and_then(|s| self.docs.info_for_span(s))
             .or_else(|| self.docs.info_for_span(inner_span_start));
         match info {
-            Some((doc, info)) => (Some(doc), info.throws_typeref()),
-            None => (None, None),
+            Some((doc, info)) => (Some(doc), info.throws()),
+            None => (None, ir::Throws::None),
         }
     }
 

--- a/src/parse/members.rs
+++ b/src/parse/members.rs
@@ -382,7 +382,7 @@ fn convert_method_signature(
             return_type,
             optional: method.optional,
             doc,
-            throws: info.throws_typeref(),
+            throws: info.throws(),
         })],
     }
 }
@@ -437,7 +437,7 @@ fn convert_construct_signature(
     Some(Member::Constructor(ConstructorMember {
         params,
         doc,
-        throws: info.throws_typeref(),
+        throws: info.throws(),
     }))
 }
 
@@ -502,7 +502,7 @@ fn convert_class_method(
             vec![Member::Constructor(ConstructorMember {
                 params,
                 doc,
-                throws: info.throws_typeref(),
+                throws: info.throws(),
             })]
         }
         MethodDefinitionKind::Get => {
@@ -550,7 +550,7 @@ fn convert_class_method(
                     params,
                     return_type,
                     doc,
-                    throws: info.throws_typeref(),
+                    throws: info.throws(),
                 })]
             } else {
                 vec![Member::Method(MethodMember {
@@ -561,7 +561,7 @@ fn convert_class_method(
                     return_type,
                     optional: method.optional,
                     doc,
-                    throws: info.throws_typeref(),
+                    throws: info.throws(),
                 })]
             }
         }

--- a/src/parse/merge.rs
+++ b/src/parse/merge.rs
@@ -63,7 +63,7 @@ pub fn extract_var_members(
                 constructor = Some(ConstructorMember {
                     params,
                     doc,
-                    throws: info.throws_typeref(),
+                    throws: info.throws(),
                 });
             }
             TSSignature::TSPropertySignature(prop) => {
@@ -117,7 +117,7 @@ pub fn extract_var_members(
                     params,
                     return_type,
                     doc,
-                    throws: info.throws_typeref(),
+                    throws: info.throws(),
                 }));
             }
             TSSignature::TSCallSignatureDeclaration(_) => {

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -686,7 +686,7 @@ mod tests {
             return_type: TypeRef::Void,
             optional: false,
             doc: None,
-            throws: None,
+            throws: crate::ir::Throws::None,
         })
     }
 

--- a/tests/fixtures/throws-never.d.ts
+++ b/tests/fixtures/throws-never.d.ts
@@ -1,0 +1,56 @@
+// Fixture: `@throws {never}` JSDoc → opt out of fallible variants.
+//
+// Sync callables annotated with `@throws {never}` get *no* `try_*`
+// companion. Async (Promise-returning) callables drop the `Result`
+// wrapper and `catch` attribute, becoming `async fn -> T`.
+// Constructors ignore the annotation — JS `new` always catches.
+
+declare class NeverThrows {
+  /**
+   * Always succeeds — no `try_safe_op` companion.
+   * @throws {never}
+   */
+  safeOp(x: number): string;
+
+  /**
+   * Async, declared infallible — emits `async fn -> Loaded` (no Result).
+   * @throws {never}
+   */
+  loaded(): Promise<Loaded>;
+
+  /**
+   * Sync method without `@throws {never}` — keeps the `try_normal_op`
+   * companion as usual.
+   */
+  normalOp(x: number): string;
+
+  /**
+   * Sync with a typed throws — keeps `try_typed_op` returning the
+   * typed error. `Throws::Type` is the existing behavior.
+   * @throws {RangeError}
+   */
+  typedOp(x: number): string;
+
+  /**
+   * Constructor with `@throws {never}` is a no-op — JS `new` can
+   * always throw, so the constructor still catches.
+   * @throws {never}
+   */
+  constructor(name: string);
+}
+
+interface Loaded {
+  readonly ready: boolean;
+}
+
+/**
+ * Free function with `@throws {never}` — no `try_pure_compute`.
+ * @throws {never}
+ */
+declare function pureCompute(x: number): number;
+
+/**
+ * Async free function with `@throws {never}` — no Result wrapper.
+ * @throws {never}
+ */
+declare function infallibleFetch(url: string): Promise<string>;

--- a/tests/snapshots/throws-never.rs
+++ b/tests/snapshots/throws-never.rs
@@ -1,0 +1,73 @@
+#[allow(unused_imports)]
+use js_sys::*;
+#[allow(unused_imports)]
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = Object)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type NeverThrows;
+    #[doc = " Always succeeds — no `try_safe_op` companion."]
+    #[wasm_bindgen(method, js_name = "safeOp")]
+    pub fn safe_op(this: &NeverThrows, x: f64) -> String;
+    #[doc = " Async, declared infallible — emits `async fn -> Loaded` (no Result)."]
+    #[wasm_bindgen(method)]
+    pub async fn loaded(this: &NeverThrows) -> Loaded;
+    #[doc = " Sync method without `@throws {never}` — keeps the `try_normal_op`"]
+    #[doc = " companion as usual."]
+    #[wasm_bindgen(method, js_name = "normalOp")]
+    pub fn normal_op(this: &NeverThrows, x: f64) -> String;
+    #[doc = " Sync method without `@throws {never}` — keeps the `try_normal_op`"]
+    #[doc = " companion as usual."]
+    #[wasm_bindgen(method, catch, js_name = "normalOp")]
+    pub fn try_normal_op(this: &NeverThrows, x: f64) -> Result<String, JsValue>;
+    #[doc = " Sync with a typed throws — keeps `try_typed_op` returning the"]
+    #[doc = " typed error. `Throws::Type` is the existing behavior."]
+    #[doc = ""]
+    #[doc = " ## Errors"]
+    #[doc = ""]
+    #[doc = " * `RangeError`"]
+    #[wasm_bindgen(method, js_name = "typedOp")]
+    pub fn typed_op(this: &NeverThrows, x: f64) -> String;
+    #[doc = " Sync with a typed throws — keeps `try_typed_op` returning the"]
+    #[doc = " typed error. `Throws::Type` is the existing behavior."]
+    #[doc = ""]
+    #[doc = " ## Errors"]
+    #[doc = ""]
+    #[doc = " * `RangeError`"]
+    #[wasm_bindgen(method, catch, js_name = "typedOp")]
+    pub fn try_typed_op(this: &NeverThrows, x: f64) -> Result<String, RangeError>;
+    #[doc = " Constructor with `@throws {never}` is a no-op — JS `new` can"]
+    #[doc = " always throw, so the constructor still catches."]
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new(name: &str) -> Result<NeverThrows, JsValue>;
+}
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = Object)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type Loaded;
+    #[wasm_bindgen(method, getter)]
+    pub fn ready(this: &Loaded) -> bool;
+}
+impl Loaded {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        #[allow(unused_unsafe)]
+        unsafe {
+            JsValue::from(js_sys::Object::new()).unchecked_into()
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[doc = " Free function with `@throws {never}` — no `try_pure_compute`."]
+    #[wasm_bindgen(js_name = "pureCompute")]
+    pub fn pure_compute(x: f64) -> f64;
+}
+#[wasm_bindgen]
+extern "C" {
+    #[doc = " Async free function with `@throws {never}` — no Result wrapper."]
+    #[wasm_bindgen(js_name = "infallibleFetch")]
+    pub async fn infallible_fetch(url: &str) -> JsString;
+}


### PR DESCRIPTION
This adds support for combining TypeScript's bottom type with JSDoc to declare that a callable never throws. The annotation tells ts-gen to skip the fallible Rust variants entirely:

* Sync methods/functions get *no* `try_<name>` companion.
* Async methods/functions drop the `Result` wrapper and `catch` attribute, becoming `async fn foo() -> T` directly.
* Constructors ignore the annotation — JS `new` always catches per spec.

```ts
class NeverThrows {
  /** @throws {never} */
  safeOp(x: number): string;

  /** @throws {never} */
  loaded(): Promise<Loaded>;
}
```

Before this change, every sync method emitted both a panicking primary and a `try_*` companion, and every async method wrapped its return in `Result<T, _>`. Now:

```rs
#[wasm_bindgen(method, js_name = "safeOp")]
pub fn safe_op(this: &NeverThrows, x: f64) -> String;

#[wasm_bindgen(method)]
pub async fn loaded(this: &NeverThrows) -> Loaded;
```

Implementation:

* New `ir::Throws` enum (`None | Type(TypeRef) | Never`) replaces the old `Option<TypeRef>` throws field on `FunctionDecl`, `MethodMember`, `ConstructorMember`, and `StaticMethodMember`. `CallableSpec` carries a single `throws: &Throws` field so the IR-to-codegen mapping stays 1:1.
* Parser recognises `@throws {never}` as the explicit "never throws" annotation. Mixed forms like `@throws {never | TypeError}` collapse to `Throws::Type(TypeError)` since `T | never` is just `T` in TypeScript.
* `@throws {never}` lines do not contribute to the rendered `## Errors` doc section — by definition there are no errors to document.
* `CONVENTIONS.md` gets a new sub-section under `@throws` documenting all the rules.

Tests:

* New fixture + snapshot at `tests/fixtures/throws-never.d.ts` and `tests/snapshots/throws-never.rs` covering sync method, async method, typed-throws (still gets `try_*`), constructor (still catches), free function, and async free function.
* 7 new unit tests in `parse::docs::tests` and 7 in `codegen::signatures::tests` covering: never sets `nothrow`, never absorbed in unions, primitives-only collapsing to never, sync nothrow → no try, async nothrow → no Result, optional-param expansion still emits each variant without try siblings, constructor ignores nothrow, typed throws unaffected.
* Full suite: 141 unit tests + 1 snapshot test pass. Clippy + fmt-check clean.

No existing snapshots changed — the new behavior is purely opt-in via JSDoc.