### PR TITLE
Collapse builtin TypeRef variants into Reference; add Returns: doc augmentation

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -842,6 +842,46 @@ is still a single `Array<Error>` type, and `Record<string, string |
 number | boolean>` lowers as one `Object` binding rather than separate
 record overloads for each value type.
 
+### `Returns:` doc augmentation for erased return types
+
+When a return-position type contains a union that erases to `JsValue`
+(no useful LUB), the static Rust type loses information about what
+runtime values the caller actually receives. ts-gen surfaces the
+original TypeScript shape in a `Returns: <ts-shape>` doc line so that
+information isn't lost:
+
+```ts
+interface EmailAttachment {
+  readonly content: string | ArrayBuffer | ArrayBufferView;
+  readonly tags: Array<32 | "foo">;
+}
+
+declare function fetchValue(): Promise<32 | "foo">;
+```
+
+emits:
+
+```rust
+#[doc = " Returns: string | ArrayBuffer | ArrayBufferView"]
+pub fn content(this: &EmailAttachment) -> JsValue;
+
+#[doc = " Returns: Array<32 | \"foo\">"]
+pub fn tags(this: &EmailAttachment) -> Array;
+
+#[doc = " Returns: 32 | \"foo\""]
+pub async fn fetch_value() -> Result<JsValue, JsValue>;
+```
+
+The detector walks the whole return type and fires when *any* nested
+union erases — `Array<32 | "foo">` flags even though the outer
+`Array` is fine. Async return types use the post-Promise-unwrap inner
+(so `Promise<32 | "foo">` documents `32 | "foo"`, since that's what
+the awaiter sees). LUB-narrowed unions (e.g. `TypeError | RangeError`
+→ `Error`) and literal-widened unions (`"a" | "b"` → `string`) don't
+fire — the narrower static type already conveys the necessary info.
+
+If the JSDoc already has a `Returns:` line, it's preserved verbatim.
+
 ## Module declarations and namespace nesting
 
 ```ts

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -1189,9 +1189,15 @@ fn generate_getter(
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
     let this_type = super::typemap::make_ident(&config.effective_rust_name());
+    // The `?:` marker on the original property widens the rendered
+    // TS shape with `| undefined`; threaded through the augmenter
+    // so the `Returns:` doc matches the static type users see in
+    // their `.d.ts`. Erasure detection runs on the inner type
+    // unchanged.
     let augmented = super::augment_return_doc(
         getter.doc.clone(),
         &getter.type_ref,
+        getter.optional,
         config.cgctx,
         config.scope,
     );
@@ -1201,30 +1207,30 @@ fn generate_getter(
     let rust_name = dedupe_name(&candidate, used_names);
     let rust_ident = super::typemap::make_ident(&rust_name);
 
-    let getter_type = if getter.optional {
-        // Unwrap Nullable to avoid Option<Option<T>> — the optionality from `?`
-        // already provides the outer Option.
-        let unwrapped = match &getter.type_ref {
-            TypeRef::Nullable(inner) => inner.as_ref(),
-            other => other,
-        };
-        let inner = to_syn_type(
-            unwrapped,
-            TypePosition::RETURN,
-            config.cgctx,
-            config.scope,
-            &config.from_module(),
-        );
-        quote! { Option<#inner> }
+    // Optional `?:` properties widen to `T | undefined` at the IR
+    // level. Modeling that as `Nullable<T>` lets the regular
+    // `to_syn_type` lowering handle every collapse rule uniformly —
+    // notably the `Option<JsValue>` → `JsValue` shortcut and the
+    // inner-position `JsOption` switch — without the getter site
+    // open-coding its own `Option<#inner>` wrap.
+    let lowered_ty = if getter.optional {
+        // Avoid `Option<Option<T>>` if the source already had a
+        // Nullable: a `T?` property whose type is `T | null` is just
+        // a single layer of optionality.
+        match &getter.type_ref {
+            TypeRef::Nullable(_) => getter.type_ref.clone(),
+            other => TypeRef::Nullable(Box::new(other.clone())),
+        }
     } else {
-        to_syn_type(
-            &getter.type_ref,
-            TypePosition::RETURN,
-            config.cgctx,
-            config.scope,
-            &config.from_module(),
-        )
+        getter.type_ref.clone()
     };
+    let getter_type = to_syn_type(
+        &lowered_ty,
+        TypePosition::RETURN,
+        config.cgctx,
+        config.scope,
+        &config.from_module(),
+    );
 
     let mut wb_parts: Vec<TokenStream> = vec![quote! { method }, quote! { getter }];
     if rust_name != getter.js_name {
@@ -1305,9 +1311,11 @@ fn generate_static_getter(
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
     let class_ident = super::typemap::make_ident(&config.effective_rust_name());
+    // Static getters don't carry an `optional` marker today.
     let augmented = super::augment_return_doc(
         getter.doc.clone(),
         &getter.type_ref,
+        false,
         config.cgctx,
         config.scope,
     );

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -841,7 +841,7 @@ fn generate_extern_block(config: &ClassConfig) -> TokenStream {
                     .first()
                     .map(|c| &c.throws)
                     .unwrap_or(&empty_throws);
-                let return_type = TypeRef::Named(config.rust_name.clone());
+                let return_type = TypeRef::ident(config.rust_name.clone());
                 let sigs = build_signatures(
                     &CallableSpec {
                         js_name: &config.js_name,
@@ -1189,7 +1189,13 @@ fn generate_getter(
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
     let this_type = super::typemap::make_ident(&config.effective_rust_name());
-    let doc = super::doc_tokens(&getter.doc);
+    let augmented = super::augment_return_doc(
+        getter.doc.clone(),
+        &getter.type_ref,
+        config.cgctx,
+        config.scope,
+    );
+    let doc = super::doc_tokens(&augmented);
 
     let candidate = public_rust_name(&to_snake_case(&getter.js_name));
     let rust_name = dedupe_name(&candidate, used_names);
@@ -1299,7 +1305,13 @@ fn generate_static_getter(
     used_names: &mut HashSet<String>,
 ) -> TokenStream {
     let class_ident = super::typemap::make_ident(&config.effective_rust_name());
-    let doc = super::doc_tokens(&getter.doc);
+    let augmented = super::augment_return_doc(
+        getter.doc.clone(),
+        &getter.type_ref,
+        config.cgctx,
+        config.scope,
+    );
+    let doc = super::doc_tokens(&augmented);
 
     let candidate = public_rust_name(&to_snake_case(&getter.js_name));
     let rust_name = dedupe_name(&candidate, used_names);
@@ -1404,8 +1416,11 @@ fn extends_tokens(
     scope: ScopeId,
     from_module: &ModuleContext,
 ) -> TokenStream {
+    // Only named references (bare or generic) are valid `extends`
+    // targets; structural types and primitives don't have a single
+    // supertype identity at the wasm-bindgen level.
     let tokens = match ty {
-        TypeRef::Named(_) | TypeRef::GenericInstantiation(_, _) => super::typemap::to_syn_type(
+        TypeRef::Reference { .. } => super::typemap::to_syn_type(
             ty,
             TypePosition::ARGUMENT.to_inner(),
             cgctx,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -13,10 +13,51 @@ pub mod typemap;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::ir::{InterfaceClassification, Module, TypeDeclaration, TypeKind};
+use crate::ir::{InterfaceClassification, Module, TypeDeclaration, TypeKind, TypeRef};
 use crate::parse::scope::ScopeId;
 
 use typemap::CodegenContext;
+
+/// Augment a doc with a `Returns: <ts-shape>` line when the return
+/// type loses information against its original TypeScript shape.
+///
+/// Fires whenever the return type contains an erasing union — see
+/// [`subtyping::return_type_has_erased_union`]. The static Rust type
+/// can't convey what the runtime values look like in those cases;
+/// surfacing the raw TS shape gives callers somewhere to look.
+///
+/// Idempotent: if the JSDoc already contains a line starting with
+/// `Returns:` we leave the doc untouched, on the assumption that the
+/// human-authored version is already correct.
+pub(crate) fn augment_return_doc(
+    doc: Option<String>,
+    return_type: &TypeRef,
+    ctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> Option<String> {
+    if !subtyping::return_type_has_erased_union(return_type, ctx, scope) {
+        return doc;
+    }
+    let line = format!("Returns: {}", return_type.format_ts());
+    match doc {
+        None => Some(line),
+        Some(existing) => {
+            if existing
+                .lines()
+                .any(|l| l.trim_start().starts_with("Returns:"))
+            {
+                return Some(existing);
+            }
+            let mut out = existing;
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push('\n');
+            out.push_str(&line);
+            Some(out)
+        }
+    }
+}
 
 /// Convert an optional doc string into `/// ...` doc-comment attributes.
 ///
@@ -246,11 +287,10 @@ fn generate_type_alias(
     from_module: &crate::ir::ModuleContext,
 ) -> TokenStream {
     if let Some(ref module) = alias.from_module {
-        // External re-export: resolve through external map.
-        let type_name = match &alias.target {
-            crate::ir::TypeRef::Named(n) => n.as_str(),
-            _ => &alias.name,
-        };
+        // External re-export: resolve through external map. The
+        // target name is the bare ident from the alias target if
+        // available, otherwise the alias name itself.
+        let type_name = alias.target.as_ident().unwrap_or(alias.name.as_str());
         if let Some(rust_path) = cgctx.resolve_external(type_name, module) {
             let path: syn::Path = syn::parse_str(&rust_path.path).unwrap_or_else(|_| {
                 syn::Path::from(syn::Ident::new("JsValue", proc_macro2::Span::call_site()))
@@ -274,9 +314,11 @@ fn generate_type_alias(
     }
 
     // Local alias — only emit if the target resolves to a known type.
-    if let crate::ir::TypeRef::Named(ref target_name) = alias.target {
+    // We only inspect bare references here; generic instantiations
+    // and qualified paths flow through to `to_syn_type` unchanged.
+    if let Some(target_name) = alias.target.as_ident() {
         if !cgctx.local_types.contains_key(target_name)
-            && !crate::codegen::typemap::JS_SYS_RESERVED.contains(&target_name.as_str())
+            && !crate::codegen::typemap::JS_SYS_RESERVED.contains(&target_name)
         {
             cgctx.warn(format!(
                 "Type alias `{}` targets unknown type `{target_name}`, skipping",

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -26,19 +26,39 @@ use typemap::CodegenContext;
 /// can't convey what the runtime values look like in those cases;
 /// surfacing the raw TS shape gives callers somewhere to look.
 ///
+/// `optional` is for sites where the return type has an outer `?:`
+/// marker that widens it with `| undefined` (e.g. dictionary
+/// property getters declared `replyTo?: string | EmailAddress`).
+/// When set, the rendered shape gets `| undefined` appended. This
+/// only affects the rendered text — erasure detection runs on the
+/// inner type as-written.
+///
 /// Idempotent: if the JSDoc already contains a line starting with
 /// `Returns:` we leave the doc untouched, on the assumption that the
 /// human-authored version is already correct.
 pub(crate) fn augment_return_doc(
     doc: Option<String>,
     return_type: &TypeRef,
+    optional: bool,
     ctx: Option<&CodegenContext<'_>>,
     scope: ScopeId,
 ) -> Option<String> {
     if !subtyping::return_type_has_erased_union(return_type, ctx, scope) {
         return doc;
     }
-    let line = format!("Returns: {}", return_type.format_ts());
+    let rendered = if optional {
+        // `T | undefined` — but if `T` is already `Nullable(...)` we
+        // don't want to render `T | null | undefined`. The IR's
+        // `Nullable` covers both null and undefined optionality, so
+        // skip the suffix when one's already present.
+        match return_type {
+            TypeRef::Nullable(_) => return_type.format_ts(),
+            other => format!("{} | undefined", other.format_ts()),
+        }
+    } else {
+        return_type.format_ts()
+    };
+    let line = format!("Returns: {rendered}");
     match doc {
         None => Some(line),
         Some(existing) => {

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -375,15 +375,25 @@ pub fn build_signatures(
 
     // Promise unwrap is per-callable, not per-overload — every expansion of a
     // given JS callable shares the same return type.
-    let (is_async, return_type) = match (spec.return_type, spec.kind.allows_async()) {
-        (TypeRef::Promise(inner), true) => (true, inner.as_ref().clone()),
-        (other, _) => (false, other.clone()),
+    let (is_async, return_type) = match (
+        spec.return_type.as_promise_inner(),
+        spec.kind.allows_async(),
+    ) {
+        (Some(inner), true) => (true, inner.clone()),
+        _ => (false, spec.return_type.clone()),
     };
 
     // `Throws::Never` suppresses every fallible form — except for
     // constructors, which always catch (`new` can always throw in JS).
     let nothrow = spec.throws.is_never() && !spec.kind.always_catches();
     let error_type = spec.throws.as_type();
+
+    // If any nested union in the return type erases to `JsValue`,
+    // append a `Returns: <ts-shape>` line to the doc so callers can
+    // still see the original TS shape. Operates on the post-Promise
+    // `return_type` since that's what shows up at the call site.
+    let augmented_doc =
+        crate::codegen::augment_return_doc(spec.doc.clone(), &return_type, cgctx, scope);
 
     let allow_try = !is_async && !nothrow && spec.kind.allows_try_variant();
     let mut out = Vec::with_capacity(expansions.len() * if allow_try { 2 } else { 1 });
@@ -408,7 +418,7 @@ pub fn build_signatures(
             } else {
                 None
             },
-            doc: spec.doc.clone(),
+            doc: augmented_doc.clone(),
         });
 
         if allow_try {
@@ -421,7 +431,7 @@ pub fn build_signatures(
                 is_async: false,
                 return_type: return_type.clone(),
                 error_type: error_type.cloned(),
-                doc: spec.doc.clone(),
+                doc: augmented_doc.clone(),
             });
         }
     }
@@ -576,10 +586,16 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
             .flat_map(|m| flatten_type(m, cgctx, scope))
             .collect(),
 
-        // Named types: resolve through aliases, then re-flatten
-        TypeRef::Named(name) => {
+        // Bare references: resolve through aliases, then re-flatten.
+        // Generic instantiations and qualified paths don't follow
+        // aliases (they're already concrete enough at this level).
+        TypeRef::Reference {
+            head,
+            segments,
+            type_args,
+        } if segments.is_empty() && type_args.is_empty() => {
             if let Some(c) = cgctx {
-                if let Some(target) = c.resolve_alias(name, scope) {
+                if let Some(target) = c.resolve_alias(head, scope) {
                     let target = target.clone();
                     return flatten_type(&target, cgctx, scope);
                 }
@@ -752,6 +768,11 @@ fn compute_trim(signatures: &[Vec<ConcreteParam>]) -> (usize, usize) {
 }
 
 /// Get a short snake_case name for a TypeRef, used in `_with_` suffixes.
+///
+/// Named references (built-ins and user types) snake-case the head:
+/// `Uint8Array` → `uint8_array`, `MyType` → `my_type`. Generic
+/// instantiations and qualified paths use just the head segment;
+/// type args don't participate in the suffix.
 fn type_snake_name(ty: &TypeRef) -> String {
     match ty {
         TypeRef::String => "str".to_string(),
@@ -762,24 +783,11 @@ fn type_snake_name(ty: &TypeRef) -> String {
         TypeRef::Null => "null".to_string(),
         TypeRef::Any | TypeRef::Unknown => "js_value".to_string(),
         TypeRef::Object => "object".to_string(),
-        TypeRef::Named(n) => to_snake_case(n),
-        TypeRef::ArrayBuffer => "array_buffer".to_string(),
         TypeRef::ArrayBufferView => "typed_array".to_string(),
-        TypeRef::Uint8Array => "uint8_array".to_string(),
-        TypeRef::Int8Array => "int8_array".to_string(),
-        TypeRef::Float32Array => "float32_array".to_string(),
-        TypeRef::Float64Array => "float64_array".to_string(),
+        TypeRef::Reference { head, .. } => to_snake_case(head),
         TypeRef::Array(_) => "array".to_string(),
-        TypeRef::Promise(_) => "promise".to_string(),
         TypeRef::Nullable(inner) => type_snake_name(inner),
-
         TypeRef::Function(_) => "function".to_string(),
-        TypeRef::Date => "date".to_string(),
-        TypeRef::RegExp => "reg_exp".to_string(),
-        TypeRef::Error => "error".to_string(),
-        TypeRef::Map(_, _) => "map".to_string(),
-        TypeRef::Set(_) => "set".to_string(),
-        TypeRef::Record(_, _) => "record".to_string(),
         _ => "js_value".to_string(),
     }
 }
@@ -1063,7 +1071,7 @@ mod tests {
         let sigs = expand(
             "Console",
             &[param("stdout")],
-            &TypeRef::Named("Console".into()),
+            &TypeRef::ident("Console"),
             SignatureKind::Constructor,
             &None,
             &mut used,
@@ -1084,7 +1092,7 @@ mod tests {
         let sigs = expand(
             "foo",
             &[],
-            &TypeRef::Promise(Box::new(TypeRef::String)),
+            &TypeRef::generic("Promise", vec![TypeRef::String]),
             SignatureKind::Method,
             &None,
             &mut used,
@@ -1104,7 +1112,7 @@ mod tests {
         let sigs = expand(
             "fetch",
             &[param("url")],
-            &TypeRef::Promise(Box::new(TypeRef::Named("Response".into()))),
+            &TypeRef::generic("Promise", vec![TypeRef::ident("Response")]),
             SignatureKind::Function,
             &None,
             &mut used,
@@ -1113,7 +1121,7 @@ mod tests {
         assert_eq!(sigs[0].rust_name, "fetch");
         assert!(sigs[0].is_async);
         assert!(sigs[0].catch);
-        assert_eq!(sigs[0].return_type, TypeRef::Named("Response".into()));
+        assert_eq!(sigs[0].return_type, TypeRef::ident("Response"));
     }
 
     #[test]
@@ -1122,7 +1130,7 @@ mod tests {
         let sigs = expand(
             "all",
             &[param("promises")],
-            &TypeRef::Promise(Box::new(TypeRef::Any)),
+            &TypeRef::generic("Promise", vec![TypeRef::Any]),
             SignatureKind::StaticMethod,
             &None,
             &mut used,
@@ -1164,13 +1172,10 @@ mod tests {
         let sigs = expand_overloads(
             "send",
             &[
-                &[typed_param(
-                    "message",
-                    TypeRef::Named("EmailMessage".into()),
-                )],
+                &[typed_param("message", TypeRef::ident("EmailMessage"))],
                 &[typed_param("builder", TypeRef::Object)],
             ],
-            &TypeRef::Promise(Box::new(TypeRef::Named("EmailSendResult".into()))),
+            &TypeRef::generic("Promise", vec![TypeRef::ident("EmailSendResult")]),
             SignatureKind::Method,
             &None,
             &mut used,
@@ -1199,7 +1204,7 @@ mod tests {
             "value",
             &[typed_param(
                 "val",
-                TypeRef::Promise(Box::new(TypeRef::String)),
+                TypeRef::generic("Promise", vec![TypeRef::String]),
             )],
             &TypeRef::Void,
             SignatureKind::Setter,
@@ -1222,7 +1227,7 @@ mod tests {
                 opt_param("stderr"),
                 opt_param("ignoreErrors"),
             ],
-            &TypeRef::Named("Console".into()),
+            &TypeRef::ident("Console"),
             SignatureKind::Constructor,
             &None,
             &mut used,
@@ -1369,7 +1374,7 @@ mod tests {
         let sigs = expand_throws(
             "loaded",
             &[],
-            &TypeRef::Promise(Box::new(TypeRef::String)),
+            &TypeRef::generic("Promise", vec![TypeRef::String]),
             SignatureKind::Method,
             &Throws::Never,
             &None,
@@ -1417,7 +1422,7 @@ mod tests {
         let sigs = expand_throws(
             "Foo",
             &[param("x")],
-            &TypeRef::Named("Foo".into()),
+            &TypeRef::ident("Foo"),
             SignatureKind::Constructor,
             &Throws::Never,
             &None,
@@ -1433,7 +1438,7 @@ mod tests {
     fn test_throws_typed_keeps_try_pair() {
         // Typed `Throws::Type(...)` behaves like the existing `@throws {T}`
         // — sync still gets the `try_` companion, with the typed error.
-        let err = TypeRef::Named("ImagesError".into());
+        let err = TypeRef::ident("ImagesError");
         let mut used = no_used();
         let sigs = expand_throws(
             "upload",
@@ -1454,12 +1459,12 @@ mod tests {
 
     #[test]
     fn test_throws_typed_async_carries_error_type() {
-        let err = TypeRef::Named("ImagesError".into());
+        let err = TypeRef::ident("ImagesError");
         let mut used = no_used();
         let sigs = expand_throws(
             "upload",
             &[],
-            &TypeRef::Promise(Box::new(TypeRef::String)),
+            &TypeRef::generic("Promise", vec![TypeRef::String]),
             SignatureKind::Method,
             &Throws::Type(err.clone()),
             &None,
@@ -1566,7 +1571,7 @@ mod tests {
         let overload1 = [typed_param("x", TypeRef::String)];
         let overload2 = [typed_param(
             "x",
-            TypeRef::Promise(Box::new(TypeRef::String)),
+            TypeRef::generic("Promise", vec![TypeRef::String]),
         )];
         let sigs = expand_overloads(
             "foo",
@@ -1624,11 +1629,11 @@ mod tests {
     #[test]
     fn record_with_mixed_primitive_union_does_not_distribute() {
         let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number, TypeRef::Boolean]);
-        let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(union_v.clone()));
+        let ty = TypeRef::generic("Record", vec![TypeRef::String, union_v.clone()]);
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
-        match &alts[0] {
-            TypeRef::Record(_, v) => assert_eq!(**v, union_v),
+        match alts[0].as_generic_head("Record") {
+            Some([_, v]) => assert_eq!(*v, union_v),
             other => panic!("expected Record, got {other:?}"),
         }
     }
@@ -1636,22 +1641,22 @@ mod tests {
     #[test]
     fn record_with_union_key_does_not_distribute() {
         let union_k = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
-        let ty = TypeRef::Record(Box::new(union_k.clone()), Box::new(TypeRef::String));
+        let ty = TypeRef::generic("Record", vec![union_k.clone(), TypeRef::String]);
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
-        match &alts[0] {
-            TypeRef::Record(k, _) => assert_eq!(**k, union_k),
+        match alts[0].as_generic_head("Record") {
+            Some([k, _]) => assert_eq!(*k, union_k),
             other => panic!("expected Record, got {other:?}"),
         }
     }
 
     #[test]
     fn record_with_single_typed_value_keeps_typed_phantom() {
-        let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(TypeRef::String));
+        let ty = TypeRef::generic("Record", vec![TypeRef::String, TypeRef::String]);
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
-        match &alts[0] {
-            TypeRef::Record(_, v) => assert_eq!(**v, TypeRef::String),
+        match alts[0].as_generic_head("Record") {
+            Some([_, v]) => assert_eq!(*v, TypeRef::String),
             other => panic!("expected Record, got {other:?}"),
         }
     }
@@ -1672,13 +1677,13 @@ mod tests {
     fn map_with_union_type_args_does_not_distribute() {
         let k = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
         let v = TypeRef::Union(vec![TypeRef::String, TypeRef::Boolean]);
-        let ty = TypeRef::Map(Box::new(k.clone()), Box::new(v.clone()));
+        let ty = TypeRef::generic("Map", vec![k.clone(), v.clone()]);
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
-        match &alts[0] {
-            TypeRef::Map(map_k, map_v) => {
-                assert_eq!(**map_k, k);
-                assert_eq!(**map_v, v);
+        match alts[0].as_generic_head("Map") {
+            Some([map_k, map_v]) => {
+                assert_eq!(*map_k, k);
+                assert_eq!(*map_v, v);
             }
             other => panic!("expected Map, got {other:?}"),
         }
@@ -1687,12 +1692,12 @@ mod tests {
     #[test]
     fn promise_with_union_does_not_distribute() {
         let union_v = TypeRef::Union(vec![TypeRef::String, TypeRef::Number]);
-        let ty = TypeRef::Promise(Box::new(union_v.clone()));
+        let ty = TypeRef::generic("Promise", vec![union_v.clone()]);
         let alts = flatten_no_ctx(&ty);
         assert_eq!(alts.len(), 1);
-        match &alts[0] {
-            TypeRef::Promise(inner) => assert_eq!(**inner, union_v),
-            other => panic!("expected Promise, got {other:?}"),
+        match alts[0].as_promise_inner() {
+            Some(inner) => assert_eq!(*inner, union_v),
+            None => panic!("expected Promise, got {:?}", alts[0]),
         }
     }
 }

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -393,7 +393,7 @@ pub fn build_signatures(
     // still see the original TS shape. Operates on the post-Promise
     // `return_type` since that's what shows up at the call site.
     let augmented_doc =
-        crate::codegen::augment_return_doc(spec.doc.clone(), &return_type, cgctx, scope);
+        crate::codegen::augment_return_doc(spec.doc.clone(), &return_type, false, cgctx, scope);
 
     let allow_try = !is_async && !nothrow && spec.kind.allows_try_variant();
     let mut out = Vec::with_capacity(expansions.len() * if allow_try { 2 } else { 1 });

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -589,11 +589,8 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
         // Bare references: resolve through aliases, then re-flatten.
         // Generic instantiations and qualified paths don't follow
         // aliases (they're already concrete enough at this level).
-        TypeRef::Reference {
-            head,
-            segments,
-            type_args,
-        } if segments.is_empty() && type_args.is_empty() => {
+        TypeRef::Reference { .. } if ty.as_ident().is_some() => {
+            let head = ty.as_ident().unwrap();
             if let Some(c) = cgctx {
                 if let Some(target) = c.resolve_alias(head, scope) {
                     let target = target.clone();
@@ -784,7 +781,11 @@ fn type_snake_name(ty: &TypeRef) -> String {
         TypeRef::Any | TypeRef::Unknown => "js_value".to_string(),
         TypeRef::Object => "object".to_string(),
         TypeRef::ArrayBufferView => "typed_array".to_string(),
-        TypeRef::Reference { head, .. } => to_snake_case(head),
+        // Snake-case the leftmost (head) segment of any named
+        // reference. Type args don't participate in `_with_` suffixes.
+        TypeRef::Reference { segments, .. } => {
+            to_snake_case(segments.first().map_or("", |s| s.as_str()))
+        }
         TypeRef::Array(_) => "array".to_string(),
         TypeRef::Nullable(inner) => type_snake_name(inner),
         TypeRef::Function(_) => "function".to_string(),

--- a/src/codegen/subtyping.rs
+++ b/src/codegen/subtyping.rs
@@ -102,11 +102,15 @@ fn user_parents(name: &str, ctx: &CodegenContext<'_>, scope: ScopeId) -> Vec<Str
 }
 
 /// Pull a name out of an `extends` `TypeRef`, ignoring complex shapes
-/// (generic instantiations, unions, etc.) that don't have a single
-/// representative supertype name.
+/// (generic instantiations, unions, qualified paths, etc.) that don't
+/// have a single representative supertype name.
 fn parent_typeref_to_names(ty: &TypeRef) -> Vec<String> {
     match ty {
-        TypeRef::Named(n) => vec![n.clone()],
+        TypeRef::Reference {
+            head,
+            segments,
+            type_args,
+        } if segments.is_empty() && type_args.is_empty() => vec![head.clone()],
         _ => Vec::new(),
     }
 }
@@ -194,7 +198,7 @@ pub fn lub_types(names: &[&str], ctx: &CodegenContext<'_>, scope: ScopeId) -> Op
 ///    `String` rather than erasing to `JsValue`.
 /// 2. **Named-type LUB**: every member is `TypeRef::Named` and they share
 ///    a common ancestor more specific than `Object` (per [`lub_types`])
-///    → returns `TypeRef::Named(ancestor)`.
+///    → returns `TypeRef::ident(ancestor)`.
 /// 3. **No useful upper bound**: returns `None`. The caller substitutes
 ///    `JsValue`.
 ///
@@ -212,10 +216,17 @@ pub fn lub_union(
         return Some(widened);
     }
     let cgctx = ctx?;
+    // Collect names: only bare references (no generics, no path)
+    // participate in the named-LUB lattice. Generic instantiations
+    // and qualified paths are too coarse to compare structurally.
     let names: Vec<&str> = members
         .iter()
         .map(|m| match m {
-            TypeRef::Named(n) => Some(n.as_str()),
+            TypeRef::Reference {
+                head,
+                segments,
+                type_args,
+            } if segments.is_empty() && type_args.is_empty() => Some(head.as_str()),
             _ => None,
         })
         .collect::<Option<Vec<_>>>()?;
@@ -223,7 +234,58 @@ pub fn lub_union(
     if lub == "Object" {
         return None;
     }
-    Some(TypeRef::Named(lub))
+    Some(TypeRef::Reference {
+        head: lub,
+        segments: Vec::new(),
+        type_args: Vec::new(),
+    })
+}
+
+/// Recursively walk a return-position `TypeRef` and report whether
+/// any nested `Union` erases to `JsValue` (i.e. has no useful LUB).
+///
+/// Used by codegen to decide whether to inject a synthetic
+/// `Returns: <ts-shape>` doc line — when the static Rust return type
+/// loses information against the original TS shape, surfacing the
+/// raw shape lets callers see what runtime values they're actually
+/// dealing with.
+///
+/// Walks into all syntactic containers (`Array<T>`, `Nullable<T>`,
+/// `Tuple`, `Intersection`) so e.g. `Array<32 | "foo">` (the wrapper
+/// is fine, the inner mixed-literal union erases) is correctly
+/// flagged. Generic instantiations also recurse into their type
+/// arguments — `Promise<32 | "foo">` flags too.
+pub fn return_type_has_erased_union(
+    ty: &TypeRef,
+    ctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> bool {
+    match ty {
+        TypeRef::Union(members) => {
+            if lub_union(members, ctx, scope).is_none() {
+                return true;
+            }
+            members
+                .iter()
+                .any(|m| return_type_has_erased_union(m, ctx, scope))
+        }
+        TypeRef::Array(inner) | TypeRef::Nullable(inner) => {
+            return_type_has_erased_union(inner, ctx, scope)
+        }
+        TypeRef::Tuple(elems) => elems
+            .iter()
+            .any(|e| return_type_has_erased_union(e, ctx, scope)),
+        TypeRef::Intersection(parts) => parts
+            .iter()
+            .any(|p| return_type_has_erased_union(p, ctx, scope)),
+        TypeRef::Reference { type_args, .. } => type_args
+            .iter()
+            .any(|a| return_type_has_erased_union(a, ctx, scope)),
+        // Function types in return position bind at the FFI as
+        // `Function<...>`; their argument-position erasure is a
+        // separate axis we don't follow into here.
+        _ => false,
+    }
 }
 
 /// If every member of `types` belongs to the same primitive family —
@@ -418,14 +480,11 @@ mod tests {
         let (gctx, scope) = ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
         let lub = lub_union(
-            &[
-                TypeRef::Named("TypeError".into()),
-                TypeRef::Named("RangeError".into()),
-            ],
+            &[TypeRef::ident("TypeError"), TypeRef::ident("RangeError")],
             Some(&cgctx),
             scope,
         );
-        assert_eq!(lub, Some(TypeRef::Named("Error".into())));
+        assert_eq!(lub, Some(TypeRef::ident("Error")));
     }
 
     #[test]
@@ -434,10 +493,7 @@ mod tests {
         let (gctx, scope) = ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
         let lub = lub_union(
-            &[
-                TypeRef::Named("Array".into()),
-                TypeRef::Named("Uint8Array".into()),
-            ],
+            &[TypeRef::ident("Array"), TypeRef::ident("Uint8Array")],
             Some(&cgctx),
             scope,
         );
@@ -468,10 +524,7 @@ mod tests {
         let (gctx, scope) = ctx();
         let cgctx = CodegenContext::empty(&gctx, scope);
         let lub = lub_union(
-            &[
-                TypeRef::StringLiteral("a".into()),
-                TypeRef::Named("Foo".into()),
-            ],
+            &[TypeRef::StringLiteral("a".into()), TypeRef::ident("Foo")],
             Some(&cgctx),
             scope,
         );
@@ -484,5 +537,86 @@ mod tests {
         let cgctx = CodegenContext::empty(&gctx, scope);
         let lub = lub_union(&[], Some(&cgctx), scope);
         assert_eq!(lub, None);
+    }
+
+    // ── return_type_has_erased_union ───────────────────────────────────
+
+    #[test]
+    fn return_erasure_flat_jsvalue_union() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        // `string | ArrayBuffer | ArrayBufferView` has no useful LUB.
+        let ty = TypeRef::Union(vec![
+            TypeRef::String,
+            TypeRef::ident("ArrayBuffer"),
+            TypeRef::ArrayBufferView,
+        ]);
+        assert!(return_type_has_erased_union(&ty, Some(&cgctx), scope));
+    }
+
+    #[test]
+    fn return_erasure_inside_array() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        // `Array<32 | "foo">` — outer is fine, inner erases.
+        let ty = TypeRef::Array(Box::new(TypeRef::Union(vec![
+            TypeRef::NumberLiteral(32.0),
+            TypeRef::StringLiteral("foo".into()),
+        ])));
+        assert!(return_type_has_erased_union(&ty, Some(&cgctx), scope));
+    }
+
+    #[test]
+    fn return_erasure_inside_promise_generic() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let ty = TypeRef::generic(
+            "Promise",
+            vec![TypeRef::Union(vec![
+                TypeRef::NumberLiteral(32.0),
+                TypeRef::StringLiteral("foo".into()),
+            ])],
+        );
+        assert!(return_type_has_erased_union(&ty, Some(&cgctx), scope));
+    }
+
+    #[test]
+    fn return_erasure_widened_literal_union_does_not_erase() {
+        // `"a" | "b"` widens to `string` via lub_union, so it doesn't erase.
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let ty = TypeRef::Union(vec![
+            TypeRef::StringLiteral("a".into()),
+            TypeRef::StringLiteral("b".into()),
+        ]);
+        assert!(!return_type_has_erased_union(&ty, Some(&cgctx), scope));
+    }
+
+    #[test]
+    fn return_erasure_named_lub_does_not_erase() {
+        // `TypeError | RangeError` LUBs to `Error`, doesn't erase.
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        let ty = TypeRef::Union(vec![
+            TypeRef::ident("TypeError"),
+            TypeRef::ident("RangeError"),
+        ]);
+        assert!(!return_type_has_erased_union(&ty, Some(&cgctx), scope));
+    }
+
+    #[test]
+    fn return_erasure_simple_types_do_not_erase() {
+        let (gctx, scope) = ctx();
+        let cgctx = CodegenContext::empty(&gctx, scope);
+        assert!(!return_type_has_erased_union(
+            &TypeRef::String,
+            Some(&cgctx),
+            scope
+        ));
+        assert!(!return_type_has_erased_union(
+            &TypeRef::ident("Foo"),
+            Some(&cgctx),
+            scope
+        ));
     }
 }

--- a/src/codegen/subtyping.rs
+++ b/src/codegen/subtyping.rs
@@ -105,13 +105,9 @@ fn user_parents(name: &str, ctx: &CodegenContext<'_>, scope: ScopeId) -> Vec<Str
 /// (generic instantiations, unions, qualified paths, etc.) that don't
 /// have a single representative supertype name.
 fn parent_typeref_to_names(ty: &TypeRef) -> Vec<String> {
-    match ty {
-        TypeRef::Reference {
-            head,
-            segments,
-            type_args,
-        } if segments.is_empty() && type_args.is_empty() => vec![head.clone()],
-        _ => Vec::new(),
+    match ty.as_ident() {
+        Some(name) => vec![name.to_string()],
+        None => Vec::new(),
     }
 }
 
@@ -216,29 +212,19 @@ pub fn lub_union(
         return Some(widened);
     }
     let cgctx = ctx?;
-    // Collect names: only bare references (no generics, no path)
-    // participate in the named-LUB lattice. Generic instantiations
-    // and qualified paths are too coarse to compare structurally.
+    // Collect names: only bare references (single-segment, no
+    // generics) participate in the named-LUB lattice. Generic
+    // instantiations and qualified paths are too coarse to compare
+    // structurally.
     let names: Vec<&str> = members
         .iter()
-        .map(|m| match m {
-            TypeRef::Reference {
-                head,
-                segments,
-                type_args,
-            } if segments.is_empty() && type_args.is_empty() => Some(head.as_str()),
-            _ => None,
-        })
+        .map(|m| m.as_ident())
         .collect::<Option<Vec<_>>>()?;
     let lub = lub_types(&names, cgctx, scope)?;
     if lub == "Object" {
         return None;
     }
-    Some(TypeRef::Reference {
-        head: lub,
-        segments: Vec::new(),
-        type_args: Vec::new(),
-    })
+    Some(TypeRef::ident(lub))
 }
 
 /// Recursively walk a return-position `TypeRef` and report whether
@@ -278,7 +264,7 @@ pub fn return_type_has_erased_union(
         TypeRef::Intersection(parts) => parts
             .iter()
             .any(|p| return_type_has_erased_union(p, ctx, scope)),
-        TypeRef::Reference { type_args, .. } => type_args
+        TypeRef::Reference { generic_args, .. } => generic_args
             .iter()
             .any(|a| return_type_has_erased_union(a, ctx, scope)),
         // Function types in return position bind at the FFI as

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -261,19 +261,12 @@ impl<'a> CodegenContext<'a> {
         if let Some(type_id) = self.gctx.scopes.resolve(scope, name) {
             let decl = self.gctx.get_type(type_id);
             if let TypeKind::TypeAlias(ref alias) = decl.kind {
-                // If the target is itself a bare reference, keep resolving.
-                // Generic instantiations / qualified paths stop here.
-                if let ir::TypeRef::Reference {
-                    head: ref inner_name,
-                    ref segments,
-                    ref type_args,
-                } = alias.target
-                {
-                    if segments.is_empty() && type_args.is_empty() {
-                        if let Some(resolved) = self.resolve_alias_impl(inner_name, scope, visited)
-                        {
-                            return Some(resolved);
-                        }
+                // If the target is itself a single-segment path,
+                // keep resolving. Generic instantiations and
+                // qualified paths stop here.
+                if let Some(inner_name) = alias.target.as_ident() {
+                    if let Some(resolved) = self.resolve_alias_impl(inner_name, scope, visited) {
+                        return Some(resolved);
                     }
                 }
                 return Some(&alias.target);
@@ -562,11 +555,10 @@ pub fn to_syn_type(
         // the external map (`web_sys::*` defaults / user mappings),
         // then `JsValue` fallback with a diagnostic.
         TypeRef::Reference {
-            head,
             segments,
-            type_args,
+            generic_args,
         } => maybe_ref(
-            lower_reference(head, segments, type_args, pos, ctx, scope, from_module),
+            lower_reference(segments, generic_args, pos, ctx, scope, from_module),
             borrow,
         ),
 
@@ -783,36 +775,38 @@ fn named_type_to_rust(
 /// alias resolution, dedicated-codegen heads (`Promise`, `Map`,
 /// `Set`, `Record`, `Array<T>`, ...), and falls through to
 /// `emit_type_name` for everything else.
+///
+/// `segments` is the full path (`["Foo"]` or `["A", "B", "C"]`).
+/// `generic_args` is empty for non-generic references and non-empty
+/// for instantiations like `Foo<T>` or `A.B.C<X>`.
 fn lower_reference(
-    head: &str,
     segments: &[String],
-    type_args: &[TypeRef],
+    generic_args: &[TypeRef],
     pos: TypePosition,
     ctx: Option<&CodegenContext<'_>>,
     scope: ScopeId,
     from_module: &ModuleContext,
 ) -> TokenStream {
-    // Qualified paths are not yet resolved through the scope chain —
-    // we keep the dotted form for `emit_type_name` to consult the
-    // external map, then fall back to JsValue with a diagnostic for
-    // anything that doesn't match.
-    if !segments.is_empty() {
-        let dotted = std::iter::once(head)
-            .chain(segments.iter().map(String::as_str))
-            .collect::<Vec<_>>()
-            .join(".");
+    // Qualified paths (more than one segment) are not yet resolved
+    // through the scope chain — we keep the dotted form for
+    // `emit_type_name` to consult the external map, then fall back
+    // to `JsValue` with a diagnostic for anything that doesn't match.
+    if segments.len() > 1 {
+        let dotted = segments.join(".");
         return match ctx {
             Some(c) => emit_type_name(&dotted, c, from_module),
             None => quote! { JsValue },
         };
     }
 
+    let head = segments.first().map(String::as_str).unwrap_or("");
+
     // Chase user-declared aliases for bare references — `type Foo =
     // string` should lower to `String`, not `Foo`. Skipped when the
     // reference carries generic type arguments (`EmailExportedHandler<Env, Props>`)
     // because we don't substitute generic params; instead we emit the
     // bare alias name and let downstream code see the alias decl.
-    if type_args.is_empty() {
+    if generic_args.is_empty() {
         if let Some(c) = ctx {
             if let Some(target) = c.resolve_alias(head, scope) {
                 let target = target.clone();
@@ -827,21 +821,21 @@ fn lower_reference(
     // share a single dispatch here.
     match head {
         "Promise" | "PromiseLike" => {
-            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            let inner = generic_args.first().cloned().unwrap_or(TypeRef::Any);
             return generic_container(quote! { Promise }, &inner, pos, ctx, scope, from_module);
         }
         "Array" | "ReadonlyArray" => {
-            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            let inner = generic_args.first().cloned().unwrap_or(TypeRef::Any);
             return generic_container(quote! { Array }, &inner, pos, ctx, scope, from_module);
         }
         "Set" | "ReadonlySet" => {
-            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            let inner = generic_args.first().cloned().unwrap_or(TypeRef::Any);
             return generic_container(quote! { Set }, &inner, pos, ctx, scope, from_module);
         }
         "Map" | "ReadonlyMap" => {
             let inner_pos = pos.to_inner();
-            let k = type_args.first().cloned().unwrap_or(TypeRef::Any);
-            let v = type_args.get(1).cloned().unwrap_or(TypeRef::Any);
+            let k = generic_args.first().cloned().unwrap_or(TypeRef::Any);
+            let v = generic_args.get(1).cloned().unwrap_or(TypeRef::Any);
             let k_arg = to_syn_type(&k, inner_pos, ctx, scope, from_module);
             let v_arg = to_syn_type(&v, inner_pos, ctx, scope, from_module);
             return if is_jsvalue_arg(&k_arg) && is_jsvalue_arg(&v_arg) {
@@ -854,7 +848,7 @@ fn lower_reference(
             // `Record<K, V>` desugars to an `Object` with V-typed
             // values. Drop the key type — wasm-bindgen has no Rust
             // representation for "object with arbitrary string keys".
-            let v = type_args.get(1).cloned().unwrap_or(TypeRef::Any);
+            let v = generic_args.get(1).cloned().unwrap_or(TypeRef::Any);
             return generic_container(quote! { Object }, &v, pos, ctx, scope, from_module);
         }
         _ => {}
@@ -863,7 +857,7 @@ fn lower_reference(
     // Generic instantiation of a non-special head — wasm-bindgen
     // bindings can't express user-defined generics yet, so we emit
     // just the base ident with a diagnostic. Type args are dropped.
-    if !type_args.is_empty() {
+    if !generic_args.is_empty() {
         if let Some(c) = ctx {
             c.warn(format!(
                 "generic type arguments on `{head}<...>` are not yet emitted, using bare `{head}`"

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -261,10 +261,19 @@ impl<'a> CodegenContext<'a> {
         if let Some(type_id) = self.gctx.scopes.resolve(scope, name) {
             let decl = self.gctx.get_type(type_id);
             if let TypeKind::TypeAlias(ref alias) = decl.kind {
-                // If the target is itself a named reference, keep resolving.
-                if let ir::TypeRef::Named(ref inner_name) = alias.target {
-                    if let Some(resolved) = self.resolve_alias_impl(inner_name, scope, visited) {
-                        return Some(resolved);
+                // If the target is itself a bare reference, keep resolving.
+                // Generic instantiations / qualified paths stop here.
+                if let ir::TypeRef::Reference {
+                    head: ref inner_name,
+                    ref segments,
+                    ref type_args,
+                } = alias.target
+                {
+                    if segments.is_empty() && type_args.is_empty() {
+                        if let Some(resolved) = self.resolve_alias_impl(inner_name, scope, visited)
+                        {
+                            return Some(resolved);
+                        }
                     }
                 }
                 return Some(&alias.target);
@@ -457,48 +466,15 @@ pub fn to_syn_type(
         TypeRef::Object => maybe_ref(quote! { Object }, borrow),
         TypeRef::Symbol => maybe_ref(quote! { JsValue }, borrow),
 
-        // === Typed Arrays ===
-        TypeRef::Int8Array => maybe_ref(quote! { Int8Array }, borrow),
-        TypeRef::Uint8Array => maybe_ref(quote! { Uint8Array }, borrow),
-        TypeRef::Uint8ClampedArray => maybe_ref(quote! { Uint8ClampedArray }, borrow),
-        TypeRef::Int16Array => maybe_ref(quote! { Int16Array }, borrow),
-        TypeRef::Uint16Array => maybe_ref(quote! { Uint16Array }, borrow),
-        TypeRef::Int32Array => maybe_ref(quote! { Int32Array }, borrow),
-        TypeRef::Uint32Array => maybe_ref(quote! { Uint32Array }, borrow),
-        TypeRef::Float32Array => maybe_ref(quote! { Float32Array }, borrow),
-        TypeRef::Float64Array => maybe_ref(quote! { Float64Array }, borrow),
-        TypeRef::BigInt64Array => maybe_ref(quote! { BigInt64Array }, borrow),
-        TypeRef::BigUint64Array => maybe_ref(quote! { BigUint64Array }, borrow),
-        TypeRef::ArrayBuffer => maybe_ref(quote! { ArrayBuffer }, borrow),
+        // === TS-only synthetic ===
+        // `ArrayBufferView` is a TS-only union alias (typed-array
+        // family + DataView), not a JS class — codegen erases it to
+        // plain `Object`.
         TypeRef::ArrayBufferView => maybe_ref(quote! { Object }, borrow),
-        TypeRef::DataView => maybe_ref(quote! { DataView }, borrow),
 
-        // === Built-in Generic Containers ===
-        TypeRef::Promise(inner) => maybe_ref(
-            generic_container(quote! { Promise }, inner, pos, ctx, scope, from_module),
-            borrow,
-        ),
+        // === Syntactic constructs ===
         TypeRef::Array(inner) => maybe_ref(
             generic_container(quote! { Array }, inner, pos, ctx, scope, from_module),
-            borrow,
-        ),
-        TypeRef::Record(_k, v) => maybe_ref(
-            generic_container(quote! { Object }, v, pos, ctx, scope, from_module),
-            borrow,
-        ),
-        TypeRef::Map(k, v) => {
-            let inner_pos = pos.to_inner();
-            let k_arg = to_syn_type(k, inner_pos, ctx, scope, from_module);
-            let v_arg = to_syn_type(v, inner_pos, ctx, scope, from_module);
-            let base = if is_jsvalue_arg(&k_arg) && is_jsvalue_arg(&v_arg) {
-                quote! { Map }
-            } else {
-                quote! { Map<#k_arg, #v_arg> }
-            };
-            maybe_ref(base, borrow)
-        }
-        TypeRef::Set(inner) => maybe_ref(
-            generic_container(quote! { Set }, inner, pos, ctx, scope, from_module),
             borrow,
         ),
 
@@ -578,31 +554,21 @@ pub fn to_syn_type(
         TypeRef::BooleanLiteral(_) => quote! { bool },
 
         // === Named References ===
-        TypeRef::Named(name) => {
-            // Resolve through type aliases before falling back to named_type_to_rust.
-            if let Some(c) = ctx {
-                if let Some(target) = c.resolve_alias(name, scope) {
-                    let target = target.clone();
-                    return to_syn_type(&target, pos, ctx, scope, from_module);
-                }
-            }
-            maybe_ref(named_type_to_rust(name, ctx, from_module), borrow)
-        }
-        TypeRef::GenericInstantiation(name, _args) => {
-            // TODO (Phase 3): preserve generic type arguments once wasm_bindgen
-            // generic support is wired through. For now, emit just the base type.
-            if let Some(c) = ctx {
-                c.warn(format!(
-                    "generic type arguments on `{name}<...>` are not yet emitted, using bare `{name}`"
-                ));
-            }
-            maybe_ref(named_type_to_rust(name, ctx, from_module), borrow)
-        }
-
-        // === Special ===
-        TypeRef::Date => maybe_ref(quote! { Date }, borrow),
-        TypeRef::RegExp => maybe_ref(quote! { RegExp }, borrow),
-        TypeRef::Error => maybe_ref(quote! { Error }, borrow),
+        //
+        // Bare ident, generic instantiation, qualified path — all
+        // flow through one arm. Resolution mirrors TypeScript's name
+        // lookup: user scope first (so `interface MyDate {}` shadows
+        // `Date`), then well-known JS heads (`js_sys::*` glob), then
+        // the external map (`web_sys::*` defaults / user mappings),
+        // then `JsValue` fallback with a diagnostic.
+        TypeRef::Reference {
+            head,
+            segments,
+            type_args,
+        } => maybe_ref(
+            lower_reference(head, segments, type_args, pos, ctx, scope, from_module),
+            borrow,
+        ),
 
         // === Fallback ===
         TypeRef::Unresolved(desc) => {
@@ -801,8 +767,111 @@ fn named_type_to_rust(
 ) -> TokenStream {
     match ctx {
         Some(ctx) => emit_type_name(name, ctx, from_module),
+        // Without a codegen context (e.g. unit tests that exercise
+        // type lowering directly) we can still resolve names that
+        // appear in the `js_sys::*` glob — emit them as a bare ident.
+        // Anything else falls back to `JsValue`.
+        None if JS_SYS_RESERVED.contains(&name) => {
+            let ident = make_ident(name);
+            quote! { #ident }
+        }
         None => quote! { JsValue },
     }
+}
+
+/// Lower a `TypeRef::Reference` to its Rust syntax token. Handles
+/// alias resolution, dedicated-codegen heads (`Promise`, `Map`,
+/// `Set`, `Record`, `Array<T>`, ...), and falls through to
+/// `emit_type_name` for everything else.
+fn lower_reference(
+    head: &str,
+    segments: &[String],
+    type_args: &[TypeRef],
+    pos: TypePosition,
+    ctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+    from_module: &ModuleContext,
+) -> TokenStream {
+    // Qualified paths are not yet resolved through the scope chain —
+    // we keep the dotted form for `emit_type_name` to consult the
+    // external map, then fall back to JsValue with a diagnostic for
+    // anything that doesn't match.
+    if !segments.is_empty() {
+        let dotted = std::iter::once(head)
+            .chain(segments.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(".");
+        return match ctx {
+            Some(c) => emit_type_name(&dotted, c, from_module),
+            None => quote! { JsValue },
+        };
+    }
+
+    // Chase user-declared aliases for bare references — `type Foo =
+    // string` should lower to `String`, not `Foo`. Skipped when the
+    // reference carries generic type arguments (`EmailExportedHandler<Env, Props>`)
+    // because we don't substitute generic params; instead we emit the
+    // bare alias name and let downstream code see the alias decl.
+    if type_args.is_empty() {
+        if let Some(c) = ctx {
+            if let Some(target) = c.resolve_alias(head, scope) {
+                let target = target.clone();
+                return to_syn_type(&target, pos, ctx, scope, from_module);
+            }
+        }
+    }
+
+    // Heads with dedicated codegen rules. `Promise<T>`, `Map<K,V>`,
+    // `Set<T>`, `Record<K,V>`, and the generic `Array<T>` form (the
+    // syntactic `T[]` is handled separately by `TypeRef::Array`)
+    // share a single dispatch here.
+    match head {
+        "Promise" | "PromiseLike" => {
+            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            return generic_container(quote! { Promise }, &inner, pos, ctx, scope, from_module);
+        }
+        "Array" | "ReadonlyArray" => {
+            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            return generic_container(quote! { Array }, &inner, pos, ctx, scope, from_module);
+        }
+        "Set" | "ReadonlySet" => {
+            let inner = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            return generic_container(quote! { Set }, &inner, pos, ctx, scope, from_module);
+        }
+        "Map" | "ReadonlyMap" => {
+            let inner_pos = pos.to_inner();
+            let k = type_args.first().cloned().unwrap_or(TypeRef::Any);
+            let v = type_args.get(1).cloned().unwrap_or(TypeRef::Any);
+            let k_arg = to_syn_type(&k, inner_pos, ctx, scope, from_module);
+            let v_arg = to_syn_type(&v, inner_pos, ctx, scope, from_module);
+            return if is_jsvalue_arg(&k_arg) && is_jsvalue_arg(&v_arg) {
+                quote! { Map }
+            } else {
+                quote! { Map<#k_arg, #v_arg> }
+            };
+        }
+        "Record" => {
+            // `Record<K, V>` desugars to an `Object` with V-typed
+            // values. Drop the key type — wasm-bindgen has no Rust
+            // representation for "object with arbitrary string keys".
+            let v = type_args.get(1).cloned().unwrap_or(TypeRef::Any);
+            return generic_container(quote! { Object }, &v, pos, ctx, scope, from_module);
+        }
+        _ => {}
+    }
+
+    // Generic instantiation of a non-special head — wasm-bindgen
+    // bindings can't express user-defined generics yet, so we emit
+    // just the base ident with a diagnostic. Type args are dropped.
+    if !type_args.is_empty() {
+        if let Some(c) = ctx {
+            c.warn(format!(
+                "generic type arguments on `{head}<...>` are not yet emitted, using bare `{head}`"
+            ));
+        }
+    }
+
+    named_type_to_rust(head, ctx, from_module)
 }
 
 /// Create a `syn::Ident`, sanitizing invalid characters and escaping keywords.
@@ -957,7 +1026,7 @@ mod tests {
     #[test]
     fn test_promise_with_named_type_unresolved() {
         // Without ctx, Foo is unresolved → JsValue, so Promise<JsValue> elides to Promise
-        let ty = TypeRef::Promise(Box::new(TypeRef::Named("Foo".into())));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::ident("Foo")]);
         assert_eq!(ret_type(&ty), "Promise");
     }
 
@@ -977,21 +1046,21 @@ mod tests {
 
     #[test]
     fn test_promise_with_string() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::String));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::String]);
         let result = ret_type(&ty);
         assert_eq!(result, "Promise < JsString >");
     }
 
     #[test]
     fn test_promise_with_any_elides_generic() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::Any));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::Any]);
         let result = ret_type(&ty);
         assert_eq!(result, "Promise");
     }
 
     #[test]
     fn test_promise_with_void() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::Void));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::Void]);
         let result = ret_type(&ty);
         assert_eq!(result, "Promise < Undefined >");
     }
@@ -999,14 +1068,14 @@ mod tests {
     #[test]
     fn test_nullable_named_type_unresolved() {
         // Without ctx, Foo is unresolved → JsValue
-        let ty = TypeRef::Nullable(Box::new(TypeRef::Named("Foo".into())));
+        let ty = TypeRef::Nullable(Box::new(TypeRef::ident("Foo")));
         assert_eq!(arg_type(&ty), "Option < & JsValue >");
         assert_eq!(ret_type(&ty), "Option < JsValue >");
     }
 
     #[test]
     fn test_promise_with_arraybuffer() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::ArrayBuffer));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::ident("ArrayBuffer")]);
         let result = ret_type(&ty);
         assert_eq!(result, "Promise < ArrayBuffer >");
     }
@@ -1027,34 +1096,37 @@ mod tests {
 
     #[test]
     fn test_set_with_type() {
-        let ty = TypeRef::Set(Box::new(TypeRef::String));
+        let ty = TypeRef::generic("Set", vec![TypeRef::String]);
         let result = ret_type(&ty);
         assert_eq!(result, "Set < JsString >");
     }
 
     #[test]
     fn test_map_with_types() {
-        let ty = TypeRef::Map(Box::new(TypeRef::String), Box::new(TypeRef::Number));
+        let ty = TypeRef::generic("Map", vec![TypeRef::String, TypeRef::Number]);
         let result = ret_type(&ty);
         assert_eq!(result, "Map < JsString , Number >");
     }
 
     #[test]
     fn test_record_erases_key() {
-        let ty = TypeRef::Record(Box::new(TypeRef::String), Box::new(TypeRef::Number));
+        let ty = TypeRef::generic("Record", vec![TypeRef::String, TypeRef::Number]);
         let result = ret_type(&ty);
         assert_eq!(result, "Object < Number >");
     }
 
     #[test]
     fn test_record_nullable_jsvalue_elides_generic() {
-        let ty = TypeRef::Record(
-            Box::new(TypeRef::String),
-            Box::new(TypeRef::Nullable(Box::new(TypeRef::Union(vec![
+        let ty = TypeRef::generic(
+            "Record",
+            vec![
                 TypeRef::String,
-                TypeRef::Number,
-                TypeRef::Boolean,
-            ])))),
+                TypeRef::Nullable(Box::new(TypeRef::Union(vec![
+                    TypeRef::String,
+                    TypeRef::Number,
+                    TypeRef::Boolean,
+                ]))),
+            ],
         );
         assert_eq!(ret_type(&ty), "Object");
     }
@@ -1062,14 +1134,17 @@ mod tests {
     #[test]
     fn test_promise_nullable_inner() {
         // Promise<string | null> → Promise<JsOption<JsString>>
-        let ty = TypeRef::Promise(Box::new(TypeRef::Nullable(Box::new(TypeRef::String))));
+        let ty = TypeRef::generic(
+            "Promise",
+            vec![TypeRef::Nullable(Box::new(TypeRef::String))],
+        );
         let result = ret_type(&ty);
         assert_eq!(result, "Promise < JsOption < JsString > >");
     }
 
     #[test]
     fn test_promise_nullable_jsvalue_elides_generic() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::Nullable(Box::new(TypeRef::Any))));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::Nullable(Box::new(TypeRef::Any))]);
         assert_eq!(ret_type(&ty), "Promise");
     }
 
@@ -1108,19 +1183,19 @@ mod tests {
     #[test]
     fn test_named_unresolved_without_ctx() {
         // Without a CodegenContext, unknown types fall back to JsValue
-        let ty = TypeRef::Named("Request".into());
+        let ty = TypeRef::ident("Request");
         assert_eq!(ret_type(&ty), "JsValue");
     }
 
     #[test]
     fn test_named_unknown_without_ctx() {
-        let ty = TypeRef::Named("MyCustomType".into());
+        let ty = TypeRef::ident("MyCustomType");
         assert_eq!(ret_type(&ty), "JsValue");
     }
 
     #[test]
     fn test_return_with_catch() {
-        let ty = TypeRef::Promise(Box::new(TypeRef::Void));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::Void]);
         let result = to_return_type(
             &ty,
             true,
@@ -1154,7 +1229,7 @@ mod tests {
         let mut ctx = CodegenContext::empty(&gctx, scope);
         ctx.local_types
             .insert("Response".into(), ModuleContext::Global);
-        let ty = TypeRef::Named("Response".into());
+        let ty = TypeRef::ident("Response");
         let result = to_syn_type(
             &ty,
             TypePosition::RETURN,
@@ -1174,7 +1249,7 @@ mod tests {
             kind: crate::ir::TypeKind::TypeAlias(crate::ir::TypeAliasDecl {
                 name: "BodyInit".to_string(),
                 type_params: vec![],
-                target: TypeRef::Union(vec![TypeRef::String, TypeRef::ArrayBuffer]),
+                target: TypeRef::Union(vec![TypeRef::String, TypeRef::ident("ArrayBuffer")]),
                 from_module: None,
             }),
             module_context: crate::ir::ModuleContext::Global,
@@ -1185,7 +1260,7 @@ mod tests {
         gctx.scopes.insert(scope, "BodyInit".to_string(), alias_id);
 
         let ctx = CodegenContext::empty(&gctx, scope);
-        let ty = TypeRef::Named("BodyInit".into());
+        let ty = TypeRef::ident("BodyInit");
         let result = to_syn_type(
             &ty,
             TypePosition::RETURN,
@@ -1204,7 +1279,7 @@ mod tests {
         // `::web_sys::Response` (rather than erasing to JsValue).
         let (gctx, scope) = test_gctx();
         let ctx = CodegenContext::empty(&gctx, scope);
-        let ty = TypeRef::Named("Response".into());
+        let ty = TypeRef::ident("Response");
         let result = to_syn_type(
             &ty,
             TypePosition::RETURN,
@@ -1228,7 +1303,7 @@ mod tests {
         // `use JsValue as Foo;` alias and an error diagnostic.
         let (gctx, scope) = test_gctx();
         let ctx = CodegenContext::empty(&gctx, scope);
-        let ty = TypeRef::Named("MyCustomThing".into());
+        let ty = TypeRef::ident("MyCustomThing");
         let result = to_syn_type(
             &ty,
             TypePosition::RETURN,
@@ -1248,7 +1323,7 @@ mod tests {
         let mut ctx = CodegenContext::empty(&gctx, scope);
         ctx.local_types
             .insert("MyThing".into(), ModuleContext::Global);
-        let ty = TypeRef::Promise(Box::new(TypeRef::Named("MyThing".into())));
+        let ty = TypeRef::generic("Promise", vec![TypeRef::ident("MyThing")]);
         let result = to_syn_type(
             &ty,
             TypePosition::RETURN,
@@ -1271,7 +1346,7 @@ mod tests {
         ctx.local_types
             .insert("EmailMessage".into(), module.clone());
 
-        let ty = TypeRef::Named("EmailMessage".into());
+        let ty = TypeRef::ident("EmailMessage");
         let result = to_syn_type(
             &ty,
             TypePosition::ARGUMENT,
@@ -1293,7 +1368,7 @@ mod tests {
             .insert("EmailSendResult".into(), ModuleContext::Global);
 
         let from = ModuleContext::Module("cloudflare:email".into());
-        let ty = TypeRef::Named("EmailSendResult".into());
+        let ty = TypeRef::ident("EmailSendResult");
         let result = to_syn_type(&ty, TypePosition::RETURN, Some(&ctx), scope, &from).to_string();
         assert_eq!(result, "EmailSendResult");
     }
@@ -1308,7 +1383,7 @@ mod tests {
             .insert("Sibling".into(), ModuleContext::Module("node:b".into()));
 
         let from = ModuleContext::Module("node:a".into());
-        let ty = TypeRef::Named("Sibling".into());
+        let ty = TypeRef::ident("Sibling");
         let result = to_syn_type(&ty, TypePosition::RETURN, Some(&ctx), scope, &from).to_string();
         assert_eq!(result, "super :: b :: Sibling");
     }
@@ -1329,7 +1404,7 @@ mod tests {
     #[test]
     fn test_inner_position_named_type_unresolved() {
         // Without ctx, unresolved named types → JsValue
-        let ty = TypeRef::Named("Response".into());
+        let ty = TypeRef::ident("Response");
         assert_eq!(inner_type(&ty), "JsValue");
         assert_eq!(ret_type(&ty), "JsValue");
     }
@@ -1337,7 +1412,7 @@ mod tests {
     #[test]
     fn test_inner_position_typed_array_unchanged() {
         // Typed arrays pass through in inner position
-        let ty = TypeRef::Uint8Array;
+        let ty = TypeRef::ident("Uint8Array");
         assert_eq!(inner_type(&ty), "Uint8Array");
         assert_eq!(ret_type(&ty), "Uint8Array");
     }
@@ -1346,8 +1421,8 @@ mod tests {
     fn test_tuple_generates_array_tuple() {
         // Without ctx, named types are unresolved → JsValue, so Array<JsValue> elides to Array
         let ty = TypeRef::Tuple(vec![
-            TypeRef::Array(Box::new(TypeRef::Named("ImportSpecifier".into()))),
-            TypeRef::Array(Box::new(TypeRef::Named("ExportSpecifier".into()))),
+            TypeRef::Array(Box::new(TypeRef::ident("ImportSpecifier"))),
+            TypeRef::Array(Box::new(TypeRef::ident("ExportSpecifier"))),
             TypeRef::Boolean,
             TypeRef::Boolean,
         ]);

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -473,11 +473,17 @@ pub fn to_syn_type(
 
         // === Structural Types ===
         TypeRef::Nullable(inner) => {
+            let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
             if pos.inner {
-                let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
                 js_option_or_js_value(inner_ty)
+            } else if !pos.is_argument() && is_jsvalue_arg(&inner_ty) {
+                // In return position, `Option<JsValue>` is redundant —
+                // `JsValue` already carries `null`/`undefined` in-band,
+                // so collapse to bare `JsValue`. Argument position
+                // keeps `Option<&JsValue>` since the caller may want
+                // to distinguish "no value" from "JsValue::NULL".
+                quote! { JsValue }
             } else {
-                let inner_ty = to_syn_type(inner, pos, ctx, scope, from_module);
                 quote! { Option<#inner_ty> }
             }
         }
@@ -1061,10 +1067,15 @@ mod tests {
 
     #[test]
     fn test_nullable_named_type_unresolved() {
-        // Without ctx, Foo is unresolved → JsValue
+        // Without ctx, `Foo` is unresolved → `JsValue`. In *return*
+        // position the `Option<JsValue>` shape is redundant (JsValue
+        // already carries `null`/`undefined` in-band) and collapses
+        // to bare `JsValue`. In *argument* position we preserve
+        // `Option<&JsValue>` so callers can distinguish "no value"
+        // from passing `JsValue::NULL`.
         let ty = TypeRef::Nullable(Box::new(TypeRef::ident("Foo")));
         assert_eq!(arg_type(&ty), "Option < & JsValue >");
-        assert_eq!(ret_type(&ty), "Option < JsValue >");
+        assert_eq!(ret_type(&ty), "JsValue");
     }
 
     #[test]

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -93,16 +93,15 @@ pub enum TypeRef {
     BooleanLiteral(bool),
 
     // === Named References ===
-    /// Named type reference — possibly qualified (`A.B.C`), possibly
-    /// generic (`Foo<T>`, `A.B.C<T>`), possibly both.
+    /// Nominal type reference: a (possibly qualified) name with an
+    /// (possibly empty) generic type argument list.
     ///
-    /// * `head`: leftmost identifier in the path.
-    /// * `segments`: subsequent dotted segments. Empty for a bare
-    ///   identifier.
-    /// * `type_args`: generic instantiation arguments. Empty for a
-    ///   non-generic reference.
+    /// * `Foo` → `Reference { segments: vec!["Foo"], generic_args: vec![] }`
+    /// * `Foo<T>` → `Reference { segments: vec!["Foo"], generic_args: vec![T] }`
+    /// * `A.B.C` → `Reference { segments: vec!["A","B","C"], generic_args: vec![] }`
+    /// * `A.B.C<T>` → `Reference { segments: vec!["A","B","C"], generic_args: vec![T] }`
     ///
-    /// All scope-resolved names go through this variant: user-declared
+    /// All scope-resolved names use this variant: user-declared
     /// types, built-in JS classes (`Date`, `Error`, `TypeError`,
     /// `Uint8Array`, ...), and `Promise`/`Map`/`Set`/`Record`. Codegen
     /// resolves these at emit time via scope chain → `JS_SYS_RESERVED`
@@ -110,14 +109,15 @@ pub enum TypeRef {
     /// special codegen rules (e.g. `Promise<T>` → `async fn`) are
     /// recognized by name at the relevant emitter.
     ///
-    /// Qualified paths (`segments` non-empty) are not yet resolved
-    /// through the scope chain — they fall back to the external map
-    /// or to `JsValue` with a diagnostic. Proper namespace traversal
-    /// is a future extension.
+    /// Single-segment references participate in alias chasing and
+    /// shadowing (mirroring TS scope-driven resolution); multi-
+    /// segment references are not yet fully resolved through the
+    /// scope chain — they fall back to the external map or to
+    /// `JsValue` with a diagnostic. Proper namespace traversal is a
+    /// future extension.
     Reference {
-        head: String,
         segments: Vec<String>,
-        type_args: Vec<TypeRef>,
+        generic_args: Vec<TypeRef>,
     },
 
     // === Fallback ===
@@ -127,56 +127,50 @@ pub enum TypeRef {
 }
 
 impl TypeRef {
-    /// Construct a bare named reference: `head` with no qualified
-    /// segments and no generic type arguments. Convenience for the
-    /// common case (`MyType`, `Date`, `Foo`).
-    pub fn ident(head: impl Into<String>) -> Self {
+    /// Construct a single-segment, non-generic reference: `Foo`.
+    /// Convenience for the common case of a bare ident.
+    pub fn ident(name: impl Into<String>) -> Self {
         TypeRef::Reference {
-            head: head.into(),
-            segments: Vec::new(),
-            type_args: Vec::new(),
+            segments: vec![name.into()],
+            generic_args: Vec::new(),
         }
     }
 
-    /// Construct a generic instantiation: `head<T1, T2, ...>` with no
-    /// qualified segments. Convenience for `Promise<T>`, `Map<K, V>`,
-    /// `Array<T>`, etc.
-    pub fn generic(head: impl Into<String>, type_args: Vec<TypeRef>) -> Self {
+    /// Construct a single-segment generic instantiation:
+    /// `head<T1, T2, ...>`. Convenience for `Promise<T>`,
+    /// `Map<K, V>`, `Array<T>`, etc.
+    pub fn generic(head: impl Into<String>, generic_args: Vec<TypeRef>) -> Self {
         TypeRef::Reference {
-            head: head.into(),
-            segments: Vec::new(),
-            type_args,
+            segments: vec![head.into()],
+            generic_args,
         }
     }
 
-    /// If `self` is a bare reference (no qualified segments, no
-    /// generic arguments), return the head identifier.
+    /// If `self` is a bare reference (single-segment, no generic
+    /// arguments), return the ident. `Foo` → `Some("Foo")`,
+    /// `A.B` → `None`, `Foo<T>` → `None`.
     pub fn as_ident(&self) -> Option<&str> {
         match self {
             TypeRef::Reference {
-                head,
                 segments,
-                type_args,
-            } if segments.is_empty() && type_args.is_empty() => Some(head.as_str()),
+                generic_args,
+            } if segments.len() == 1 && generic_args.is_empty() => Some(segments[0].as_str()),
             _ => None,
         }
     }
 
-    /// If `self` is a non-qualified reference to the well-known
-    /// generic head `name` (e.g. `"Promise"`, `"Array"`, `"Map"`),
-    /// return its type arguments. Returns `None` for any other shape.
-    ///
-    /// Used by codegen sites that need to recognize `Promise<T>`,
-    /// `Map<K,V>`, etc. without caring whether the head was reached
-    /// via the `T[]` syntactic shortcut, a generic instantiation, or
-    /// any other route.
+    /// If `self` is a generic instantiation of a single-segment head
+    /// matching `name` (e.g. `"Promise"`, `"Map"`), return its type
+    /// arguments. Used by codegen sites that recognize specific
+    /// generic shapes for dedicated lowering.
     pub fn as_generic_head(&self, name: &str) -> Option<&[TypeRef]> {
         match self {
             TypeRef::Reference {
-                head,
                 segments,
-                type_args,
-            } if segments.is_empty() && head == name => Some(type_args),
+                generic_args,
+            } if segments.len() == 1 && segments[0] == name && !generic_args.is_empty() => {
+                Some(generic_args)
+            }
             _ => None,
         }
     }
@@ -260,19 +254,14 @@ impl TypeRef {
             TypeRef::NumberLiteral(n) => n.to_string(),
             TypeRef::BooleanLiteral(b) => b.to_string(),
             TypeRef::Reference {
-                head,
                 segments,
-                type_args,
+                generic_args,
             } => {
-                let mut name = head.clone();
-                for s in segments {
-                    name.push('.');
-                    name.push_str(s);
-                }
-                if type_args.is_empty() {
+                let name = segments.join(".");
+                if generic_args.is_empty() {
                     name
                 } else {
-                    let args = type_args
+                    let args = generic_args
                         .iter()
                         .map(Self::format_ts)
                         .collect::<Vec<_>>()
@@ -760,9 +749,8 @@ mod tests {
     #[test]
     fn format_ts_qualified_path() {
         let ty = TypeRef::Reference {
-            head: "A".into(),
-            segments: vec!["B".into(), "C".into()],
-            type_args: vec![],
+            segments: vec!["A".into(), "B".into(), "C".into()],
+            generic_args: vec![],
         };
         assert_eq!(ty.format_ts(), "A.B.C");
     }
@@ -770,9 +758,8 @@ mod tests {
     #[test]
     fn format_ts_qualified_generic() {
         let ty = TypeRef::Reference {
-            head: "Rpc".into(),
-            segments: vec!["Stub".into()],
-            type_args: vec![TypeRef::ident("Foo")],
+            segments: vec!["Rpc".into(), "Stub".into()],
+            generic_args: vec![TypeRef::ident("Foo")],
         };
         assert_eq!(ty.format_ts(), "Rpc.Stub<Foo>");
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -31,10 +31,27 @@ pub enum ModuleContext {
 // ─── Type References ─────────────────────────────────────────────────
 
 /// A reference to a TypeScript type, resolved from the AST.
+///
+/// The IR mirrors TypeScript's own type system: only the syntactic
+/// constructs from the grammar get dedicated variants. Anything that
+/// would resolve through TS's name lookup (built-in JS classes,
+/// `Promise<T>`, `Map<K,V>`, user-declared types, qualified paths)
+/// flows through [`TypeRef::Reference`] and is resolved at codegen
+/// time against the scope chain. This means user-declared types
+/// shadow built-ins exactly the way they do in TypeScript.
+///
+/// Note that `T[]` and `Array<T>` are **distinct** at the IR level
+/// (matching TS): `T[]` is the syntactic [`TypeRef::Array`] shortcut
+/// that never goes through name resolution, while `Array<T>` is a
+/// `Reference { head: "Array", ... }` that *does* go through the
+/// scope chain and is therefore affected by local shadowing.
 #[derive(Clone, Debug, PartialEq)]
-
 pub enum TypeRef {
     // === Primitives ===
+    //
+    // Lower to a Rust-side type at the FFI boundary, not a JS class —
+    // e.g. `String` → `String`/`&str`, `Number` → `f64`. Each variant
+    // carries its own non-trivial lowering rule.
     Boolean,
     Number,
     String,
@@ -45,36 +62,29 @@ pub enum TypeRef {
     Any,
     Unknown,
     Object,
+    /// JS `symbol` primitive — there is no Rust-side equivalent at the
+    /// FFI boundary, so it lowers to `JsValue`.
     Symbol,
 
-    // === Typed Arrays ===
-    Int8Array,
-    Uint8Array,
-    Uint8ClampedArray,
-    Int16Array,
-    Uint16Array,
-    Int32Array,
-    Uint32Array,
-    Float32Array,
-    Float64Array,
-    BigInt64Array,
-    BigUint64Array,
-    ArrayBuffer,
+    // === TS-only synthetic types ===
+    /// `ArrayBufferView` is a TS-only union alias for the typed-array
+    /// family + `DataView`. There is no JS class with this name, so it
+    /// can't lower to a `js_sys` ident — codegen erases it to `Object`.
     ArrayBufferView,
-    DataView,
 
-    // === Built-in Generic Containers ===
-    Promise(Box<TypeRef>),
+    // === Syntactic constructs ===
+    /// `T[]` — the syntactic array shortcut. Distinct from
+    /// `Array<T>` (which is a [`TypeRef::Reference`] to the global
+    /// `Array` symbol and goes through name resolution). `T[]` is
+    /// unaffected by local shadowing of `Array`.
     Array(Box<TypeRef>),
-    Record(Box<TypeRef>, Box<TypeRef>),
-    Map(Box<TypeRef>, Box<TypeRef>),
-    Set(Box<TypeRef>),
-
-    // === Structural Types ===
+    /// `T | null` / `T | undefined` / `T?` — wraps the inner in
+    /// `Option<T>` at lowering. Coalesces `null`/`undefined` arms.
     Nullable(Box<TypeRef>),
     Union(Vec<TypeRef>),
     Intersection(Vec<TypeRef>),
     Tuple(Vec<TypeRef>),
+    /// `(args) => ret` — function type literal.
     Function(FunctionSig),
 
     // === Literal Types ===
@@ -83,20 +93,196 @@ pub enum TypeRef {
     BooleanLiteral(bool),
 
     // === Named References ===
-    /// Reference to a type by name. Resolved during first pass.
-    Named(String),
-    /// Generic instantiation: `Named<T1, T2, ...>`
-    GenericInstantiation(String, Vec<TypeRef>),
-
-    // === Special ===
-    Date,
-    RegExp,
-    Error,
+    /// Named type reference — possibly qualified (`A.B.C`), possibly
+    /// generic (`Foo<T>`, `A.B.C<T>`), possibly both.
+    ///
+    /// * `head`: leftmost identifier in the path.
+    /// * `segments`: subsequent dotted segments. Empty for a bare
+    ///   identifier.
+    /// * `type_args`: generic instantiation arguments. Empty for a
+    ///   non-generic reference.
+    ///
+    /// All scope-resolved names go through this variant: user-declared
+    /// types, built-in JS classes (`Date`, `Error`, `TypeError`,
+    /// `Uint8Array`, ...), and `Promise`/`Map`/`Set`/`Record`. Codegen
+    /// resolves these at emit time via scope chain → `JS_SYS_RESERVED`
+    /// (built-ins) → external map → `JsValue` fallback. Heads with
+    /// special codegen rules (e.g. `Promise<T>` → `async fn`) are
+    /// recognized by name at the relevant emitter.
+    ///
+    /// Qualified paths (`segments` non-empty) are not yet resolved
+    /// through the scope chain — they fall back to the external map
+    /// or to `JsValue` with a diagnostic. Proper namespace traversal
+    /// is a future extension.
+    Reference {
+        head: String,
+        segments: Vec<String>,
+        type_args: Vec<TypeRef>,
+    },
 
     // === Fallback ===
     /// For TS constructs we can't represent (conditional types, mapped types,
     /// template literals, `keyof`, etc.) — erased to `JsValue`.
     Unresolved(String),
+}
+
+impl TypeRef {
+    /// Construct a bare named reference: `head` with no qualified
+    /// segments and no generic type arguments. Convenience for the
+    /// common case (`MyType`, `Date`, `Foo`).
+    pub fn ident(head: impl Into<String>) -> Self {
+        TypeRef::Reference {
+            head: head.into(),
+            segments: Vec::new(),
+            type_args: Vec::new(),
+        }
+    }
+
+    /// Construct a generic instantiation: `head<T1, T2, ...>` with no
+    /// qualified segments. Convenience for `Promise<T>`, `Map<K, V>`,
+    /// `Array<T>`, etc.
+    pub fn generic(head: impl Into<String>, type_args: Vec<TypeRef>) -> Self {
+        TypeRef::Reference {
+            head: head.into(),
+            segments: Vec::new(),
+            type_args,
+        }
+    }
+
+    /// If `self` is a bare reference (no qualified segments, no
+    /// generic arguments), return the head identifier.
+    pub fn as_ident(&self) -> Option<&str> {
+        match self {
+            TypeRef::Reference {
+                head,
+                segments,
+                type_args,
+            } if segments.is_empty() && type_args.is_empty() => Some(head.as_str()),
+            _ => None,
+        }
+    }
+
+    /// If `self` is a non-qualified reference to the well-known
+    /// generic head `name` (e.g. `"Promise"`, `"Array"`, `"Map"`),
+    /// return its type arguments. Returns `None` for any other shape.
+    ///
+    /// Used by codegen sites that need to recognize `Promise<T>`,
+    /// `Map<K,V>`, etc. without caring whether the head was reached
+    /// via the `T[]` syntactic shortcut, a generic instantiation, or
+    /// any other route.
+    pub fn as_generic_head(&self, name: &str) -> Option<&[TypeRef]> {
+        match self {
+            TypeRef::Reference {
+                head,
+                segments,
+                type_args,
+            } if segments.is_empty() && head == name => Some(type_args),
+            _ => None,
+        }
+    }
+
+    /// `Promise<T>` → `Some(&T)`. Convenience over [`Self::as_generic_head`]
+    /// for the common Promise-unwrap case (signature collapse for
+    /// async returns).
+    pub fn as_promise_inner(&self) -> Option<&TypeRef> {
+        let args = self.as_generic_head("Promise")?;
+        args.first()
+    }
+
+    /// Render this `TypeRef` back into a TypeScript-like string.
+    ///
+    /// Pretty-prints structurally faithful to the source — primitives
+    /// as their lowercase keywords, generics as `Foo<T1, T2>`, unions
+    /// as `A | B`, etc. Used to surface the original TS shape of a
+    /// return type in `Returns:` doc comments when the static Rust
+    /// type loses information (e.g. an erased union).
+    pub fn format_ts(&self) -> String {
+        match self {
+            TypeRef::Boolean => "boolean".into(),
+            TypeRef::Number => "number".into(),
+            TypeRef::String => "string".into(),
+            TypeRef::BigInt => "bigint".into(),
+            TypeRef::Void => "void".into(),
+            TypeRef::Undefined => "undefined".into(),
+            TypeRef::Null => "null".into(),
+            TypeRef::Any => "any".into(),
+            TypeRef::Unknown => "unknown".into(),
+            TypeRef::Object => "object".into(),
+            TypeRef::Symbol => "symbol".into(),
+            TypeRef::ArrayBufferView => "ArrayBufferView".into(),
+            TypeRef::Array(inner) => {
+                // Wrap composite inner types in parens so e.g.
+                // `(A | B)[]` doesn't render as the wrong-precedence
+                // `A | B[]`.
+                let needs_parens = matches!(
+                    inner.as_ref(),
+                    TypeRef::Union(_) | TypeRef::Intersection(_) | TypeRef::Nullable(_)
+                );
+                if needs_parens {
+                    format!("({})[]", inner.format_ts())
+                } else {
+                    format!("{}[]", inner.format_ts())
+                }
+            }
+            TypeRef::Nullable(inner) => format!("{} | null", inner.format_ts()),
+            TypeRef::Union(members) => members
+                .iter()
+                .map(Self::format_ts)
+                .collect::<Vec<_>>()
+                .join(" | "),
+            TypeRef::Intersection(parts) => parts
+                .iter()
+                .map(Self::format_ts)
+                .collect::<Vec<_>>()
+                .join(" & "),
+            TypeRef::Tuple(elems) => format!(
+                "[{}]",
+                elems
+                    .iter()
+                    .map(Self::format_ts)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            TypeRef::Function(sig) => {
+                let params = sig
+                    .params
+                    .iter()
+                    .map(|p| {
+                        let opt = if p.optional { "?" } else { "" };
+                        let dots = if p.variadic { "..." } else { "" };
+                        format!("{dots}{}{opt}: {}", p.name, p.type_ref.format_ts())
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("({params}) => {}", sig.return_type.format_ts())
+            }
+            TypeRef::StringLiteral(s) => format!("\"{s}\""),
+            TypeRef::NumberLiteral(n) => n.to_string(),
+            TypeRef::BooleanLiteral(b) => b.to_string(),
+            TypeRef::Reference {
+                head,
+                segments,
+                type_args,
+            } => {
+                let mut name = head.clone();
+                for s in segments {
+                    name.push('.');
+                    name.push_str(s);
+                }
+                if type_args.is_empty() {
+                    name
+                } else {
+                    let args = type_args
+                        .iter()
+                        .map(Self::format_ts)
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{name}<{args}>")
+                }
+            }
+            TypeRef::Unresolved(s) => s.clone(),
+        }
+    }
 }
 
 // ─── Function Signatures ─────────────────────────────────────────────
@@ -510,4 +696,90 @@ pub enum RegisteredKind {
     Function,
     Variable,
     Namespace,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_ts_primitives_use_lowercase_keywords() {
+        assert_eq!(TypeRef::String.format_ts(), "string");
+        assert_eq!(TypeRef::Number.format_ts(), "number");
+        assert_eq!(TypeRef::Boolean.format_ts(), "boolean");
+        assert_eq!(TypeRef::Null.format_ts(), "null");
+        assert_eq!(TypeRef::Undefined.format_ts(), "undefined");
+    }
+
+    #[test]
+    fn format_ts_literals_use_their_textual_form() {
+        assert_eq!(TypeRef::StringLiteral("foo".into()).format_ts(), "\"foo\"");
+        assert_eq!(TypeRef::NumberLiteral(32.0).format_ts(), "32");
+        assert_eq!(TypeRef::BooleanLiteral(true).format_ts(), "true");
+    }
+
+    #[test]
+    fn format_ts_union_renders_with_pipes() {
+        let ty = TypeRef::Union(vec![
+            TypeRef::String,
+            TypeRef::ident("ArrayBuffer"),
+            TypeRef::ArrayBufferView,
+        ]);
+        assert_eq!(ty.format_ts(), "string | ArrayBuffer | ArrayBufferView");
+    }
+
+    #[test]
+    fn format_ts_array_wraps_composite_inner_in_parens() {
+        // `(string | number)[]` — without parens this would mean
+        // `string | (number[])`, which is wrong precedence.
+        let ty = TypeRef::Array(Box::new(TypeRef::Union(vec![
+            TypeRef::String,
+            TypeRef::Number,
+        ])));
+        assert_eq!(ty.format_ts(), "(string | number)[]");
+    }
+
+    #[test]
+    fn format_ts_array_simple_inner_no_parens() {
+        let ty = TypeRef::Array(Box::new(TypeRef::String));
+        assert_eq!(ty.format_ts(), "string[]");
+    }
+
+    #[test]
+    fn format_ts_generic_with_inner_union() {
+        let ty = TypeRef::generic(
+            "Array",
+            vec![TypeRef::Union(vec![
+                TypeRef::NumberLiteral(32.0),
+                TypeRef::StringLiteral("foo".into()),
+            ])],
+        );
+        assert_eq!(ty.format_ts(), "Array<32 | \"foo\">");
+    }
+
+    #[test]
+    fn format_ts_qualified_path() {
+        let ty = TypeRef::Reference {
+            head: "A".into(),
+            segments: vec!["B".into(), "C".into()],
+            type_args: vec![],
+        };
+        assert_eq!(ty.format_ts(), "A.B.C");
+    }
+
+    #[test]
+    fn format_ts_qualified_generic() {
+        let ty = TypeRef::Reference {
+            head: "Rpc".into(),
+            segments: vec!["Stub".into()],
+            type_args: vec![TypeRef::ident("Foo")],
+        };
+        assert_eq!(ty.format_ts(), "Rpc.Stub<Foo>");
+    }
+
+    #[test]
+    fn format_ts_nullable() {
+        let ty = TypeRef::Nullable(Box::new(TypeRef::String));
+        assert_eq!(ty.format_ts(), "string | null");
+    }
 }

--- a/src/parse/docs.rs
+++ b/src/parse/docs.rs
@@ -61,12 +61,9 @@ impl JsDocInfo {
         match self.throws.len() {
             0 if self.nothrow => Throws::Never,
             0 => Throws::None,
-            1 => Throws::Type(TypeRef::Named(self.throws[0].clone())),
+            1 => Throws::Type(TypeRef::ident(self.throws[0].clone())),
             _ => Throws::Type(TypeRef::Union(
-                self.throws
-                    .iter()
-                    .map(|n| TypeRef::Named(n.clone()))
-                    .collect(),
+                self.throws.iter().map(TypeRef::ident).collect(),
             )),
         }
     }
@@ -644,7 +641,7 @@ mod tests {
         assert!(!info.nothrow);
         assert_eq!(
             info.throws(),
-            crate::ir::Throws::Type(crate::ir::TypeRef::Named("TypeError".into()))
+            crate::ir::Throws::Type(crate::ir::TypeRef::ident("TypeError"))
         );
     }
 

--- a/src/parse/first_pass/converters.rs
+++ b/src/parse/first_pass/converters.rs
@@ -375,11 +375,13 @@ fn convert_ts_type_from_heritage(
     diag: &mut DiagnosticCollector,
 ) -> ir::TypeRef {
     match expression_to_path(expr) {
-        Some((head, segments)) => ir::TypeRef::Reference {
-            head,
-            segments,
-            type_args: Vec::new(),
-        },
+        Some((head, mut segments)) => {
+            segments.insert(0, head);
+            ir::TypeRef::Reference {
+                segments,
+                generic_args: Vec::new(),
+            }
+        }
         None => {
             diag.warn("Unsupported heritage expression, falling back to Object");
             ir::TypeRef::ident("Object")
@@ -417,11 +419,11 @@ fn convert_ts_type_name_to_ref(type_name: &ast::TSTypeName<'_>) -> ir::TypeRef {
     match type_name {
         ast::TSTypeName::IdentifierReference(ident) => ir::TypeRef::ident(ident.name.to_string()),
         ast::TSTypeName::QualifiedName(qualified) => {
-            let (head, segments) = collect_qualified_path(qualified);
+            let (head, mut segments) = collect_qualified_path(qualified);
+            segments.insert(0, head);
             ir::TypeRef::Reference {
-                head,
                 segments,
-                type_args: Vec::new(),
+                generic_args: Vec::new(),
             }
         }
         ast::TSTypeName::ThisExpression(_) => ir::TypeRef::Unresolved("this".to_string()),

--- a/src/parse/first_pass/converters.rs
+++ b/src/parse/first_pass/converters.rs
@@ -30,7 +30,7 @@ pub fn convert_class_decl(
         .super_class
         .as_ref()
         .and_then(|sc| match expression_to_dotted_name(sc) {
-            Some(name) => Some(ir::TypeRef::Named(name)),
+            Some(name) => Some(ir::TypeRef::ident(name)),
             None => {
                 diag.warn("Complex super class expression is not supported");
                 None
@@ -374,37 +374,75 @@ fn convert_ts_type_from_heritage(
     expr: &ast::Expression<'_>,
     diag: &mut DiagnosticCollector,
 ) -> ir::TypeRef {
-    match expression_to_dotted_name(expr) {
-        Some(name) => ir::TypeRef::Named(name),
+    match expression_to_path(expr) {
+        Some((head, segments)) => ir::TypeRef::Reference {
+            head,
+            segments,
+            type_args: Vec::new(),
+        },
         None => {
             diag.warn("Unsupported heritage expression, falling back to Object");
-            ir::TypeRef::Named("Object".to_string())
+            ir::TypeRef::ident("Object")
         }
     }
 }
 
-/// Extract a dotted name from an expression (e.g., `Foo.Bar.Baz` → `"Foo.Bar.Baz"`).
-pub fn expression_to_dotted_name(expr: &ast::Expression<'_>) -> Option<String> {
+/// Extract a path from an expression: `Foo` → `("Foo", [])`,
+/// `Foo.Bar.Baz` → `("Foo", ["Bar", "Baz"])`. Returns `None` for
+/// expressions that don't form a static dotted name.
+pub fn expression_to_path(expr: &ast::Expression<'_>) -> Option<(String, Vec<String>)> {
     match expr {
-        ast::Expression::Identifier(ident) => Some(ident.name.to_string()),
+        ast::Expression::Identifier(ident) => Some((ident.name.to_string(), Vec::new())),
         ast::Expression::StaticMemberExpression(member) => {
-            let left = expression_to_dotted_name(&member.object)?;
-            Some(format!("{left}.{}", member.property.name))
+            let (head, mut segments) = expression_to_path(&member.object)?;
+            segments.push(member.property.name.to_string());
+            Some((head, segments))
         }
         _ => None,
     }
 }
 
+/// Backwards-compatible helper that flattens a path expression to
+/// dotted form. Prefer [`expression_to_path`] for new code.
+pub fn expression_to_dotted_name(expr: &ast::Expression<'_>) -> Option<String> {
+    let (head, segments) = expression_to_path(expr)?;
+    if segments.is_empty() {
+        Some(head)
+    } else {
+        Some(format!("{}.{}", head, segments.join(".")))
+    }
+}
+
 fn convert_ts_type_name_to_ref(type_name: &ast::TSTypeName<'_>) -> ir::TypeRef {
     match type_name {
-        ast::TSTypeName::IdentifierReference(ident) => ir::TypeRef::Named(ident.name.to_string()),
+        ast::TSTypeName::IdentifierReference(ident) => ir::TypeRef::ident(ident.name.to_string()),
         ast::TSTypeName::QualifiedName(qualified) => {
-            let left = convert_ts_type_name_to_string(&qualified.left);
-            let right = &qualified.right.name;
-            ir::TypeRef::Named(format!("{left}.{right}"))
+            let (head, segments) = collect_qualified_path(qualified);
+            ir::TypeRef::Reference {
+                head,
+                segments,
+                type_args: Vec::new(),
+            }
         }
         ast::TSTypeName::ThisExpression(_) => ir::TypeRef::Unresolved("this".to_string()),
     }
+}
+
+fn collect_qualified_path(q: &ast::TSQualifiedName<'_>) -> (String, Vec<String>) {
+    fn walk(name: &ast::TSTypeName<'_>) -> (String, Vec<String>) {
+        match name {
+            ast::TSTypeName::IdentifierReference(ident) => (ident.name.to_string(), Vec::new()),
+            ast::TSTypeName::QualifiedName(qual) => {
+                let (head, mut segments) = walk(&qual.left);
+                segments.push(qual.right.name.to_string());
+                (head, segments)
+            }
+            ast::TSTypeName::ThisExpression(_) => ("this".to_string(), Vec::new()),
+        }
+    }
+    let (head, mut segments) = walk(&q.left);
+    segments.push(q.right.name.to_string());
+    (head, segments)
 }
 
 /// Debug name for an `ExportDefaultDeclarationKind` variant.
@@ -444,16 +482,4 @@ fn f64_to_i64(
         ));
     }
     result
-}
-
-fn convert_ts_type_name_to_string(type_name: &ast::TSTypeName<'_>) -> String {
-    match type_name {
-        ast::TSTypeName::IdentifierReference(ident) => ident.name.to_string(),
-        ast::TSTypeName::QualifiedName(qualified) => {
-            let left = convert_ts_type_name_to_string(&qualified.left);
-            let right = &qualified.right.name;
-            format!("{left}.{right}")
-        }
-        ast::TSTypeName::ThisExpression(_) => "this".to_string(),
-    }
 }

--- a/src/parse/first_pass/populate.rs
+++ b/src/parse/first_pass/populate.rs
@@ -190,7 +190,7 @@ impl<'a> PopulateCtx<'a> {
                         kind: ir::TypeKind::TypeAlias(ir::TypeAliasDecl {
                             name: exported_name,
                             type_params: vec![],
-                            target: ir::TypeRef::Named(local),
+                            target: ir::TypeRef::ident(local),
                             from_module,
                         }),
                         module_context: ctx.clone(),

--- a/src/parse/literal_union.rs
+++ b/src/parse/literal_union.rs
@@ -207,10 +207,14 @@ pub(crate) fn merge_member_branches(branches: &[Vec<Member>]) -> Vec<Member> {
     out
 }
 
-/// Wrap a sequence of types in `TypeRef::Union` unless they're all
-/// identical — in which case the single type is returned directly. The
-/// regular union resolution (subtyping LUB / `JsValue` erasure) then
-/// applies as usual.
+/// Combine per-property branch types into a single `TypeRef`.
+///
+/// Identical branches collapse to a single type. Otherwise we hand
+/// off to the regular [`simplify_union`] from the parse layer so
+/// `null` / `undefined` arms coalesce into `Nullable<T>` (matching
+/// what users get from a hand-written `T | null` union).
+///
+/// [`simplify_union`]: crate::parse::types::simplify_union
 fn union_member_types(types: impl IntoIterator<Item = TypeRef>) -> TypeRef {
     let mut all: Vec<TypeRef> = types.into_iter().collect();
     if all.is_empty() {
@@ -220,5 +224,5 @@ fn union_member_types(types: impl IntoIterator<Item = TypeRef>) -> TypeRef {
     if all.len() == 1 {
         return all.into_iter().next().unwrap();
     }
-    TypeRef::Union(all)
+    crate::parse::types::simplify_union(all)
 }

--- a/src/parse/members.rs
+++ b/src/parse/members.rs
@@ -158,7 +158,7 @@ fn try_synthesize_inline_param(
                 diag,
             );
             synth.push(iface);
-            Some(TypeRef::Named(synth_name))
+            Some(TypeRef::ident(synth_name))
         }
         TSType::TSUnionType(union) if all_type_literals(&union.types) => {
             let synth_name = unique_type_name(parent_name, segment, used_type_names);
@@ -197,7 +197,7 @@ fn try_synthesize_inline_param(
                 members: merged,
                 classification,
             });
-            Some(TypeRef::Named(synth_name))
+            Some(TypeRef::ident(synth_name))
         }
         _ => None,
     }

--- a/src/parse/types.rs
+++ b/src/parse/types.rs
@@ -169,19 +169,36 @@ pub fn convert_ts_type_scoped(
 }
 
 /// Convert a type reference with type parameter scope.
+///
+/// Most named type references — built-in JS classes, user-declared
+/// types, `Promise<T>`, `Map<K,V>`, qualified paths — flow through
+/// `TypeRef::Reference`. Resolution happens at codegen time against
+/// the scope chain (mirroring TypeScript's name lookup), which means
+/// user declarations shadow built-ins exactly the way they do in TS.
+///
+/// A few constructs *are* desugared at parse time because they're
+/// purely TS utility-type sugar with no JS runtime presence:
+///
+/// * `Boolean` / `Number` / `String` / `Object` / `Symbol` (capital-letter
+///   "wrapper" keyword aliases) → primitive variants.
+/// * `Partial` / `Required` / ... `Awaited` (utility types that don't
+///   produce new runtime types) → identity on their first type argument.
+/// * `Function` (the legacy global `Function` type alias) → an
+///   `(args) => any` function type.
 fn convert_type_reference_scoped(
     type_ref: &TSTypeReference<'_>,
     scope: &TypeParamScope<'_>,
     diag: &mut DiagnosticCollector,
 ) -> TypeRef {
-    let name = type_name_to_string(&type_ref.type_name);
+    let (head, segments) = collect_type_name_path(&type_ref.type_name);
 
-    // If the name is an in-scope type parameter, erase to Any
-    if scope.contains(name.as_str()) {
+    // If the head is an in-scope type parameter, erase to Any.
+    // Qualified paths through type parameters aren't supported either.
+    if scope.contains(head.as_str()) {
         return TypeRef::Any;
     }
 
-    // Collect generic type arguments if present (field is `type_arguments` in oxc 0.118)
+    // Collect generic type arguments if present.
     let type_args: Vec<TypeRef> = type_ref
         .type_arguments
         .as_ref()
@@ -193,94 +210,75 @@ fn convert_type_reference_scoped(
         })
         .unwrap_or_default();
 
-    // Handle well-known generic types
-    match name.as_str() {
-        "Promise" | "PromiseLike" => {
-            let inner = type_args.into_iter().next().unwrap_or(TypeRef::Any);
-            TypeRef::Promise(Box::new(inner))
-        }
-        "Array" | "ReadonlyArray" => {
-            let inner = type_args.into_iter().next().unwrap_or(TypeRef::Any);
-            TypeRef::Array(Box::new(inner))
-        }
-        "Record" => {
-            let mut args = type_args.into_iter();
-            let key = args.next().unwrap_or(TypeRef::String);
-            let value = args.next().unwrap_or(TypeRef::Any);
-            TypeRef::Record(Box::new(key), Box::new(value))
-        }
-        "Map" | "ReadonlyMap" => {
-            let mut args = type_args.into_iter();
-            let key = args.next().unwrap_or(TypeRef::Any);
-            let value = args.next().unwrap_or(TypeRef::Any);
-            TypeRef::Map(Box::new(key), Box::new(value))
-        }
-        "Set" | "ReadonlySet" => {
-            let inner = type_args.into_iter().next().unwrap_or(TypeRef::Any);
-            TypeRef::Set(Box::new(inner))
-        }
+    // For unqualified references, intercept TS-only sugar that
+    // doesn't need to flow through name resolution.
+    if segments.is_empty() {
+        match head.as_str() {
+            // `ArrayBufferView` is a TS-only union alias for the
+            // typed-array family + DataView. There is no JS class
+            // with this name, so it lowers specially at codegen time.
+            "ArrayBufferView" => return TypeRef::ArrayBufferView,
+            // Capital-case aliases for primitives — these read as the
+            // primitive itself in TS, never as the boxed JS class.
+            "Boolean" => return TypeRef::Boolean,
+            "Number" => return TypeRef::Number,
+            "String" => return TypeRef::String,
+            "Object" => return TypeRef::Object,
+            "Symbol" => return TypeRef::Symbol,
 
-        "Int8Array" => TypeRef::Int8Array,
-        "Uint8Array" => TypeRef::Uint8Array,
-        "Uint8ClampedArray" => TypeRef::Uint8ClampedArray,
-        "Int16Array" => TypeRef::Int16Array,
-        "Uint16Array" => TypeRef::Uint16Array,
-        "Int32Array" => TypeRef::Int32Array,
-        "Uint32Array" => TypeRef::Uint32Array,
-        "Float32Array" => TypeRef::Float32Array,
-        "Float64Array" => TypeRef::Float64Array,
-        "BigInt64Array" => TypeRef::BigInt64Array,
-        "BigUint64Array" => TypeRef::BigUint64Array,
-        "ArrayBuffer" | "SharedArrayBuffer" => TypeRef::ArrayBuffer,
-        "ArrayBufferView" => TypeRef::ArrayBufferView,
-        "DataView" => TypeRef::DataView,
-        "Date" => TypeRef::Date,
-        "RegExp" => TypeRef::RegExp,
-        "Error" | "TypeError" | "RangeError" | "SyntaxError" | "DOMException" => TypeRef::Error,
-        "Boolean" => TypeRef::Boolean,
-        "Number" => TypeRef::Number,
-        "String" => TypeRef::String,
-        "Object" => TypeRef::Object,
-        "Symbol" => TypeRef::Symbol,
-        "Function" => TypeRef::Function(crate::ir::FunctionSig {
-            params: vec![],
-            return_type: Box::new(TypeRef::Any),
-        }),
-        "Partial"
-        | "Required"
-        | "Pick"
-        | "Omit"
-        | "Exclude"
-        | "Extract"
-        | "NonNullable"
-        | "ReturnType"
-        | "Parameters"
-        | "ConstructorParameters"
-        | "InstanceType"
-        | "ThisParameterType"
-        | "OmitThisParameter"
-        | "ThisType"
-        | "Awaited" => type_args.into_iter().next().unwrap_or(TypeRef::Object),
-        _ => {
-            if type_args.is_empty() {
-                TypeRef::Named(name)
-            } else {
-                TypeRef::GenericInstantiation(name, type_args)
+            // The legacy global `Function` type — TS treats it as
+            // "any callable", with no fixed signature. We model that
+            // as `(args) => any`.
+            "Function" => {
+                return TypeRef::Function(crate::ir::FunctionSig {
+                    params: vec![],
+                    return_type: Box::new(TypeRef::Any),
+                });
             }
+
+            // TS utility types that resolve to the structure of their
+            // first type argument at type-check time. For our
+            // purposes (FFI types) they're identity on the argument,
+            // or `Object` when there's no useful argument to keep.
+            "Partial"
+            | "Required"
+            | "Pick"
+            | "Omit"
+            | "Exclude"
+            | "Extract"
+            | "NonNullable"
+            | "ReturnType"
+            | "Parameters"
+            | "ConstructorParameters"
+            | "InstanceType"
+            | "ThisParameterType"
+            | "OmitThisParameter"
+            | "ThisType"
+            | "Awaited" => {
+                return type_args.into_iter().next().unwrap_or(TypeRef::Object);
+            }
+            _ => {}
         }
+    }
+
+    TypeRef::Reference {
+        head,
+        segments,
+        type_args,
     }
 }
 
-/// Convert a `TSTypeName` to a string.
-fn type_name_to_string(type_name: &TSTypeName<'_>) -> String {
+/// Convert a `TSTypeName` into its head identifier and any qualified
+/// path segments (`A.B.C` → `("A", ["B", "C"])`).
+fn collect_type_name_path(type_name: &TSTypeName<'_>) -> (String, Vec<String>) {
     match type_name {
-        TSTypeName::IdentifierReference(ident) => ident.name.to_string(),
+        TSTypeName::IdentifierReference(ident) => (ident.name.to_string(), Vec::new()),
         TSTypeName::QualifiedName(qualified) => {
-            let left = type_name_to_string(&qualified.left);
-            let right = &qualified.right.name;
-            format!("{left}.{right}")
+            let (head, mut segments) = collect_type_name_path(&qualified.left);
+            segments.push(qualified.right.name.to_string());
+            (head, segments)
         }
-        TSTypeName::ThisExpression(_) => "this".to_string(),
+        TSTypeName::ThisExpression(_) => ("this".to_string(), Vec::new()),
     }
 }
 
@@ -413,8 +411,16 @@ fn convert_literal_type(lit: &TSLiteralType<'_>, _diag: &mut DiagnosticCollector
     }
 }
 
-/// Simplify a union type.
-fn simplify_union(types: Vec<TypeRef>) -> TypeRef {
+/// Simplify a union type at parse time.
+///
+/// Coalesces `null` / `undefined` arms into the standard
+/// `Nullable<T>` wrapper that the rest of the pipeline understands —
+/// `string | null` and `string | undefined` and
+/// `string | null | undefined` all become `Nullable<String>`.
+///
+/// Used by both the regular `TSUnionType` parsing and the
+/// per-property union merge in `literal_union::union_member_types`.
+pub(crate) fn simplify_union(types: Vec<TypeRef>) -> TypeRef {
     let mut non_null_types = Vec::new();
     let mut has_null = false;
     let mut has_undefined = false;

--- a/src/parse/types.rs
+++ b/src/parse/types.rs
@@ -261,10 +261,11 @@ fn convert_type_reference_scoped(
         }
     }
 
+    let mut path = vec![head];
+    path.extend(segments);
     TypeRef::Reference {
-        head,
-        segments,
-        type_args,
+        segments: path,
+        generic_args: type_args,
     }
 }
 

--- a/src/util/naming.rs
+++ b/src/util/naming.rs
@@ -22,8 +22,55 @@ pub fn module_specifier_to_ident(specifier: &str) -> String {
 /// Does NOT escape Rust keywords — that's handled by `make_ident` at the
 /// codegen boundary using `r#` raw identifiers, so that name composition
 /// (prefixes like `try_`, `set_`, suffixes like `_with_foo`) works correctly.
+/// Convert a JS identifier to Rust `snake_case`.
+///
+/// Departs from `convert_case::Case::Snake` in one place: digits
+/// don't introduce a word boundary when they trail an alphabetic
+/// run. So `Float32Array` → `float32_array` (not `float_32_array`),
+/// `Int8Array` → `int8_array`, `Uint8ClampedArray` →
+/// `uint8_clamped_array`. This matches the historical wasm-bindgen /
+/// `js_sys` naming convention for typed arrays and produces more
+/// readable identifiers in general.
+///
+/// We keep the digit-as-boundary behavior in the *other* direction
+/// — a digit followed by a letter still introduces a boundary
+/// (`HTML5Element` → `html5_element` would still split the `5e`,
+/// matching the standard convention).
 pub fn to_snake_case(name: &str) -> String {
-    name.to_case(Case::Snake)
+    // First pass through `convert_case::Case::Snake` to do the
+    // standard splits (camelCase boundaries, runs of caps, etc.).
+    let standard = name.to_case(Case::Snake);
+
+    // Then merge any `<word>_<digits>(_|$)` back into `<word><digits>`.
+    // The trailing context (`_` or end) ensures we only merge digits
+    // that originally trailed a letter run, not standalone numeric
+    // segments.
+    let bytes = standard.as_bytes();
+    let mut out = String::with_capacity(standard.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        // Look for `<letter>_<digits>` and elide the `_`.
+        if c.is_ascii_alphabetic() && i + 1 < bytes.len() && bytes[i + 1] == b'_' {
+            let mut j = i + 2;
+            while j < bytes.len() && (bytes[j] as char).is_ascii_digit() {
+                j += 1;
+            }
+            // Only merge when the digit run is followed by a word
+            // boundary (`_` or end) — otherwise it's a separate
+            // numeric segment we want to keep separated.
+            let merged_ok = j > i + 2 && (j == bytes.len() || bytes[j] == b'_');
+            if merged_ok {
+                out.push(c);
+                out.push_str(&standard[i + 2..j]);
+                i = j;
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
 }
 
 /// Convert a JS identifier to a Rust PascalCase name (for types, enums).
@@ -69,6 +116,17 @@ mod tests {
         assert_eq!(to_snake_case("getUserById"), "get_user_by_id");
         assert_eq!(to_snake_case("HTMLElement"), "html_element");
         assert_eq!(to_snake_case("send"), "send");
+    }
+
+    #[test]
+    fn test_snake_case_keeps_trailing_digits_with_word() {
+        // Digits trailing a letter run stay attached. This matches
+        // the historical wasm-bindgen typed-array naming convention.
+        assert_eq!(to_snake_case("Float32Array"), "float32_array");
+        assert_eq!(to_snake_case("Int8Array"), "int8_array");
+        assert_eq!(to_snake_case("Uint8ClampedArray"), "uint8_clamped_array");
+        assert_eq!(to_snake_case("BigInt64Array"), "big_int64_array");
+        assert_eq!(to_snake_case("Float64"), "float64");
     }
 
     #[test]

--- a/tests/fixtures/erased-return-doc.d.ts
+++ b/tests/fixtures/erased-return-doc.d.ts
@@ -1,0 +1,31 @@
+// Fixture: when a return-position type contains a union that erases to
+// `JsValue`, codegen appends a `Returns: <ts-shape>` doc line so the
+// caller can still see the original TypeScript shape.
+//
+// Erasing cases (get the doc):
+//   * Mixed-kind unions with no LUB: `string | ArrayBuffer | ArrayBufferView`
+//   * Inner-erased generics: `Array<32 | "foo">`, `Promise<32 | "foo">`
+//
+// Non-erasing cases (no doc):
+//   * Single types
+//   * Literal-widened unions: `"a" | "b"` lowers to `string`
+//   * Named-LUB unions: `TypeError | RangeError` lowers to `Error`
+
+interface Erased {
+  /** Mixed primitives + objects — no LUB, erases to JsValue. */
+  readonly content: string | ArrayBuffer | ArrayBufferView;
+
+  /** Inner-erased generic. */
+  readonly tags: Array<32 | "foo">;
+}
+
+interface NoErasure {
+  /** Literal widening — lowers to `string`, no Returns: line. */
+  readonly variant: "a" | "b";
+
+  /** Plain type — no Returns: line. */
+  readonly name: string;
+}
+
+/** Async function returning erased inner union. */
+declare function fetchValue(): Promise<32 | "foo">;

--- a/tests/snapshots/basic.rs
+++ b/tests/snapshots/basic.rs
@@ -179,7 +179,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "statusText")]
     pub fn set_status_text(this: &ResponseInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &ResponseInit) -> Option<JsValue>;
+    pub fn headers(this: &ResponseInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &ResponseInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]

--- a/tests/snapshots/cloudflare-worker.rs
+++ b/tests/snapshots/cloudflare-worker.rs
@@ -123,7 +123,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_method(this: &RequestInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &RequestInit) -> Option<JsValue>;
+    pub fn headers(this: &RequestInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &RequestInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
@@ -134,7 +134,7 @@ extern "C" {
         val: &Array<ArrayTuple<(JsString, JsString)>>,
     );
     #[wasm_bindgen(method, getter)]
-    pub fn body(this: &RequestInit) -> Option<JsValue>;
+    pub fn body(this: &RequestInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_body(this: &RequestInit, val: &ReadableStream);
     #[wasm_bindgen(method, setter, js_name = "body")]
@@ -336,7 +336,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "statusText")]
     pub fn set_status_text(this: &ResponseInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &ResponseInit) -> Option<JsValue>;
+    pub fn headers(this: &ResponseInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &ResponseInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]

--- a/tests/snapshots/coverage.rs
+++ b/tests/snapshots/coverage.rs
@@ -394,12 +394,14 @@ extern "C" {
     pub fn method(this: &FetchOptions) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_method(this: &FetchOptions, val: &str);
+    #[doc = " Returns: Headers | Record<string, string>"]
     #[wasm_bindgen(method, getter)]
     pub fn headers(this: &FetchOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &FetchOptions, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &FetchOptions, val: &Object<JsString>);
+    #[doc = " Returns: string | ArrayBuffer | null"]
     #[wasm_bindgen(method, getter)]
     pub fn body(this: &FetchOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -560,6 +562,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type MutableWidget;
+    #[doc = " Returns: string | number"]
     #[wasm_bindgen(method, getter)]
     pub fn label(this: &MutableWidget) -> JsValue;
     #[wasm_bindgen(method, setter)]

--- a/tests/snapshots/coverage.rs
+++ b/tests/snapshots/coverage.rs
@@ -394,16 +394,16 @@ extern "C" {
     pub fn method(this: &FetchOptions) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_method(this: &FetchOptions, val: &str);
-    #[doc = " Returns: Headers | Record<string, string>"]
+    #[doc = " Returns: Headers | Record<string, string> | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &FetchOptions) -> Option<JsValue>;
+    pub fn headers(this: &FetchOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &FetchOptions, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &FetchOptions, val: &Object<JsString>);
     #[doc = " Returns: string | ArrayBuffer | null"]
     #[wasm_bindgen(method, getter)]
-    pub fn body(this: &FetchOptions) -> Option<JsValue>;
+    pub fn body(this: &FetchOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_body(this: &FetchOptions, val: &str);
     #[wasm_bindgen(method, setter, js_name = "body")]
@@ -519,7 +519,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_tag(this: &NotificationOptions, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn data(this: &NotificationOptions) -> Option<JsValue>;
+    pub fn data(this: &NotificationOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_data(this: &NotificationOptions, val: &JsValue);
 }

--- a/tests/snapshots/erased-return-doc.rs
+++ b/tests/snapshots/erased-return-doc.rs
@@ -1,0 +1,58 @@
+#[allow(unused_imports)]
+use js_sys::*;
+#[allow(unused_imports)]
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = Object)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type Erased;
+    #[doc = " Mixed primitives + objects — no LUB, erases to JsValue."]
+    #[doc = ""]
+    #[doc = " Returns: string | ArrayBuffer | ArrayBufferView"]
+    #[wasm_bindgen(method, getter)]
+    pub fn content(this: &Erased) -> JsValue;
+    #[doc = " Inner-erased generic."]
+    #[doc = ""]
+    #[doc = " Returns: Array<32 | \"foo\">"]
+    #[wasm_bindgen(method, getter)]
+    pub fn tags(this: &Erased) -> Array;
+}
+impl Erased {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        #[allow(unused_unsafe)]
+        unsafe {
+            JsValue::from(js_sys::Object::new()).unchecked_into()
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = Object)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type NoErasure;
+    #[doc = " Literal widening — lowers to `string`, no Returns: line."]
+    #[wasm_bindgen(method, getter)]
+    pub fn variant(this: &NoErasure) -> String;
+    #[doc = " Plain type — no Returns: line."]
+    #[wasm_bindgen(method, getter)]
+    pub fn name(this: &NoErasure) -> String;
+}
+impl NoErasure {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        #[allow(unused_unsafe)]
+        unsafe {
+            JsValue::from(js_sys::Object::new()).unchecked_into()
+        }
+    }
+}
+#[wasm_bindgen]
+extern "C" {
+    #[doc = " Async function returning erased inner union."]
+    #[doc = ""]
+    #[doc = " Returns: 32 | \"foo\""]
+    #[wasm_bindgen(catch, js_name = "fetchValue")]
+    pub async fn fetch_value() -> Result<JsValue, JsValue>;
+}

--- a/tests/snapshots/node-console.rs
+++ b/tests/snapshots/node-console.rs
@@ -34,7 +34,7 @@ pub mod console {
         #[doc = ""]
         #[doc = " Returns: boolean | string | null"]
         #[wasm_bindgen(method, getter, js_name = "colorMode")]
-        pub fn color_mode(this: &ConsoleOptions) -> Option<JsValue>;
+        pub fn color_mode(this: &ConsoleOptions) -> JsValue;
         #[wasm_bindgen(method, setter, js_name = "colorMode")]
         pub fn set_color_mode(this: &ConsoleOptions, val: bool);
         #[wasm_bindgen(method, setter, js_name = "colorMode")]

--- a/tests/snapshots/node-console.rs
+++ b/tests/snapshots/node-console.rs
@@ -31,6 +31,8 @@ pub mod console {
         pub fn set_ignore_errors_with_null(this: &ConsoleOptions, val: &Null);
         #[doc = " Set color support for this `Console` instance."]
         #[doc = " @default 'auto'"]
+        #[doc = ""]
+        #[doc = " Returns: boolean | string | null"]
         #[wasm_bindgen(method, getter, js_name = "colorMode")]
         pub fn color_mode(this: &ConsoleOptions) -> Option<JsValue>;
         #[wasm_bindgen(method, setter, js_name = "colorMode")]

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -75,8 +75,6 @@ use JsValue as R;
 #[allow(dead_code)]
 use JsValue as Readonly;
 #[allow(dead_code)]
-use JsValue as Record;
-#[allow(dead_code)]
 use JsValue as RequestInfo;
 #[allow(dead_code)]
 use JsValue as T;
@@ -1123,7 +1121,7 @@ extern "C" {
         input: &URL,
     ) -> Result<Response, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "fetch")]
-    pub async fn fetch_with_js_value_and_init(
+    pub async fn fetch_with_request_and_init(
         this: &ServiceWorkerGlobalScope,
         input: &Request,
         init: &RequestInit,
@@ -1697,7 +1695,7 @@ extern "C" {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(catch, js_name = "fetch")]
-    pub async fn fetch_with_js_value_and_init(
+    pub async fn fetch_with_request_and_init(
         input: &Request,
         init: &RequestInit,
     ) -> Result<Response, JsValue>;
@@ -1945,9 +1943,13 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "sendBeacon")]
     pub fn try_send_beacon(this: &Navigator, url: &str) -> Result<bool, JsValue>;
     #[wasm_bindgen(method, js_name = "sendBeacon")]
-    pub fn send_beacon_with_js_value(this: &Navigator, url: &str, body: &ReadableStream) -> bool;
+    pub fn send_beacon_with_readable_stream(
+        this: &Navigator,
+        url: &str,
+        body: &ReadableStream,
+    ) -> bool;
     #[wasm_bindgen(method, catch, js_name = "sendBeacon")]
-    pub fn try_send_beacon_with_js_value(
+    pub fn try_send_beacon_with_readable_stream(
         this: &Navigator,
         url: &str,
         body: &ReadableStream,
@@ -2005,17 +2007,21 @@ extern "C" {
         body: &FormData,
     ) -> Result<bool, JsValue>;
     #[wasm_bindgen(method, js_name = "sendBeacon")]
-    pub fn send_beacon_with_js_value_1(this: &Navigator, url: &str, body: &Iterable) -> bool;
+    pub fn send_beacon_with_iterable(this: &Navigator, url: &str, body: &Iterable) -> bool;
     #[wasm_bindgen(method, catch, js_name = "sendBeacon")]
-    pub fn try_send_beacon_with_js_value_1(
+    pub fn try_send_beacon_with_iterable(
         this: &Navigator,
         url: &str,
         body: &Iterable,
     ) -> Result<bool, JsValue>;
     #[wasm_bindgen(method, js_name = "sendBeacon")]
-    pub fn send_beacon_with_js_value_2(this: &Navigator, url: &str, body: &AsyncIterable) -> bool;
+    pub fn send_beacon_with_async_iterable(
+        this: &Navigator,
+        url: &str,
+        body: &AsyncIterable,
+    ) -> bool;
     #[wasm_bindgen(method, catch, js_name = "sendBeacon")]
-    pub fn try_send_beacon_with_js_value_2(
+    pub fn try_send_beacon_with_async_iterable(
         this: &Navigator,
         url: &str,
         body: &AsyncIterable,
@@ -2070,8 +2076,10 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type DurableObject;
+    #[doc = " Returns: Response | Promise<Response>"]
     #[wasm_bindgen(method)]
     pub fn fetch(this: &DurableObject, request: &Request) -> JsValue;
+    #[doc = " Returns: Response | Promise<Response>"]
     #[wasm_bindgen(method, catch, js_name = "fetch")]
     pub fn try_fetch(this: &DurableObject, request: &Request) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method)]
@@ -3052,6 +3060,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AnalyticsEngineDataPoint;
+    #[doc = " Returns: (ArrayBuffer | string | null)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn indexes(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -3060,6 +3069,7 @@ extern "C" {
     pub fn doubles(this: &AnalyticsEngineDataPoint) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_doubles(this: &AnalyticsEngineDataPoint, val: &Array<Number>);
+    #[doc = " Returns: (ArrayBuffer | string | null)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn blobs(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -3999,7 +4009,7 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "delete")]
     pub async fn delete_with_url(this: &Cache, request: &URL) -> Result<Boolean, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "delete")]
-    pub async fn delete_with_js_value_and_options(
+    pub async fn delete_with_request_and_options(
         this: &Cache,
         request: &Request,
         options: &CacheQueryOptions,
@@ -4025,7 +4035,7 @@ extern "C" {
     pub async fn match_with_url(this: &Cache, request: &URL)
         -> Result<JsOption<Response>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "match")]
-    pub async fn match_with_js_value_and_options(
+    pub async fn match_with_request_and_options(
         this: &Cache,
         request: &Request,
         options: &CacheQueryOptions,
@@ -4383,6 +4393,8 @@ extern "C" {
     #[doc = " The **`generateKey()`** method of the SubtleCrypto interface is used to generate a new key (for symmetric algorithms) or key pair (for public-key algorithms)."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)"]
+    #[doc = ""]
+    #[doc = " Returns: CryptoKey | CryptoKeyPair"]
     #[wasm_bindgen(method, catch, js_name = "generateKey")]
     pub async fn generate_key(
         this: &SubtleCrypto,
@@ -4393,6 +4405,8 @@ extern "C" {
     #[doc = " The **`generateKey()`** method of the SubtleCrypto interface is used to generate a new key (for symmetric algorithms) or key pair (for public-key algorithms)."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey)"]
+    #[doc = ""]
+    #[doc = " Returns: CryptoKey | CryptoKeyPair"]
     #[wasm_bindgen(method, catch, js_name = "generateKey")]
     pub async fn generate_key_with_subtle_crypto_generate_key_algorithm(
         this: &SubtleCrypto,
@@ -4581,6 +4595,8 @@ extern "C" {
     #[doc = " The **`exportKey()`** method of the SubtleCrypto interface exports a key: that is, it takes as input a CryptoKey object and gives you the key in an external, portable format."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey)"]
+    #[doc = ""]
+    #[doc = " Returns: ArrayBuffer | JsonWebKey"]
     #[wasm_bindgen(method, catch, js_name = "exportKey")]
     pub async fn export_key(
         this: &SubtleCrypto,
@@ -4784,6 +4800,8 @@ extern "C" {
     #[doc = " The read-only **`algorithm`** property of the CryptoKey interface returns an object describing the algorithm for which this key can be used, and any associated extra parameters."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/CryptoKey/algorithm)"]
+    #[doc = ""]
+    #[doc = " Returns: CryptoKeyKeyAlgorithm | CryptoKeyAesKeyAlgorithm | CryptoKeyHmacKeyAlgorithm | CryptoKeyRsaKeyAlgorithm | CryptoKeyEllipticKeyAlgorithm | CryptoKeyArbitraryKeyAlgorithm"]
     #[wasm_bindgen(method, getter)]
     pub fn algorithm(this: &CryptoKey) -> JsValue;
     #[doc = " The read-only **`usages`** property of the CryptoKey interface indicates what can be done with the key."]
@@ -5035,6 +5053,7 @@ extern "C" {
     pub fn name(this: &SubtleCryptoDeriveKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoDeriveKeyAlgorithm, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn salt(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5048,6 +5067,7 @@ extern "C" {
     pub fn iterations(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_iterations(this: &SubtleCryptoDeriveKeyAlgorithm, val: f64);
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
     #[wasm_bindgen(method, getter)]
     pub fn hash(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5061,6 +5081,7 @@ extern "C" {
     pub fn public(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<CryptoKey>;
     #[wasm_bindgen(method, setter)]
     pub fn set_public(this: &SubtleCryptoDeriveKeyAlgorithm, val: &CryptoKey);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn info(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5130,6 +5151,7 @@ extern "C" {
     pub fn name(this: &SubtleCryptoEncryptAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoEncryptAlgorithm, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn iv(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5139,6 +5161,7 @@ extern "C" {
         this: &SubtleCryptoEncryptAlgorithm,
         val: &T,
     );
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter, js_name = "additionalData")]
     pub fn additional_data(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "additionalData")]
@@ -5152,6 +5175,7 @@ extern "C" {
     pub fn tag_length(this: &SubtleCryptoEncryptAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter, js_name = "tagLength")]
     pub fn set_tag_length(this: &SubtleCryptoEncryptAlgorithm, val: f64);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn counter(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5165,6 +5189,7 @@ extern "C" {
     pub fn length(this: &SubtleCryptoEncryptAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_length(this: &SubtleCryptoEncryptAlgorithm, val: f64);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn label(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5242,6 +5267,7 @@ extern "C" {
     pub fn name(this: &SubtleCryptoGenerateKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoGenerateKeyAlgorithm, val: &str);
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
     #[wasm_bindgen(method, getter)]
     pub fn hash(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5255,6 +5281,7 @@ extern "C" {
     pub fn modulus_length(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter, js_name = "modulusLength")]
     pub fn set_modulus_length(this: &SubtleCryptoGenerateKeyAlgorithm, val: f64);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter, js_name = "publicExponent")]
     pub fn public_exponent(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "publicExponent")]
@@ -5345,6 +5372,7 @@ extern "C" {
     pub fn name(this: &SubtleCryptoImportKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoImportKeyAlgorithm, val: &str);
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
     #[wasm_bindgen(method, getter)]
     pub fn hash(this: &SubtleCryptoImportKeyAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5414,6 +5442,7 @@ extern "C" {
     pub fn name(this: &SubtleCryptoSignAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoSignAlgorithm, val: &str);
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
     #[wasm_bindgen(method, getter)]
     pub fn hash(this: &SubtleCryptoSignAlgorithm) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -5545,6 +5574,7 @@ extern "C" {
     pub fn modulus_length(this: &CryptoKeyRsaKeyAlgorithm) -> f64;
     #[wasm_bindgen(method, setter, js_name = "modulusLength")]
     pub fn set_modulus_length(this: &CryptoKeyRsaKeyAlgorithm, val: f64);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter, js_name = "publicExponent")]
     pub fn public_exponent(this: &CryptoKeyRsaKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "publicExponent")]
@@ -5696,6 +5726,7 @@ extern "C" {
     ) -> Result<DigestStream, JsValue>;
     #[wasm_bindgen(method, getter)]
     pub fn digest(this: &DigestStream) -> Promise<ArrayBuffer>;
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "bytesWritten")]
     pub fn bytes_written(this: &DigestStream) -> JsValue;
 }
@@ -6041,6 +6072,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type MessageEventInit;
+    #[doc = " Returns: ArrayBuffer | string"]
     #[wasm_bindgen(method, getter)]
     pub fn data(this: &MessageEventInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -6131,21 +6163,29 @@ extern "C" {
     #[doc = " The **`get()`** method of the FormData interface returns the first value associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get)"]
+    #[doc = ""]
+    #[doc = " Returns: File | string | null"]
     #[wasm_bindgen(method)]
     pub fn get(this: &FormData, name: &str) -> Option<JsValue>;
     #[doc = " The **`get()`** method of the FormData interface returns the first value associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get)"]
+    #[doc = ""]
+    #[doc = " Returns: File | string | null"]
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub fn try_get(this: &FormData, name: &str) -> Result<Option<JsValue>, JsValue>;
     #[doc = " The **`getAll()`** method of the FormData interface returns all the values associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll)"]
+    #[doc = ""]
+    #[doc = " Returns: (File | string)[]"]
     #[wasm_bindgen(method, js_name = "getAll")]
     pub fn get_all(this: &FormData, name: &str) -> Array;
     #[doc = " The **`getAll()`** method of the FormData interface returns all the values associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll)"]
+    #[doc = ""]
+    #[doc = " Returns: (File | string)[]"]
     #[wasm_bindgen(method, catch, js_name = "getAll")]
     pub fn try_get_all(this: &FormData, name: &str) -> Result<Array, JsValue>;
     #[doc = " The **`has()`** method of the FormData interface returns whether a `FormData` object contains a certain key."]
@@ -6193,16 +6233,20 @@ extern "C" {
         value: &Blob,
         filename: &str,
     ) -> Result<(), JsValue>;
+    #[doc = " Returns: IterableIterator<[string, File | string]>"]
     #[wasm_bindgen(method)]
     pub fn entries(this: &FormData) -> IterableIterator;
+    #[doc = " Returns: IterableIterator<[string, File | string]>"]
     #[wasm_bindgen(method, catch, js_name = "entries")]
     pub fn try_entries(this: &FormData) -> Result<IterableIterator, JsValue>;
     #[wasm_bindgen(method)]
     pub fn keys(this: &FormData) -> IterableIterator;
     #[wasm_bindgen(method, catch, js_name = "keys")]
     pub fn try_keys(this: &FormData) -> Result<IterableIterator, JsValue>;
+    #[doc = " Returns: IterableIterator<File | string>"]
     #[wasm_bindgen(method)]
     pub fn values(this: &FormData) -> IterableIterator;
+    #[doc = " Returns: IterableIterator<File | string>"]
     #[wasm_bindgen(method, catch, js_name = "values")]
     pub fn try_values(this: &FormData) -> Result<IterableIterator, JsValue>;
     #[wasm_bindgen(method, js_name = "forEach")]
@@ -7174,7 +7218,7 @@ extern "C" {
     #[wasm_bindgen(constructor, catch, js_name = "Headers")]
     pub fn new_with_headers(init: &Headers) -> Result<Headers, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Headers")]
-    pub fn new_with_js_value(init: &Iterable) -> Result<Headers, JsValue>;
+    pub fn new_with_iterable(init: &Iterable) -> Result<Headers, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Headers")]
     pub fn new_with_record(init: &Object<JsString>) -> Result<Headers, JsValue>;
     #[doc = " The **`get()`** method of the Headers interface returns a byte string of all the values of a header within a `Headers` object with a given name."]
@@ -7308,7 +7352,7 @@ extern "C" {
     #[wasm_bindgen(constructor, catch)]
     pub fn new() -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value(body: &ReadableStream) -> Result<Response, JsValue>;
+    pub fn new_with_readable_stream(body: &ReadableStream) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
     pub fn new_with_str(body: &str) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
@@ -7322,13 +7366,13 @@ extern "C" {
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
     pub fn new_with_form_data(body: &FormData) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value_1(body: &Iterable) -> Result<Response, JsValue>;
+    pub fn new_with_iterable(body: &Iterable) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value_2(body: &AsyncIterable) -> Result<Response, JsValue>;
+    pub fn new_with_async_iterable(body: &AsyncIterable) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
     pub fn new_with_null(body: &Null) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value_and_init(
+    pub fn new_with_readable_stream_and_init(
         body: &ReadableStream,
         init: &ResponseInit,
     ) -> Result<Response, JsValue>;
@@ -7357,12 +7401,12 @@ extern "C" {
         init: &ResponseInit,
     ) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value_and_init_1(
+    pub fn new_with_iterable_and_init(
         body: &Iterable,
         init: &ResponseInit,
     ) -> Result<Response, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Response")]
-    pub fn new_with_js_value_and_init_2(
+    pub fn new_with_async_iterable_and_init(
         body: &AsyncIterable,
         init: &ResponseInit,
     ) -> Result<Response, JsValue>;
@@ -7488,7 +7532,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &ResponseInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
-    pub fn set_headers_with_js_value(this: &ResponseInit, val: &Iterable);
+    pub fn set_headers_with_iterable(this: &ResponseInit, val: &Iterable);
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &ResponseInit, val: &Object<JsString>);
     #[wasm_bindgen(method, getter)]
@@ -7532,8 +7576,8 @@ impl ResponseInitBuilder {
         self.inner.set_headers(val);
         self
     }
-    pub fn headers_with_js_value(self, val: &Iterable) -> Self {
-        self.inner.set_headers_with_js_value(val);
+    pub fn headers_with_iterable(self, val: &Iterable) -> Self {
+        self.inner.set_headers_with_iterable(val);
         self
     }
     pub fn headers_with_record(self, val: &Object<JsString>) -> Self {
@@ -7572,7 +7616,7 @@ extern "C" {
     #[wasm_bindgen(constructor, catch, js_name = "Request")]
     pub fn new_with_url(input: &URL) -> Result<Request, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "Request")]
-    pub fn new_with_js_value_and_init(
+    pub fn new_with_request_info_and_init(
         input: &RequestInfo,
         init: &RequestInit,
     ) -> Result<Request, JsValue>;
@@ -7669,7 +7713,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &RequestInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
-    pub fn set_headers_with_js_value(this: &RequestInit, val: &Iterable);
+    pub fn set_headers_with_iterable(this: &RequestInit, val: &Iterable);
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &RequestInit, val: &Object<JsString>);
     #[wasm_bindgen(method, getter)]
@@ -7689,9 +7733,9 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "body")]
     pub fn set_body_with_form_data(this: &RequestInit, val: &FormData);
     #[wasm_bindgen(method, setter, js_name = "body")]
-    pub fn set_body_with_js_value(this: &RequestInit, val: &Iterable);
+    pub fn set_body_with_iterable(this: &RequestInit, val: &Iterable);
     #[wasm_bindgen(method, setter, js_name = "body")]
-    pub fn set_body_with_js_value_1(this: &RequestInit, val: &AsyncIterable);
+    pub fn set_body_with_async_iterable(this: &RequestInit, val: &AsyncIterable);
     #[wasm_bindgen(method, setter, js_name = "body")]
     pub fn set_body_with_null(this: &RequestInit, val: &Null);
     #[wasm_bindgen(method, getter)]
@@ -7749,8 +7793,8 @@ impl RequestInitBuilder {
         self.inner.set_headers(val);
         self
     }
-    pub fn headers_with_js_value(self, val: &Iterable) -> Self {
-        self.inner.set_headers_with_js_value(val);
+    pub fn headers_with_iterable(self, val: &Iterable) -> Self {
+        self.inner.set_headers_with_iterable(val);
         self
     }
     pub fn headers_with_record(self, val: &Object<JsString>) -> Self {
@@ -7785,12 +7829,12 @@ impl RequestInitBuilder {
         self.inner.set_body_with_form_data(val);
         self
     }
-    pub fn body_with_js_value(self, val: &Iterable) -> Self {
-        self.inner.set_body_with_js_value(val);
+    pub fn body_with_iterable(self, val: &Iterable) -> Self {
+        self.inner.set_body_with_iterable(val);
         self
     }
-    pub fn body_with_js_value_1(self, val: &AsyncIterable) -> Self {
-        self.inner.set_body_with_js_value_1(val);
+    pub fn body_with_async_iterable(self, val: &AsyncIterable) -> Self {
+        self.inner.set_body_with_async_iterable(val);
         self
     }
     pub fn body_with_null(self, val: &Null) -> Self {
@@ -8656,7 +8700,7 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "get")]
     pub async fn get_1(this: &R2Bucket, key: &str) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
-    pub async fn get_with_r_2_get_options(
+    pub async fn get_with_r2_get_options(
         this: &R2Bucket,
         key: &str,
         options: &R2GetOptions,
@@ -8740,42 +8784,42 @@ extern "C" {
         options: &JsValue,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_readable_stream_and_r_2_put_options(
+    pub async fn put_with_readable_stream_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &ReadableStream,
         options: &R2PutOptions,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_array_buffer_and_r_2_put_options(
+    pub async fn put_with_array_buffer_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &ArrayBuffer,
         options: &R2PutOptions,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_typed_array_and_r_2_put_options(
+    pub async fn put_with_typed_array_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &Object,
         options: &R2PutOptions,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_str_and_r_2_put_options(
+    pub async fn put_with_str_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &str,
         options: &R2PutOptions,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_blob_and_r_2_put_options(
+    pub async fn put_with_blob_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &Blob,
         options: &R2PutOptions,
     ) -> Result<JsOption<R2Object>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "put")]
-    pub async fn put_with_null_and_r_2_put_options(
+    pub async fn put_with_null_and_r2_put_options(
         this: &R2Bucket,
         key: &str,
         value: &Null,
@@ -8951,7 +8995,7 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = "storageClass")]
     pub fn storage_class(this: &R2Object) -> String;
     #[wasm_bindgen(method, getter, js_name = "ssecKeyMd5")]
-    pub fn ssec_key_md_5(this: &R2Object) -> Option<String>;
+    pub fn ssec_key_md5(this: &R2Object) -> Option<String>;
     #[wasm_bindgen(method, js_name = "writeHttpMetadata")]
     pub fn write_http_metadata(this: &R2Object, headers: &Headers);
     #[wasm_bindgen(method, catch, js_name = "writeHttpMetadata")]
@@ -9094,18 +9138,21 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2GetOptions;
+    #[doc = " Returns: R2Conditional | Headers"]
     #[wasm_bindgen(method, getter, js_name = "onlyIf")]
     pub fn only_if(this: &R2GetOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if(this: &R2GetOptions, val: &R2Conditional);
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if_with_headers(this: &R2GetOptions, val: &Headers);
+    #[doc = " Returns: R2Range | Headers"]
     #[wasm_bindgen(method, getter)]
     pub fn range(this: &R2GetOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
     pub fn set_range(this: &R2GetOptions, val: &R2Range);
     #[wasm_bindgen(method, setter, js_name = "range")]
     pub fn set_range_with_headers(this: &R2GetOptions, val: &Headers);
+    #[doc = " Returns: ArrayBuffer | string"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
     pub fn ssec_key(this: &R2GetOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9160,12 +9207,14 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2PutOptions;
+    #[doc = " Returns: R2Conditional | Headers"]
     #[wasm_bindgen(method, getter, js_name = "onlyIf")]
     pub fn only_if(this: &R2PutOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if(this: &R2PutOptions, val: &R2Conditional);
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if_with_headers(this: &R2PutOptions, val: &Headers);
+    #[doc = " Returns: R2HTTPMetadata | Headers"]
     #[wasm_bindgen(method, getter, js_name = "httpMetadata")]
     pub fn http_metadata(this: &R2PutOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
@@ -9176,50 +9225,56 @@ extern "C" {
     pub fn custom_metadata(this: &R2PutOptions) -> Option<Object<JsString>>;
     #[wasm_bindgen(method, setter, js_name = "customMetadata")]
     pub fn set_custom_metadata(this: &R2PutOptions, val: &Object<JsString>);
-    #[wasm_bindgen(method, getter, js_name = "md5")]
-    pub fn md_5(this: &R2PutOptions) -> Option<JsValue>;
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[wasm_bindgen(method, getter)]
+    pub fn md5(this: &R2PutOptions) -> Option<JsValue>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_md5(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "md5")]
-    pub fn set_md_5(this: &R2PutOptions, val: &ArrayBuffer);
+    pub fn set_md5_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "md5")]
-    pub fn set_md_5_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
-    #[wasm_bindgen(method, setter, js_name = "md5")]
-    pub fn set_md_5_with_str(this: &R2PutOptions, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha1")]
-    pub fn sha_1(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn set_md5_with_str(this: &R2PutOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[wasm_bindgen(method, getter)]
+    pub fn sha1(this: &R2PutOptions) -> Option<JsValue>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha1(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha1")]
-    pub fn set_sha_1(this: &R2PutOptions, val: &ArrayBuffer);
+    pub fn set_sha1_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha1")]
-    pub fn set_sha_1_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
-    #[wasm_bindgen(method, setter, js_name = "sha1")]
-    pub fn set_sha_1_with_str(this: &R2PutOptions, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha256")]
-    pub fn sha_256(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn set_sha1_with_str(this: &R2PutOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[wasm_bindgen(method, getter)]
+    pub fn sha256(this: &R2PutOptions) -> Option<JsValue>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha256(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha256")]
-    pub fn set_sha_256(this: &R2PutOptions, val: &ArrayBuffer);
+    pub fn set_sha256_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha256")]
-    pub fn set_sha_256_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
-    #[wasm_bindgen(method, setter, js_name = "sha256")]
-    pub fn set_sha_256_with_str(this: &R2PutOptions, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha384")]
-    pub fn sha_384(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn set_sha256_with_str(this: &R2PutOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[wasm_bindgen(method, getter)]
+    pub fn sha384(this: &R2PutOptions) -> Option<JsValue>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha384(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha384")]
-    pub fn set_sha_384(this: &R2PutOptions, val: &ArrayBuffer);
+    pub fn set_sha384_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha384")]
-    pub fn set_sha_384_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
-    #[wasm_bindgen(method, setter, js_name = "sha384")]
-    pub fn set_sha_384_with_str(this: &R2PutOptions, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha512")]
-    pub fn sha_512(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn set_sha384_with_str(this: &R2PutOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[wasm_bindgen(method, getter)]
+    pub fn sha512(this: &R2PutOptions) -> Option<JsValue>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha512(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha512")]
-    pub fn set_sha_512(this: &R2PutOptions, val: &ArrayBuffer);
+    pub fn set_sha512_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha512")]
-    pub fn set_sha_512_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
-    #[wasm_bindgen(method, setter, js_name = "sha512")]
-    pub fn set_sha_512_with_str(this: &R2PutOptions, val: &str);
+    pub fn set_sha512_with_str(this: &R2PutOptions, val: &str);
     #[wasm_bindgen(method, getter, js_name = "storageClass")]
     pub fn storage_class(this: &R2PutOptions) -> Option<String>;
     #[wasm_bindgen(method, setter, js_name = "storageClass")]
     pub fn set_storage_class(this: &R2PutOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | string"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
     pub fn ssec_key(this: &R2PutOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9261,64 +9316,64 @@ impl R2PutOptionsBuilder {
         self.inner.set_custom_metadata(val);
         self
     }
-    pub fn md_5(self, val: &ArrayBuffer) -> Self {
-        self.inner.set_md_5(val);
+    pub fn md5(self, val: &ArrayBuffer) -> Self {
+        self.inner.set_md5(val);
         self
     }
-    pub fn md_5_with_typed_array(self, val: &Object) -> Self {
-        self.inner.set_md_5_with_typed_array(val);
+    pub fn md5_with_typed_array(self, val: &Object) -> Self {
+        self.inner.set_md5_with_typed_array(val);
         self
     }
-    pub fn md_5_with_str(self, val: &str) -> Self {
-        self.inner.set_md_5_with_str(val);
+    pub fn md5_with_str(self, val: &str) -> Self {
+        self.inner.set_md5_with_str(val);
         self
     }
-    pub fn sha_1(self, val: &ArrayBuffer) -> Self {
-        self.inner.set_sha_1(val);
+    pub fn sha1(self, val: &ArrayBuffer) -> Self {
+        self.inner.set_sha1(val);
         self
     }
-    pub fn sha_1_with_typed_array(self, val: &Object) -> Self {
-        self.inner.set_sha_1_with_typed_array(val);
+    pub fn sha1_with_typed_array(self, val: &Object) -> Self {
+        self.inner.set_sha1_with_typed_array(val);
         self
     }
-    pub fn sha_1_with_str(self, val: &str) -> Self {
-        self.inner.set_sha_1_with_str(val);
+    pub fn sha1_with_str(self, val: &str) -> Self {
+        self.inner.set_sha1_with_str(val);
         self
     }
-    pub fn sha_256(self, val: &ArrayBuffer) -> Self {
-        self.inner.set_sha_256(val);
+    pub fn sha256(self, val: &ArrayBuffer) -> Self {
+        self.inner.set_sha256(val);
         self
     }
-    pub fn sha_256_with_typed_array(self, val: &Object) -> Self {
-        self.inner.set_sha_256_with_typed_array(val);
+    pub fn sha256_with_typed_array(self, val: &Object) -> Self {
+        self.inner.set_sha256_with_typed_array(val);
         self
     }
-    pub fn sha_256_with_str(self, val: &str) -> Self {
-        self.inner.set_sha_256_with_str(val);
+    pub fn sha256_with_str(self, val: &str) -> Self {
+        self.inner.set_sha256_with_str(val);
         self
     }
-    pub fn sha_384(self, val: &ArrayBuffer) -> Self {
-        self.inner.set_sha_384(val);
+    pub fn sha384(self, val: &ArrayBuffer) -> Self {
+        self.inner.set_sha384(val);
         self
     }
-    pub fn sha_384_with_typed_array(self, val: &Object) -> Self {
-        self.inner.set_sha_384_with_typed_array(val);
+    pub fn sha384_with_typed_array(self, val: &Object) -> Self {
+        self.inner.set_sha384_with_typed_array(val);
         self
     }
-    pub fn sha_384_with_str(self, val: &str) -> Self {
-        self.inner.set_sha_384_with_str(val);
+    pub fn sha384_with_str(self, val: &str) -> Self {
+        self.inner.set_sha384_with_str(val);
         self
     }
-    pub fn sha_512(self, val: &ArrayBuffer) -> Self {
-        self.inner.set_sha_512(val);
+    pub fn sha512(self, val: &ArrayBuffer) -> Self {
+        self.inner.set_sha512(val);
         self
     }
-    pub fn sha_512_with_typed_array(self, val: &Object) -> Self {
-        self.inner.set_sha_512_with_typed_array(val);
+    pub fn sha512_with_typed_array(self, val: &Object) -> Self {
+        self.inner.set_sha512_with_typed_array(val);
         self
     }
-    pub fn sha_512_with_str(self, val: &str) -> Self {
-        self.inner.set_sha_512_with_str(val);
+    pub fn sha512_with_str(self, val: &str) -> Self {
+        self.inner.set_sha512_with_str(val);
         self
     }
     pub fn storage_class(self, val: &str) -> Self {
@@ -9342,6 +9397,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2MultipartOptions;
+    #[doc = " Returns: R2HTTPMetadata | Headers"]
     #[wasm_bindgen(method, getter, js_name = "httpMetadata")]
     pub fn http_metadata(this: &R2MultipartOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
@@ -9356,6 +9412,7 @@ extern "C" {
     pub fn storage_class(this: &R2MultipartOptions) -> Option<String>;
     #[wasm_bindgen(method, setter, js_name = "storageClass")]
     pub fn set_storage_class(this: &R2MultipartOptions, val: &str);
+    #[doc = " Returns: ArrayBuffer | string"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
     pub fn ssec_key(this: &R2MultipartOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9410,16 +9467,16 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Checksums;
-    #[wasm_bindgen(method, getter, js_name = "md5")]
-    pub fn md_5(this: &R2Checksums) -> Option<ArrayBuffer>;
-    #[wasm_bindgen(method, getter, js_name = "sha1")]
-    pub fn sha_1(this: &R2Checksums) -> Option<ArrayBuffer>;
-    #[wasm_bindgen(method, getter, js_name = "sha256")]
-    pub fn sha_256(this: &R2Checksums) -> Option<ArrayBuffer>;
-    #[wasm_bindgen(method, getter, js_name = "sha384")]
-    pub fn sha_384(this: &R2Checksums) -> Option<ArrayBuffer>;
-    #[wasm_bindgen(method, getter, js_name = "sha512")]
-    pub fn sha_512(this: &R2Checksums) -> Option<ArrayBuffer>;
+    #[wasm_bindgen(method, getter)]
+    pub fn md5(this: &R2Checksums) -> Option<ArrayBuffer>;
+    #[wasm_bindgen(method, getter)]
+    pub fn sha1(this: &R2Checksums) -> Option<ArrayBuffer>;
+    #[wasm_bindgen(method, getter)]
+    pub fn sha256(this: &R2Checksums) -> Option<ArrayBuffer>;
+    #[wasm_bindgen(method, getter)]
+    pub fn sha384(this: &R2Checksums) -> Option<ArrayBuffer>;
+    #[wasm_bindgen(method, getter)]
+    pub fn sha512(this: &R2Checksums) -> Option<ArrayBuffer>;
     #[wasm_bindgen(method, js_name = "toJSON")]
     pub fn to_json(this: &R2Checksums) -> R2StringChecksums;
     #[wasm_bindgen(method, catch, js_name = "toJSON")]
@@ -9430,26 +9487,26 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2StringChecksums;
-    #[wasm_bindgen(method, getter, js_name = "md5")]
-    pub fn md_5(this: &R2StringChecksums) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "md5")]
-    pub fn set_md_5(this: &R2StringChecksums, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha1")]
-    pub fn sha_1(this: &R2StringChecksums) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "sha1")]
-    pub fn set_sha_1(this: &R2StringChecksums, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha256")]
-    pub fn sha_256(this: &R2StringChecksums) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "sha256")]
-    pub fn set_sha_256(this: &R2StringChecksums, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha384")]
-    pub fn sha_384(this: &R2StringChecksums) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "sha384")]
-    pub fn set_sha_384(this: &R2StringChecksums, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "sha512")]
-    pub fn sha_512(this: &R2StringChecksums) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "sha512")]
-    pub fn set_sha_512(this: &R2StringChecksums, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn md5(this: &R2StringChecksums) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_md5(this: &R2StringChecksums, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn sha1(this: &R2StringChecksums) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha1(this: &R2StringChecksums, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn sha256(this: &R2StringChecksums) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha256(this: &R2StringChecksums, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn sha384(this: &R2StringChecksums) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha384(this: &R2StringChecksums, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn sha512(this: &R2StringChecksums) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_sha512(this: &R2StringChecksums, val: &str);
 }
 impl R2StringChecksums {
     pub fn new() -> R2StringChecksums {
@@ -9465,24 +9522,24 @@ pub struct R2StringChecksumsBuilder {
     inner: R2StringChecksums,
 }
 impl R2StringChecksumsBuilder {
-    pub fn md_5(self, val: &str) -> Self {
-        self.inner.set_md_5(val);
+    pub fn md5(self, val: &str) -> Self {
+        self.inner.set_md5(val);
         self
     }
-    pub fn sha_1(self, val: &str) -> Self {
-        self.inner.set_sha_1(val);
+    pub fn sha1(self, val: &str) -> Self {
+        self.inner.set_sha1(val);
         self
     }
-    pub fn sha_256(self, val: &str) -> Self {
-        self.inner.set_sha_256(val);
+    pub fn sha256(self, val: &str) -> Self {
+        self.inner.set_sha256(val);
         self
     }
-    pub fn sha_384(self, val: &str) -> Self {
-        self.inner.set_sha_384(val);
+    pub fn sha384(self, val: &str) -> Self {
+        self.inner.set_sha384(val);
         self
     }
-    pub fn sha_512(self, val: &str) -> Self {
-        self.inner.set_sha_512(val);
+    pub fn sha512(self, val: &str) -> Self {
+        self.inner.set_sha512(val);
         self
     }
     pub fn build(self) -> R2StringChecksums {
@@ -9568,6 +9625,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2UploadPartOptions;
+    #[doc = " Returns: ArrayBuffer | string"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
     pub fn ssec_key(this: &R2UploadPartOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9634,6 +9692,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type QueuingStrategy;
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
     pub fn high_water_mark(this: &QueuingStrategy) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -9885,6 +9944,7 @@ extern "C" {
         this: &UnderlyingSource,
         val: &Function<fn(JsValue) -> JsOption<Promise<Undefined>>>,
     );
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "expectedLength")]
     pub fn expected_length(this: &UnderlyingSource) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "expectedLength")]
@@ -10132,13 +10192,13 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn done(this: &ReadableStreamReadResult) -> bool;
     #[wasm_bindgen(method, getter)]
-    pub fn value(this: &ReadableStreamReadResult) -> Option<JsValue>;
+    pub fn value(this: &ReadableStreamReadResult) -> Option<R>;
     #[wasm_bindgen(method, setter)]
     pub fn set_done(this: &ReadableStreamReadResult, val: bool);
     #[wasm_bindgen(method, setter)]
     pub fn set_value(this: &ReadableStreamReadResult, val: &R);
     #[wasm_bindgen(method, setter, js_name = "value")]
-    pub fn set_value_with_undefined(this: &ReadableStreamReadResult, val: &Undefined);
+    pub fn set_value_with_null(this: &ReadableStreamReadResult, val: &Null);
 }
 impl ReadableStreamReadResult {
     #[doc = " ## Inlined fields"]
@@ -10178,8 +10238,8 @@ impl ReadableStreamReadResultBuilder {
         self.inner.set_value(val);
         self
     }
-    pub fn value_with_undefined(self, val: &Undefined) -> Self {
-        self.inner.set_value_with_undefined(val);
+    pub fn value_with_null(self, val: &Null) -> Self {
+        self.inner.set_value_with_null(val);
         self
     }
     pub fn build(self) -> ReadableStreamReadResult {
@@ -10913,6 +10973,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type IdentityTransformStreamQueuingStrategy;
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
     pub fn high_water_mark(this: &IdentityTransformStreamQueuingStrategy) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -11184,6 +11245,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type TraceItem;
+    #[doc = " Returns: TraceItemFetchEventInfo | TraceItemJsRpcEventInfo | TraceItemScheduledEventInfo | TraceItemAlarmEventInfo | TraceItemQueueEventInfo | TraceItemEmailEventInfo | TraceItemTailEventInfo | TraceItemCustomEventInfo | TraceItemHibernatableWebSocketEventInfo | null"]
     #[wasm_bindgen(method, getter)]
     pub fn event(this: &TraceItem) -> Option<JsValue>;
     #[wasm_bindgen(method, getter, js_name = "eventTimestamp")]
@@ -11420,6 +11482,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type TraceItemHibernatableWebSocketEventInfo;
+    #[doc = " Returns: TraceItemHibernatableWebSocketEventInfoMessage | TraceItemHibernatableWebSocketEventInfoClose | TraceItemHibernatableWebSocketEventInfoError"]
     #[wasm_bindgen(method, getter, js_name = "getWebSocketEvent")]
     pub fn get_web_socket_event(this: &TraceItemHibernatableWebSocketEventInfo) -> JsValue;
 }
@@ -11804,7 +11867,7 @@ extern "C" {
     #[wasm_bindgen(constructor, catch)]
     pub fn new() -> Result<URLSearchParams, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "URLSearchParams")]
-    pub fn new_with_js_value(init: &Iterable) -> Result<URLSearchParams, JsValue>;
+    pub fn new_with_iterable(init: &Iterable) -> Result<URLSearchParams, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "URLSearchParams")]
     pub fn new_with_record(init: &Object<JsString>) -> Result<URLSearchParams, JsValue>;
     #[wasm_bindgen(constructor, catch, js_name = "URLSearchParams")]
@@ -12225,6 +12288,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type URLPatternResult;
+    #[doc = " Returns: (string | URLPatternInit)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn inputs(this: &URLPatternResult) -> Array;
     #[wasm_bindgen(method, setter)]
@@ -12663,8 +12727,10 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type SqlStorageCursor;
+    #[doc = " Returns: object | object"]
     #[wasm_bindgen(method)]
     pub fn next(this: &SqlStorageCursor) -> JsValue;
+    #[doc = " Returns: object | object"]
     #[wasm_bindgen(method, catch, js_name = "next")]
     pub fn try_next(this: &SqlStorageCursor) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method, js_name = "toArray")]
@@ -12732,6 +12798,7 @@ extern "C" {
     pub fn allow_half_open(this: &SocketOptions) -> bool;
     #[wasm_bindgen(method, setter, js_name = "allowHalfOpen")]
     pub fn set_allow_half_open(this: &SocketOptions, val: bool);
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
     pub fn high_water_mark(this: &SocketOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -13043,6 +13110,7 @@ extern "C" {
     pub fn env(this: &ContainerStartupOptions) -> Option<Object<JsString>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_env(this: &ContainerStartupOptions, val: &Object<JsString>);
+    #[doc = " Returns: number | bigint"]
     #[wasm_bindgen(method, getter, js_name = "hardTimeout")]
     pub fn hard_timeout(this: &ContainerStartupOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "hardTimeout")]
@@ -13178,13 +13246,13 @@ extern "C" {
     #[doc = " The **`port1`** read-only property of the the port attached to the context that originated the channel."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageChannel/port1)"]
-    #[wasm_bindgen(method, getter, js_name = "port1")]
-    pub fn port_1(this: &MessageChannel) -> MessagePort;
+    #[wasm_bindgen(method, getter)]
+    pub fn port1(this: &MessageChannel) -> MessagePort;
     #[doc = " The **`port2`** read-only property of the the port attached to the context at the other end of the channel, which the message is initially sent to."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageChannel/port2)"]
-    #[wasm_bindgen(method, getter, js_name = "port2")]
-    pub fn port_2(this: &MessageChannel) -> MessagePort;
+    #[wasm_bindgen(method, getter)]
+    pub fn port2(this: &MessageChannel) -> MessagePort;
 }
 #[wasm_bindgen]
 extern "C" {
@@ -13506,6 +13574,7 @@ extern "C" {
     pub fn main_module(this: &WorkerLoaderWorkerCode) -> String;
     #[wasm_bindgen(method, setter, js_name = "mainModule")]
     pub fn set_main_module(this: &WorkerLoaderWorkerCode, val: &str);
+    #[doc = " Returns: Record<string, WorkerLoaderModule | string>"]
     #[wasm_bindgen(method, getter)]
     pub fn modules(this: &WorkerLoaderWorkerCode) -> Object;
     #[wasm_bindgen(method, setter)]
@@ -13793,8 +13862,8 @@ impl AiSearchConfig {
     #[doc = " * `type: \"r2\"`"]
     #[doc = ""]
     #[doc = " * `id` - Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$)"]
-    pub fn new_r_2(id: &str, source: &str) -> AiSearchConfig {
-        Self::builder_r_2(id, source).build()
+    pub fn new_r2(id: &str, source: &str) -> AiSearchConfig {
+        Self::builder_r2(id, source).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -13809,7 +13878,7 @@ impl AiSearchConfig {
     #[doc = " * `type: \"r2\"`"]
     #[doc = ""]
     #[doc = " * `id` - Instance ID (1-32 chars, pattern: ^[a-z0-9_]+(?:-[a-z0-9_]+)*$)"]
-    pub fn builder_r_2(id: &str, source: &str) -> AiSearchConfigBuilder {
+    pub fn builder_r2(id: &str, source: &str) -> AiSearchConfigBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_type("r2");
@@ -14646,6 +14715,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiTextEmbeddingsInput;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &AiTextEmbeddingsInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -14706,6 +14776,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type RoleScopedChatInput;
+    #[doc = " Returns: \"user\" | \"assistant\" | \"system\" | \"tool\" | string & unknown"]
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &RoleScopedChatInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -14850,6 +14921,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiTextGenerationToolInput;
+    #[doc = " Returns: \"function\" | string & unknown"]
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &AiTextGenerationToolInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -14993,6 +15065,7 @@ extern "C" {
     pub fn response_format(this: &AiTextGenerationInput) -> Option<AiTextGenerationResponseFormat>;
     #[wasm_bindgen(method, setter)]
     pub fn set_response_format(this: &AiTextGenerationInput, val: &AiTextGenerationResponseFormat);
+    #[doc = " Returns: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[] | object & unknown"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &AiTextGenerationInput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -15316,10 +15389,10 @@ extern "C" {
     pub fn image(this: &AiTextToImageInput) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_image(this: &AiTextToImageInput, val: &Array<Number>);
-    #[wasm_bindgen(method, getter, js_name = "image_b64")]
-    pub fn image_b_64(this: &AiTextToImageInput) -> Option<String>;
-    #[wasm_bindgen(method, setter, js_name = "image_b64")]
-    pub fn set_image_b_64(this: &AiTextToImageInput, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn image_b64(this: &AiTextToImageInput) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_image_b64(this: &AiTextToImageInput, val: &str);
     #[wasm_bindgen(method, getter)]
     pub fn mask(this: &AiTextToImageInput) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
@@ -15371,8 +15444,8 @@ impl AiTextToImageInputBuilder {
         self.inner.set_image(val);
         self
     }
-    pub fn image_b_64(self, val: &str) -> Self {
-        self.inner.set_image_b_64(val);
+    pub fn image_b64(self, val: &str) -> Self {
+        self.inner.set_image_b64(val);
         self
     }
     pub fn mask(self, val: &Array<Number>) -> Self {
@@ -15513,6 +15586,7 @@ extern "C" {
     pub fn set_background(this: &ResponsesInput, val: bool);
     #[wasm_bindgen(method, setter, js_name = "background")]
     pub fn set_background_with_null(this: &ResponsesInput, val: &Null);
+    #[doc = " Returns: string | ResponseConversationParam | null"]
     #[wasm_bindgen(method, getter)]
     pub fn conversation(this: &ResponsesInput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -15530,6 +15604,7 @@ extern "C" {
     pub fn set_include(this: &ResponsesInput, val: &Array<ResponseIncludable>);
     #[wasm_bindgen(method, setter, js_name = "include")]
     pub fn set_include_with_null(this: &ResponsesInput, val: &Null);
+    #[doc = " Returns: string | ResponseInput"]
     #[wasm_bindgen(method, getter)]
     pub fn input(this: &ResponsesInput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -15602,6 +15677,7 @@ extern "C" {
     pub fn text(this: &ResponsesInput) -> Option<ResponseTextConfig>;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &ResponsesInput, val: &ResponseTextConfig);
+    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction"]
     #[wasm_bindgen(method, getter)]
     pub fn tool_choice(this: &ResponsesInput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -15827,6 +15903,7 @@ extern "C" {
     pub fn set_incomplete_details(this: &ResponsesOutput, val: &ResponseIncompleteDetails);
     #[wasm_bindgen(method, setter, js_name = "incomplete_details")]
     pub fn set_incomplete_details_with_null(this: &ResponsesOutput, val: &Null);
+    #[doc = " Returns: string | Array<ResponseInputItem> | null"]
     #[wasm_bindgen(method, getter)]
     pub fn instructions(this: &ResponsesOutput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -15853,6 +15930,7 @@ extern "C" {
     pub fn set_temperature(this: &ResponsesOutput, val: f64);
     #[wasm_bindgen(method, setter, js_name = "temperature")]
     pub fn set_temperature_with_null(this: &ResponsesOutput, val: &Null);
+    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction"]
     #[wasm_bindgen(method, getter)]
     pub fn tool_choice(this: &ResponsesOutput) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -16092,6 +16170,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type EasyInputMessage;
+    #[doc = " Returns: string | ResponseInputMessageContentList"]
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &EasyInputMessage) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -16135,14 +16214,14 @@ impl EasyInputMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user_with_response_input_message_content_list(content: &Array) -> EasyInputMessage {
+    pub fn new_user_with_response_input_message_content_list(content: &&Array) -> EasyInputMessage {
         Self::builder_user_with_response_input_message_content_list(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"assistant\"`"]
     pub fn new_assistant_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessage {
         Self::builder_assistant_with_response_input_message_content_list(content).build()
     }
@@ -16150,7 +16229,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
     pub fn new_system_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessage {
         Self::builder_system_with_response_input_message_content_list(content).build()
     }
@@ -16158,7 +16237,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
     pub fn new_developer_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessage {
         Self::builder_developer_with_response_input_message_content_list(content).build()
     }
@@ -16202,7 +16281,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
     pub fn builder_user_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
@@ -16213,7 +16292,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"assistant\"`"]
     pub fn builder_assistant_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
@@ -16224,7 +16303,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
     pub fn builder_system_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
@@ -16235,7 +16314,7 @@ impl EasyInputMessage {
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
     pub fn builder_developer_with_response_input_message_content_list(
-        content: &Array,
+        content: &&Array,
     ) -> EasyInputMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
@@ -16567,6 +16646,7 @@ extern "C" {
     pub fn call_id(this: &ResponseCustomToolCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_call_id(this: &ResponseCustomToolCallOutput, val: &str);
+    #[doc = " Returns: string | Array<ResponseInputText | ResponseInputImage>"]
     #[wasm_bindgen(method, getter)]
     pub fn output(this: &ResponseCustomToolCallOutput) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -16712,7 +16792,7 @@ impl ResponseError {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `code: \"invalid_base64_image\"`"]
-    pub fn new_invalid_base_64_image(message: &str) -> ResponseError {
+    pub fn new_invalid_base64_image(message: &str) -> ResponseError {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_code("invalid_base64_image");
         inner.set_message(message);
@@ -17211,6 +17291,7 @@ extern "C" {
     pub fn call_id(this: &ResponseFunctionToolCallOutputItem) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_call_id(this: &ResponseFunctionToolCallOutputItem, val: &str);
+    #[doc = " Returns: string | Array<ResponseInputText | ResponseInputImage>"]
     #[wasm_bindgen(method, getter)]
     pub fn output(this: &ResponseFunctionToolCallOutputItem) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -17499,6 +17580,7 @@ extern "C" {
     pub fn call_id(this: &ResponseInputItemFunctionCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_call_id(this: &ResponseInputItemFunctionCallOutput, val: &str);
+    #[doc = " Returns: string | ResponseFunctionCallOutputItemList"]
     #[wasm_bindgen(method, getter)]
     pub fn output(this: &ResponseInputItemFunctionCallOutput) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -17537,7 +17619,7 @@ impl ResponseInputItemFunctionCallOutput {
     #[doc = " * `type: \"function_call_output\"`"]
     pub fn new_function_call_output_with_response_function_call_output_item_list(
         call_id: &str,
-        output: &Array,
+        output: &&Array,
     ) -> ResponseInputItemFunctionCallOutput {
         Self::builder_function_call_output_with_response_function_call_output_item_list(
             call_id, output,
@@ -17562,7 +17644,7 @@ impl ResponseInputItemFunctionCallOutput {
     #[doc = " * `type: \"function_call_output\"`"]
     pub fn builder_function_call_output_with_response_function_call_output_item_list(
         call_id: &str,
-        output: &Array,
+        output: &&Array,
     ) -> ResponseInputItemFunctionCallOutputBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_call_id(call_id);
@@ -17621,25 +17703,25 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user(content: &Array) -> ResponseInputItemMessage {
+    pub fn new_user(content: &&Array) -> ResponseInputItemMessage {
         Self::builder_user(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn new_system(content: &Array) -> ResponseInputItemMessage {
+    pub fn new_system(content: &&Array) -> ResponseInputItemMessage {
         Self::builder_system(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn new_developer(content: &Array) -> ResponseInputItemMessage {
+    pub fn new_developer(content: &&Array) -> ResponseInputItemMessage {
         Self::builder_developer(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn builder_user(content: &Array) -> ResponseInputItemMessageBuilder {
+    pub fn builder_user(content: &&Array) -> ResponseInputItemMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("user");
@@ -17648,7 +17730,7 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn builder_system(content: &Array) -> ResponseInputItemMessageBuilder {
+    pub fn builder_system(content: &&Array) -> ResponseInputItemMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("system");
@@ -17657,7 +17739,7 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn builder_developer(content: &Array) -> ResponseInputItemMessageBuilder {
+    pub fn builder_developer(content: &&Array) -> ResponseInputItemMessageBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("developer");
@@ -17712,25 +17794,25 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user(id: &str, content: &Array) -> ResponseInputMessageItem {
+    pub fn new_user(id: &str, content: &&Array) -> ResponseInputMessageItem {
         Self::builder_user(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn new_system(id: &str, content: &Array) -> ResponseInputMessageItem {
+    pub fn new_system(id: &str, content: &&Array) -> ResponseInputMessageItem {
         Self::builder_system(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn new_developer(id: &str, content: &Array) -> ResponseInputMessageItem {
+    pub fn new_developer(id: &str, content: &&Array) -> ResponseInputMessageItem {
         Self::builder_developer(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn builder_user(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
+    pub fn builder_user(id: &str, content: &&Array) -> ResponseInputMessageItemBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -17740,7 +17822,7 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn builder_system(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
+    pub fn builder_system(id: &str, content: &&Array) -> ResponseInputMessageItemBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -17750,7 +17832,7 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn builder_developer(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
+    pub fn builder_developer(id: &str, content: &&Array) -> ResponseInputMessageItemBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -17865,7 +17947,7 @@ impl ResponseOutputItemAddedEvent {
     #[doc = ""]
     #[doc = " * `type: \"response.output_item.added\"`"]
     pub fn new_responseoutput_itemadded(
-        item: &JsValue,
+        item: &&JsValue,
         output_index: f64,
         sequence_number: f64,
     ) -> ResponseOutputItemAddedEvent {
@@ -17914,7 +17996,7 @@ impl ResponseOutputItemDoneEvent {
     #[doc = ""]
     #[doc = " * `type: \"response.output_item.done\"`"]
     pub fn new_responseoutput_itemdone(
-        item: &JsValue,
+        item: &&JsValue,
         output_index: f64,
         sequence_number: f64,
     ) -> ResponseOutputItemDoneEvent {
@@ -17935,6 +18017,7 @@ extern "C" {
     pub fn id(this: &ResponseOutputMessage) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &ResponseOutputMessage, val: &str);
+    #[doc = " Returns: Array<ResponseOutputText | ResponseOutputRefusal>"]
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &ResponseOutputMessage) -> Array;
     #[wasm_bindgen(method, setter)]
@@ -18821,6 +18904,7 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<Array<Object>>;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -18918,7 +19002,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
     pub fn set_post_processed_outputs(this: &Base_Ai_Cf_Baai_Bge_Base_En_V1_5, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_base_en_v_1_5_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_base_en_v1_5_async_response(
         this: &Base_Ai_Cf_Baai_Bge_Base_En_V1_5,
         val: &Ai_Cf_Baai_Bge_Base_En_V1_5_AsyncResponse,
     );
@@ -19108,7 +19192,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
     pub fn set_post_processed_outputs(this: &Base_Ai_Cf_Meta_M2M100_1_2B, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_meta_m_2_m_100_1_2_b_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_meta_m2_m100_1_2_b_async_response(
         this: &Base_Ai_Cf_Meta_M2M100_1_2B,
         val: &Ai_Cf_Meta_M2M100_1_2B_AsyncResponse,
     );
@@ -19124,6 +19208,7 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<Array<Object>>;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -19221,7 +19306,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
     pub fn set_post_processed_outputs(this: &Base_Ai_Cf_Baai_Bge_Small_En_V1_5, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_small_en_v_1_5_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_small_en_v1_5_async_response(
         this: &Base_Ai_Cf_Baai_Bge_Small_En_V1_5,
         val: &Ai_Cf_Baai_Bge_Small_En_V1_5_AsyncResponse,
     );
@@ -19237,6 +19322,7 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<Array<Object>>;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -19334,7 +19420,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
     pub fn set_post_processed_outputs(this: &Base_Ai_Cf_Baai_Bge_Large_En_V1_5, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_large_en_v_1_5_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_large_en_v1_5_async_response(
         this: &Base_Ai_Cf_Baai_Bge_Large_En_V1_5,
         val: &Ai_Cf_Baai_Bge_Large_En_V1_5_AsyncResponse,
     );
@@ -19693,6 +19779,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Baai_Bge_M3_Input_Embedding;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_M3_Input_Embedding) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -19789,6 +19876,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Baai_Bge_M3_Input_Embedding_1;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_M3_Input_Embedding_1) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -20017,7 +20105,7 @@ extern "C" {
         val: &Ai_Cf_Baai_Bge_M3_Input_QueryAnd_Contexts,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_baai_bge_m_3_input_embedding(
+    pub fn set_inputs_with_ai_cf_baai_bge_m3_input_embedding(
         this: &Base_Ai_Cf_Baai_Bge_M3,
         val: &Ai_Cf_Baai_Bge_M3_Input_Embedding,
     );
@@ -20031,17 +20119,17 @@ extern "C" {
         val: &Ai_Cf_Baai_Bge_M3_Ouput_Query,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m_3_output_embedding_for_contexts(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m3_output_embedding_for_contexts(
         this: &Base_Ai_Cf_Baai_Bge_M3,
         val: &Ai_Cf_Baai_Bge_M3_Output_EmbeddingFor_Contexts,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m_3_ouput_embedding(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m3_ouput_embedding(
         this: &Base_Ai_Cf_Baai_Bge_M3,
         val: &Ai_Cf_Baai_Bge_M3_Ouput_Embedding,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m_3_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_baai_bge_m3_async_response(
         this: &Base_Ai_Cf_Baai_Bge_M3,
         val: &Ai_Cf_Baai_Bge_M3_AsyncResponse,
     );
@@ -20155,6 +20243,7 @@ extern "C" {
     pub fn prompt(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_prompt(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt, val: &str);
+    #[doc = " Returns: number[] | string & unknown"]
     #[wasm_bindgen(method, getter)]
     pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -20308,6 +20397,7 @@ extern "C" {
         this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages,
         val: &Array<Object>,
     );
+    #[doc = " Returns: number[] | string & unknown"]
     #[wasm_bindgen(method, getter)]
     pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -20327,6 +20417,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -20523,7 +20615,7 @@ extern "C" {
         val: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_meta_llama_3_2_11_b_vision_instruct_messages(
+    pub fn set_inputs_with_ai_cf_meta_llama3_2_11_b_vision_instruct_messages(
         this: &Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct,
         val: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages,
     );
@@ -20765,6 +20857,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -21101,12 +21195,12 @@ extern "C" {
         val: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_meta_llama_3_3_70_b_instruct_fp_8_fast_messages(
+    pub fn set_inputs_with_ai_cf_meta_llama3_3_70_b_instruct_fp8_fast_messages(
         this: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
         val: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_meta_llama_3_3_70_b_instruct_fp_8_fast_async_batch(
+    pub fn set_inputs_with_ai_cf_meta_llama3_3_70_b_instruct_fp8_fast_async_batch(
         this: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
         val: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Async_Batch,
     );
@@ -21125,7 +21219,7 @@ extern "C" {
         val: &str,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_meta_llama_3_3_70_b_instruct_fp_8_fast_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_meta_llama3_3_70_b_instruct_fp8_fast_async_response(
         this: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
         val: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_AsyncResponse,
     );
@@ -21193,6 +21287,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Meta_Llama_Guard_3_8B_Output;
+    #[doc = " Returns: string | object"]
     #[wasm_bindgen(method, getter)]
     pub fn response(this: &Ai_Cf_Meta_Llama_Guard_3_8B_Output) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -21556,6 +21651,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -21799,7 +21896,7 @@ extern "C" {
         val: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_qwen_qwen_2_5_coder_32_b_instruct_messages(
+    pub fn set_inputs_with_ai_cf_qwen_qwen2_5_coder32_b_instruct_messages(
         this: &Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct,
         val: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages,
     );
@@ -21960,6 +22057,8 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwq_32B_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwq_32B_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -22151,7 +22250,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_inputs(this: &Base_Ai_Cf_Qwen_Qwq_32B, val: &Ai_Cf_Qwen_Qwq_32B_Prompt);
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_qwen_qwq_32_b_messages(
+    pub fn set_inputs_with_ai_cf_qwen_qwq32_b_messages(
         this: &Base_Ai_Cf_Qwen_Qwq_32B,
         val: &Ai_Cf_Qwen_Qwq_32B_Messages,
     );
@@ -22341,6 +22440,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -22571,7 +22672,7 @@ extern "C" {
         val: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_mistralai_mistral_small_3_1_24_b_instruct_messages(
+    pub fn set_inputs_with_ai_cf_mistralai_mistral_small3_1_24_b_instruct_messages(
         this: &Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct,
         val: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages,
     );
@@ -22732,6 +22833,8 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_functions(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -22926,7 +23029,7 @@ extern "C" {
         val: &Ai_Cf_Google_Gemma_3_12B_It_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_google_gemma_3_12_b_it_messages(
+    pub fn set_inputs_with_ai_cf_google_gemma3_12_b_it_messages(
         this: &Base_Ai_Cf_Google_Gemma_3_12B_It,
         val: &Ai_Cf_Google_Gemma_3_12B_It_Messages,
     );
@@ -23164,6 +23267,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -23335,6 +23440,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch;
+    #[doc = " Returns: (Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt_Inner | Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
@@ -23541,6 +23647,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -23790,12 +23898,12 @@ extern "C" {
         val: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_meta_llama_4_scout_17_b_16_e_instruct_messages(
+    pub fn set_inputs_with_ai_cf_meta_llama4_scout17_b16_e_instruct_messages(
         this: &Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct,
         val: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_meta_llama_4_scout_17_b_16_e_instruct_async_batch(
+    pub fn set_inputs_with_ai_cf_meta_llama4_scout17_b16_e_instruct_async_batch(
         this: &Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct,
         val: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Async_Batch,
     );
@@ -24009,6 +24117,8 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -24190,6 +24300,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch;
+    #[doc = " Returns: (Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt_1 | Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
@@ -24400,6 +24511,8 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -24813,12 +24926,12 @@ extern "C" {
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_qwen_qwen_3_30_b_a_3_b_fp_8_messages(
+    pub fn set_inputs_with_ai_cf_qwen_qwen3_30_b_a3_b_fp8_messages(
         this: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_qwen_qwen_3_30_b_a_3_b_fp_8_async_batch(
+    pub fn set_inputs_with_ai_cf_qwen_qwen3_30_b_a3_b_fp8_async_batch(
         this: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Async_Batch,
     );
@@ -24830,14 +24943,14 @@ extern "C" {
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Chat_Completion_Response,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_qwen_qwen_3_30_b_a_3_b_fp_8_text_completion_response(
+    pub fn set_post_processed_outputs_with_ai_cf_qwen_qwen3_30_b_a3_b_fp8_text_completion_response(
         this: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Text_Completion_Response,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
     pub fn set_post_processed_outputs_with_str(this: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8, val: &str);
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_qwen_qwen_3_30_b_a_3_b_fp_8_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_qwen_qwen3_30_b_a3_b_fp8_async_response(
         this: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
         val: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_AsyncResponse,
     );
@@ -25241,6 +25354,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn queries(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -25255,6 +25369,7 @@ extern "C" {
     pub fn instruction(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_instruction(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input, val: &str);
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn documents(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -25264,6 +25379,7 @@ extern "C" {
         this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input,
         val: &Array<JsString>,
     );
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -25387,6 +25503,8 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input;
     #[doc = " readable stream with audio data and content-type specified for that data"]
+    #[doc = ""]
+    #[doc = " Returns: object | string"]
     #[wasm_bindgen(method, getter)]
     pub fn audio(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input) -> JsValue;
     #[doc = " type of data PCM data that's sent to the inference server as raw array"]
@@ -25869,6 +25987,8 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input;
     #[doc = " Input text to translate. Can be a single string or a list of strings."]
+    #[doc = ""]
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -26976,6 +27096,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -27182,6 +27304,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch;
+    #[doc = " Returns: (Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt_1 | Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch) -> Array;
     #[wasm_bindgen(method, setter)]
@@ -27423,6 +27546,8 @@ extern "C" {
         val: &Array<Object>,
     );
     #[doc = " A list of tools available for the assistant to use."]
+    #[doc = ""]
+    #[doc = " Returns: (object | object)[]"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -27917,12 +28042,12 @@ extern "C" {
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Prompt,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_aisingapore_gemma_sea_lion_v_4_27_b_it_messages(
+    pub fn set_inputs_with_ai_cf_aisingapore_gemma_sea_lion_v4_27_b_it_messages(
         this: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages,
     );
     #[wasm_bindgen(method, setter, js_name = "inputs")]
-    pub fn set_inputs_with_ai_cf_aisingapore_gemma_sea_lion_v_4_27_b_it_async_batch(
+    pub fn set_inputs_with_ai_cf_aisingapore_gemma_sea_lion_v4_27_b_it_async_batch(
         this: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Async_Batch,
     );
@@ -27936,7 +28061,7 @@ extern "C" {
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Chat_Completion_Response,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_aisingapore_gemma_sea_lion_v_4_27_b_it_text_completion_response(
+    pub fn set_post_processed_outputs_with_ai_cf_aisingapore_gemma_sea_lion_v4_27_b_it_text_completion_response(
         this: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Text_Completion_Response,
     );
@@ -27946,7 +28071,7 @@ extern "C" {
         val: &str,
     );
     #[wasm_bindgen(method, setter, js_name = "postProcessedOutputs")]
-    pub fn set_post_processed_outputs_with_ai_cf_aisingapore_gemma_sea_lion_v_4_27_b_it_async_response(
+    pub fn set_post_processed_outputs_with_ai_cf_aisingapore_gemma_sea_lion_v4_27_b_it_async_response(
         this: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
         val: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_AsyncResponse,
     );
@@ -27957,6 +28082,8 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Pfnet_Plamo_Embedding_1B_Input;
     #[doc = " Input text to embed. Can be a single string or a list of strings."]
+    #[doc = ""]
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Pfnet_Plamo_Embedding_1B_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -28092,15 +28219,15 @@ impl Ai_Cf_Deepgram_Flux_Input {
     #[doc = " * `encoding: \"linear16\"` - Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM."]
     #[doc = ""]
     #[doc = " * `sample_rate` - Sample rate of the audio stream in Hz."]
-    pub fn new_linear_16(sample_rate: &str) -> Ai_Cf_Deepgram_Flux_Input {
-        Self::builder_linear_16(sample_rate).build()
+    pub fn new_linear16(sample_rate: &str) -> Ai_Cf_Deepgram_Flux_Input {
+        Self::builder_linear16(sample_rate).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `encoding: \"linear16\"` - Encoding of the audio stream. Currently only supports raw signed little-endian 16-bit PCM."]
     #[doc = ""]
     #[doc = " * `sample_rate` - Sample rate of the audio stream in Hz."]
-    pub fn builder_linear_16(sample_rate: &str) -> Ai_Cf_Deepgram_Flux_InputBuilder {
+    pub fn builder_linear16(sample_rate: &str) -> Ai_Cf_Deepgram_Flux_InputBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_encoding("linear16");
         inner.set_sample_rate(sample_rate);
@@ -28451,9 +28578,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiModels;
     #[wasm_bindgen(method, getter, js_name = "@cf/huggingface/distilbert-sst-2-int8")]
-    pub fn cfhuggingfacedistilbert_sst_2_int_8(this: &AiModels) -> BaseAiTextClassification;
+    pub fn cfhuggingfacedistilbert_sst2_int8(this: &AiModels) -> BaseAiTextClassification;
     #[wasm_bindgen(method, setter, js_name = "@cf/huggingface/distilbert-sst-2-int8")]
-    pub fn set_cfhuggingfacedistilbert_sst_2_int_8(this: &AiModels, val: &BaseAiTextClassification);
+    pub fn set_cfhuggingfacedistilbert_sst2_int8(this: &AiModels, val: &BaseAiTextClassification);
     #[wasm_bindgen(
         method,
         getter,
@@ -28471,24 +28598,21 @@ extern "C" {
         getter,
         js_name = "@cf/runwayml/stable-diffusion-v1-5-inpainting"
     )]
-    pub fn cfrunwaymlstable_diffusion_v_1_5_inpainting(this: &AiModels) -> BaseAiTextToImage;
+    pub fn cfrunwaymlstable_diffusion_v1_5_inpainting(this: &AiModels) -> BaseAiTextToImage;
     #[wasm_bindgen(
         method,
         setter,
         js_name = "@cf/runwayml/stable-diffusion-v1-5-inpainting"
     )]
-    pub fn set_cfrunwaymlstable_diffusion_v_1_5_inpainting(
-        this: &AiModels,
-        val: &BaseAiTextToImage,
-    );
+    pub fn set_cfrunwaymlstable_diffusion_v1_5_inpainting(this: &AiModels, val: &BaseAiTextToImage);
     #[wasm_bindgen(method, getter, js_name = "@cf/runwayml/stable-diffusion-v1-5-img2img")]
-    pub fn cfrunwaymlstable_diffusion_v_1_5_img_2_img(this: &AiModels) -> BaseAiTextToImage;
+    pub fn cfrunwaymlstable_diffusion_v1_5_img2_img(this: &AiModels) -> BaseAiTextToImage;
     #[wasm_bindgen(method, setter, js_name = "@cf/runwayml/stable-diffusion-v1-5-img2img")]
-    pub fn set_cfrunwaymlstable_diffusion_v_1_5_img_2_img(this: &AiModels, val: &BaseAiTextToImage);
+    pub fn set_cfrunwaymlstable_diffusion_v1_5_img2_img(this: &AiModels, val: &BaseAiTextToImage);
     #[wasm_bindgen(method, getter, js_name = "@cf/lykon/dreamshaper-8-lcm")]
-    pub fn cflykondreamshaper_8_lcm(this: &AiModels) -> BaseAiTextToImage;
+    pub fn cflykondreamshaper8_lcm(this: &AiModels) -> BaseAiTextToImage;
     #[wasm_bindgen(method, setter, js_name = "@cf/lykon/dreamshaper-8-lcm")]
-    pub fn set_cflykondreamshaper_8_lcm(this: &AiModels, val: &BaseAiTextToImage);
+    pub fn set_cflykondreamshaper8_lcm(this: &AiModels, val: &BaseAiTextToImage);
     #[wasm_bindgen(
         method,
         getter,
@@ -28506,49 +28630,49 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "@cf/myshell-ai/melotts")]
     pub fn set_cfmyshell_aimelotts(this: &AiModels, val: &BaseAiTextToSpeech);
     #[wasm_bindgen(method, getter, js_name = "@cf/google/embeddinggemma-300m")]
-    pub fn cfgoogleembeddinggemma_300_m(this: &AiModels) -> BaseAiTextEmbeddings;
+    pub fn cfgoogleembeddinggemma300_m(this: &AiModels) -> BaseAiTextEmbeddings;
     #[wasm_bindgen(method, setter, js_name = "@cf/google/embeddinggemma-300m")]
-    pub fn set_cfgoogleembeddinggemma_300_m(this: &AiModels, val: &BaseAiTextEmbeddings);
+    pub fn set_cfgoogleembeddinggemma300_m(this: &AiModels, val: &BaseAiTextEmbeddings);
     #[wasm_bindgen(method, getter, js_name = "@cf/microsoft/resnet-50")]
-    pub fn cfmicrosoftresnet_50(this: &AiModels) -> BaseAiImageClassification;
+    pub fn cfmicrosoftresnet50(this: &AiModels) -> BaseAiImageClassification;
     #[wasm_bindgen(method, setter, js_name = "@cf/microsoft/resnet-50")]
-    pub fn set_cfmicrosoftresnet_50(this: &AiModels, val: &BaseAiImageClassification);
+    pub fn set_cfmicrosoftresnet50(this: &AiModels, val: &BaseAiImageClassification);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-2-7b-chat-int8")]
-    pub fn cfmetallama_2_7_b_chat_int_8(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmetallama2_7_b_chat_int8(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-2-7b-chat-int8")]
-    pub fn set_cfmetallama_2_7_b_chat_int_8(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmetallama2_7_b_chat_int8(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/mistral/mistral-7b-instruct-v0.1")]
-    pub fn cfmistralmistral_7_b_instruct_v_01(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmistralmistral7_b_instruct_v_01(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/mistral/mistral-7b-instruct-v0.1")]
-    pub fn set_cfmistralmistral_7_b_instruct_v_01(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmistralmistral7_b_instruct_v_01(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-2-7b-chat-fp16")]
-    pub fn cfmetallama_2_7_b_chat_fp_16(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmetallama2_7_b_chat_fp16(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-2-7b-chat-fp16")]
-    pub fn set_cfmetallama_2_7_b_chat_fp_16(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmetallama2_7_b_chat_fp16(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/llama-2-13b-chat-awq")]
-    pub fn hftheblokellama_2_13_b_chat_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokellama2_13_b_chat_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/llama-2-13b-chat-awq")]
-    pub fn set_hftheblokellama_2_13_b_chat_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokellama2_13_b_chat_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/mistral-7b-instruct-v0.1-awq")]
-    pub fn hftheblokemistral_7_b_instruct_v_01_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokemistral7_b_instruct_v_01_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/mistral-7b-instruct-v0.1-awq")]
-    pub fn set_hftheblokemistral_7_b_instruct_v_01_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokemistral7_b_instruct_v_01_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/zephyr-7b-beta-awq")]
-    pub fn hftheblokezephyr_7_b_beta_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokezephyr7_b_beta_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/zephyr-7b-beta-awq")]
-    pub fn set_hftheblokezephyr_7_b_beta_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokezephyr7_b_beta_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/openhermes-2.5-mistral-7b-awq")]
-    pub fn hftheblokeopenhermes_25_mistral_7_b_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokeopenhermes_25_mistral7_b_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/openhermes-2.5-mistral-7b-awq")]
-    pub fn set_hftheblokeopenhermes_25_mistral_7_b_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokeopenhermes_25_mistral7_b_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/neural-chat-7b-v3-1-awq")]
-    pub fn hftheblokeneural_chat_7_b_v_3_1_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokeneural_chat7_b_v3_1_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/neural-chat-7b-v3-1-awq")]
-    pub fn set_hftheblokeneural_chat_7_b_v_3_1_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokeneural_chat7_b_v3_1_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/llamaguard-7b-awq")]
-    pub fn hftheblokellamaguard_7_b_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hftheblokellamaguard7_b_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/llamaguard-7b-awq")]
-    pub fn set_hftheblokellamaguard_7_b_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hftheblokellamaguard7_b_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/thebloke/deepseek-coder-6.7b-base-awq")]
     pub fn hftheblokedeepseek_coder_67_b_base_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/thebloke/deepseek-coder-6.7b-base-awq")]
@@ -28569,25 +28693,25 @@ extern "C" {
         val: &BaseAiTextGeneration,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/deepseek-ai/deepseek-math-7b-instruct")]
-    pub fn cfdeepseek_aideepseek_math_7_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfdeepseek_aideepseek_math7_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/deepseek-ai/deepseek-math-7b-instruct")]
-    pub fn set_cfdeepseek_aideepseek_math_7_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfdeepseek_aideepseek_math7_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/defog/sqlcoder-7b-2")]
-    pub fn cfdefogsqlcoder_7_b_2(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfdefogsqlcoder7_b2(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/defog/sqlcoder-7b-2")]
-    pub fn set_cfdefogsqlcoder_7_b_2(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfdefogsqlcoder7_b2(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/openchat/openchat-3.5-0106")]
     pub fn cfopenchatopenchat_35_0106(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/openchat/openchat-3.5-0106")]
     pub fn set_cfopenchatopenchat_35_0106(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/tiiuae/falcon-7b-instruct")]
-    pub fn cftiiuaefalcon_7_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cftiiuaefalcon7_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/tiiuae/falcon-7b-instruct")]
-    pub fn set_cftiiuaefalcon_7_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cftiiuaefalcon7_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/thebloke/discolm-german-7b-v1-awq")]
-    pub fn cftheblokediscolm_german_7_b_v_1_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cftheblokediscolm_german7_b_v1_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/thebloke/discolm-german-7b-v1-awq")]
-    pub fn set_cftheblokediscolm_german_7_b_v_1_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cftheblokediscolm_german7_b_v1_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwen1.5-0.5b-chat")]
     pub fn cfqwenqwen_15_05_b_chat(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwen1.5-0.5b-chat")]
@@ -28605,61 +28729,61 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "@cf/tinyllama/tinyllama-1.1b-chat-v1.0")]
     pub fn set_cftinyllamatinyllama_11_b_chat_v_10(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/microsoft/phi-2")]
-    pub fn cfmicrosoftphi_2(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmicrosoftphi2(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/microsoft/phi-2")]
-    pub fn set_cfmicrosoftphi_2(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmicrosoftphi2(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwen1.5-1.8b-chat")]
     pub fn cfqwenqwen_15_18_b_chat(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwen1.5-1.8b-chat")]
     pub fn set_cfqwenqwen_15_18_b_chat(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/mistral/mistral-7b-instruct-v0.2-lora")]
-    pub fn cfmistralmistral_7_b_instruct_v_02_lora(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmistralmistral7_b_instruct_v_02_lora(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/mistral/mistral-7b-instruct-v0.2-lora")]
-    pub fn set_cfmistralmistral_7_b_instruct_v_02_lora(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmistralmistral7_b_instruct_v_02_lora(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/nousresearch/hermes-2-pro-mistral-7b")]
-    pub fn hfnousresearchhermes_2_pro_mistral_7_b(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hfnousresearchhermes2_pro_mistral7_b(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/nousresearch/hermes-2-pro-mistral-7b")]
-    pub fn set_hfnousresearchhermes_2_pro_mistral_7_b(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hfnousresearchhermes2_pro_mistral7_b(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/nexusflow/starling-lm-7b-beta")]
-    pub fn hfnexusflowstarling_lm_7_b_beta(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hfnexusflowstarling_lm7_b_beta(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/nexusflow/starling-lm-7b-beta")]
-    pub fn set_hfnexusflowstarling_lm_7_b_beta(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hfnexusflowstarling_lm7_b_beta(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/google/gemma-7b-it")]
-    pub fn hfgooglegemma_7_b_it(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hfgooglegemma7_b_it(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/google/gemma-7b-it")]
-    pub fn set_hfgooglegemma_7_b_it(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hfgooglegemma7_b_it(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta-llama/llama-2-7b-chat-hf-lora")]
-    pub fn cfmeta_llamallama_2_7_b_chat_hf_lora(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmeta_llamallama2_7_b_chat_hf_lora(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta-llama/llama-2-7b-chat-hf-lora")]
-    pub fn set_cfmeta_llamallama_2_7_b_chat_hf_lora(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmeta_llamallama2_7_b_chat_hf_lora(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/google/gemma-2b-it-lora")]
-    pub fn cfgooglegemma_2_b_it_lora(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfgooglegemma2_b_it_lora(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/google/gemma-2b-it-lora")]
-    pub fn set_cfgooglegemma_2_b_it_lora(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfgooglegemma2_b_it_lora(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/google/gemma-7b-it-lora")]
-    pub fn cfgooglegemma_7_b_it_lora(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfgooglegemma7_b_it_lora(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/google/gemma-7b-it-lora")]
-    pub fn set_cfgooglegemma_7_b_it_lora(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfgooglegemma7_b_it_lora(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@hf/mistral/mistral-7b-instruct-v0.2")]
-    pub fn hfmistralmistral_7_b_instruct_v_02(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn hfmistralmistral7_b_instruct_v_02(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@hf/mistral/mistral-7b-instruct-v0.2")]
-    pub fn set_hfmistralmistral_7_b_instruct_v_02(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_hfmistralmistral7_b_instruct_v_02(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-3-8b-instruct")]
-    pub fn cfmetallama_3_8_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmetallama3_8_b_instruct(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-3-8b-instruct")]
-    pub fn set_cfmetallama_3_8_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmetallama3_8_b_instruct(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/fblgit/una-cybertron-7b-v2-bf16")]
-    pub fn cffblgituna_cybertron_7_b_v_2_bf_16(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cffblgituna_cybertron7_b_v2_bf16(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/fblgit/una-cybertron-7b-v2-bf16")]
-    pub fn set_cffblgituna_cybertron_7_b_v_2_bf_16(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cffblgituna_cybertron7_b_v2_bf16(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-3-8b-instruct-awq")]
-    pub fn cfmetallama_3_8_b_instruct_awq(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmetallama3_8_b_instruct_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-3-8b-instruct-awq")]
-    pub fn set_cfmetallama_3_8_b_instruct_awq(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmetallama3_8_b_instruct_awq(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-3.1-8b-instruct-fp8")]
-    pub fn cfmetallama_31_8_b_instruct_fp_8(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfmetallama_31_8_b_instruct_fp8(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-3.1-8b-instruct-fp8")]
-    pub fn set_cfmetallama_31_8_b_instruct_fp_8(this: &AiModels, val: &BaseAiTextGeneration);
+    pub fn set_cfmetallama_31_8_b_instruct_fp8(this: &AiModels, val: &BaseAiTextGeneration);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-3.1-8b-instruct-awq")]
     pub fn cfmetallama_31_8_b_instruct_awq(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-3.1-8b-instruct-awq")]
@@ -28677,13 +28801,13 @@ extern "C" {
         getter,
         js_name = "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b"
     )]
-    pub fn cfdeepseek_aideepseek_r_1_distill_qwen_32_b(this: &AiModels) -> BaseAiTextGeneration;
+    pub fn cfdeepseek_aideepseek_r1_distill_qwen32_b(this: &AiModels) -> BaseAiTextGeneration;
     #[wasm_bindgen(
         method,
         setter,
         js_name = "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b"
     )]
-    pub fn set_cfdeepseek_aideepseek_r_1_distill_qwen_32_b(
+    pub fn set_cfdeepseek_aideepseek_r1_distill_qwen32_b(
         this: &AiModels,
         val: &BaseAiTextGeneration,
     );
@@ -28708,9 +28832,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_cfopenaiwhisper(this: &AiModels, val: &Base_Ai_Cf_Openai_Whisper);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/m2m100-1.2b")]
-    pub fn cfmetam_2_m_100_12_b(this: &AiModels) -> Base_Ai_Cf_Meta_M2M100_1_2B;
+    pub fn cfmetam2_m100_12_b(this: &AiModels) -> Base_Ai_Cf_Meta_M2M100_1_2B;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/m2m100-1.2b")]
-    pub fn set_cfmetam_2_m_100_12_b(this: &AiModels, val: &Base_Ai_Cf_Meta_M2M100_1_2B);
+    pub fn set_cfmetam2_m100_12_b(this: &AiModels, val: &Base_Ai_Cf_Meta_M2M100_1_2B);
     #[wasm_bindgen(method, getter, js_name = "@cf/baai/bge-small-en-v1.5")]
     pub fn cfbaaibge_small_en_v_15(this: &AiModels) -> Base_Ai_Cf_Baai_Bge_Small_En_V1_5;
     #[wasm_bindgen(method, setter, js_name = "@cf/baai/bge-small-en-v1.5")]
@@ -28720,9 +28844,9 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "@cf/baai/bge-large-en-v1.5")]
     pub fn set_cfbaaibge_large_en_v_15(this: &AiModels, val: &Base_Ai_Cf_Baai_Bge_Large_En_V1_5);
     #[wasm_bindgen(method, getter, js_name = "@cf/unum/uform-gen2-qwen-500m")]
-    pub fn cfunumuform_gen_2_qwen_500_m(this: &AiModels) -> Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M;
+    pub fn cfunumuform_gen2_qwen500_m(this: &AiModels) -> Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M;
     #[wasm_bindgen(method, setter, js_name = "@cf/unum/uform-gen2-qwen-500m")]
-    pub fn set_cfunumuform_gen_2_qwen_500_m(
+    pub fn set_cfunumuform_gen2_qwen500_m(
         this: &AiModels,
         val: &Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M,
     );
@@ -28731,24 +28855,24 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "@cf/openai/whisper-tiny-en")]
     pub fn set_cfopenaiwhisper_tiny_en(this: &AiModels, val: &Base_Ai_Cf_Openai_Whisper_Tiny_En);
     #[wasm_bindgen(method, getter, js_name = "@cf/openai/whisper-large-v3-turbo")]
-    pub fn cfopenaiwhisper_large_v_3_turbo(
+    pub fn cfopenaiwhisper_large_v3_turbo(
         this: &AiModels,
     ) -> Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo;
     #[wasm_bindgen(method, setter, js_name = "@cf/openai/whisper-large-v3-turbo")]
-    pub fn set_cfopenaiwhisper_large_v_3_turbo(
+    pub fn set_cfopenaiwhisper_large_v3_turbo(
         this: &AiModels,
         val: &Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/baai/bge-m3")]
-    pub fn cfbaaibge_m_3(this: &AiModels) -> Base_Ai_Cf_Baai_Bge_M3;
+    pub fn cfbaaibge_m3(this: &AiModels) -> Base_Ai_Cf_Baai_Bge_M3;
     #[wasm_bindgen(method, setter, js_name = "@cf/baai/bge-m3")]
-    pub fn set_cfbaaibge_m_3(this: &AiModels, val: &Base_Ai_Cf_Baai_Bge_M3);
+    pub fn set_cfbaaibge_m3(this: &AiModels, val: &Base_Ai_Cf_Baai_Bge_M3);
     #[wasm_bindgen(method, getter, js_name = "@cf/black-forest-labs/flux-1-schnell")]
-    pub fn cfblack_forest_labsflux_1_schnell(
+    pub fn cfblack_forest_labsflux1_schnell(
         this: &AiModels,
     ) -> Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell;
     #[wasm_bindgen(method, setter, js_name = "@cf/black-forest-labs/flux-1-schnell")]
-    pub fn set_cfblack_forest_labsflux_1_schnell(
+    pub fn set_cfblack_forest_labsflux1_schnell(
         this: &AiModels,
         val: &Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell,
     );
@@ -28762,35 +28886,35 @@ extern "C" {
         val: &Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-3.3-70b-instruct-fp8-fast")]
-    pub fn cfmetallama_33_70_b_instruct_fp_8_fast(
+    pub fn cfmetallama_33_70_b_instruct_fp8_fast(
         this: &AiModels,
     ) -> Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-3.3-70b-instruct-fp8-fast")]
-    pub fn set_cfmetallama_33_70_b_instruct_fp_8_fast(
+    pub fn set_cfmetallama_33_70_b_instruct_fp8_fast(
         this: &AiModels,
         val: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-guard-3-8b")]
-    pub fn cfmetallama_guard_3_8_b(this: &AiModels) -> Base_Ai_Cf_Meta_Llama_Guard_3_8B;
+    pub fn cfmetallama_guard3_8_b(this: &AiModels) -> Base_Ai_Cf_Meta_Llama_Guard_3_8B;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-guard-3-8b")]
-    pub fn set_cfmetallama_guard_3_8_b(this: &AiModels, val: &Base_Ai_Cf_Meta_Llama_Guard_3_8B);
+    pub fn set_cfmetallama_guard3_8_b(this: &AiModels, val: &Base_Ai_Cf_Meta_Llama_Guard_3_8B);
     #[wasm_bindgen(method, getter, js_name = "@cf/baai/bge-reranker-base")]
     pub fn cfbaaibge_reranker_base(this: &AiModels) -> Base_Ai_Cf_Baai_Bge_Reranker_Base;
     #[wasm_bindgen(method, setter, js_name = "@cf/baai/bge-reranker-base")]
     pub fn set_cfbaaibge_reranker_base(this: &AiModels, val: &Base_Ai_Cf_Baai_Bge_Reranker_Base);
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwen2.5-coder-32b-instruct")]
-    pub fn cfqwenqwen_25_coder_32_b_instruct(
+    pub fn cfqwenqwen_25_coder32_b_instruct(
         this: &AiModels,
     ) -> Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwen2.5-coder-32b-instruct")]
-    pub fn set_cfqwenqwen_25_coder_32_b_instruct(
+    pub fn set_cfqwenqwen_25_coder32_b_instruct(
         this: &AiModels,
         val: &Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwq-32b")]
-    pub fn cfqwenqwq_32_b(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwq_32B;
+    pub fn cfqwenqwq32_b(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwq_32B;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwq-32b")]
-    pub fn set_cfqwenqwq_32_b(this: &AiModels, val: &Base_Ai_Cf_Qwen_Qwq_32B);
+    pub fn set_cfqwenqwq32_b(this: &AiModels, val: &Base_Ai_Cf_Qwen_Qwq_32B);
     #[wasm_bindgen(
         method,
         getter,
@@ -28809,51 +28933,48 @@ extern "C" {
         val: &Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/google/gemma-3-12b-it")]
-    pub fn cfgooglegemma_3_12_b_it(this: &AiModels) -> Base_Ai_Cf_Google_Gemma_3_12B_It;
+    pub fn cfgooglegemma3_12_b_it(this: &AiModels) -> Base_Ai_Cf_Google_Gemma_3_12B_It;
     #[wasm_bindgen(method, setter, js_name = "@cf/google/gemma-3-12b-it")]
-    pub fn set_cfgooglegemma_3_12_b_it(this: &AiModels, val: &Base_Ai_Cf_Google_Gemma_3_12B_It);
+    pub fn set_cfgooglegemma3_12_b_it(this: &AiModels, val: &Base_Ai_Cf_Google_Gemma_3_12B_It);
     #[wasm_bindgen(method, getter, js_name = "@cf/meta/llama-4-scout-17b-16e-instruct")]
-    pub fn cfmetallama_4_scout_17_b_16_e_instruct(
+    pub fn cfmetallama4_scout17_b16_e_instruct(
         this: &AiModels,
     ) -> Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct;
     #[wasm_bindgen(method, setter, js_name = "@cf/meta/llama-4-scout-17b-16e-instruct")]
-    pub fn set_cfmetallama_4_scout_17_b_16_e_instruct(
+    pub fn set_cfmetallama4_scout17_b16_e_instruct(
         this: &AiModels,
         val: &Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwen3-30b-a3b-fp8")]
-    pub fn cfqwenqwen_3_30_b_a_3_b_fp_8(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
+    pub fn cfqwenqwen3_30_b_a3_b_fp8(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwen3-30b-a3b-fp8")]
-    pub fn set_cfqwenqwen_3_30_b_a_3_b_fp_8(
-        this: &AiModels,
-        val: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
-    );
+    pub fn set_cfqwenqwen3_30_b_a3_b_fp8(this: &AiModels, val: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8);
     #[wasm_bindgen(method, getter, js_name = "@cf/deepgram/nova-3")]
-    pub fn cfdeepgramnova_3(this: &AiModels) -> Base_Ai_Cf_Deepgram_Nova_3;
+    pub fn cfdeepgramnova3(this: &AiModels) -> Base_Ai_Cf_Deepgram_Nova_3;
     #[wasm_bindgen(method, setter, js_name = "@cf/deepgram/nova-3")]
-    pub fn set_cfdeepgramnova_3(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Nova_3);
+    pub fn set_cfdeepgramnova3(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Nova_3);
     #[wasm_bindgen(method, getter, js_name = "@cf/qwen/qwen3-embedding-0.6b")]
-    pub fn cfqwenqwen_3_embedding_06_b(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
+    pub fn cfqwenqwen3_embedding_06_b(this: &AiModels) -> Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B;
     #[wasm_bindgen(method, setter, js_name = "@cf/qwen/qwen3-embedding-0.6b")]
-    pub fn set_cfqwenqwen_3_embedding_06_b(
+    pub fn set_cfqwenqwen3_embedding_06_b(
         this: &AiModels,
         val: &Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/pipecat-ai/smart-turn-v2")]
-    pub fn cfpipecat_aismart_turn_v_2(this: &AiModels) -> Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
+    pub fn cfpipecat_aismart_turn_v2(this: &AiModels) -> Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2;
     #[wasm_bindgen(method, setter, js_name = "@cf/pipecat-ai/smart-turn-v2")]
-    pub fn set_cfpipecat_aismart_turn_v_2(
+    pub fn set_cfpipecat_aismart_turn_v2(
         this: &AiModels,
         val: &Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/openai/gpt-oss-120b")]
-    pub fn cfopenaigpt_oss_120_b(this: &AiModels) -> Base_Ai_Cf_Openai_Gpt_Oss_120B;
+    pub fn cfopenaigpt_oss120_b(this: &AiModels) -> Base_Ai_Cf_Openai_Gpt_Oss_120B;
     #[wasm_bindgen(method, setter, js_name = "@cf/openai/gpt-oss-120b")]
-    pub fn set_cfopenaigpt_oss_120_b(this: &AiModels, val: &Base_Ai_Cf_Openai_Gpt_Oss_120B);
+    pub fn set_cfopenaigpt_oss120_b(this: &AiModels, val: &Base_Ai_Cf_Openai_Gpt_Oss_120B);
     #[wasm_bindgen(method, getter, js_name = "@cf/openai/gpt-oss-20b")]
-    pub fn cfopenaigpt_oss_20_b(this: &AiModels) -> Base_Ai_Cf_Openai_Gpt_Oss_20B;
+    pub fn cfopenaigpt_oss20_b(this: &AiModels) -> Base_Ai_Cf_Openai_Gpt_Oss_20B;
     #[wasm_bindgen(method, setter, js_name = "@cf/openai/gpt-oss-20b")]
-    pub fn set_cfopenaigpt_oss_20_b(this: &AiModels, val: &Base_Ai_Cf_Openai_Gpt_Oss_20B);
+    pub fn set_cfopenaigpt_oss20_b(this: &AiModels, val: &Base_Ai_Cf_Openai_Gpt_Oss_20B);
     #[wasm_bindgen(method, getter, js_name = "@cf/leonardo/phoenix-1.0")]
     pub fn cfleonardophoenix_10(this: &AiModels) -> Base_Ai_Cf_Leonardo_Phoenix_1_0;
     #[wasm_bindgen(method, setter, js_name = "@cf/leonardo/phoenix-1.0")]
@@ -28863,31 +28984,31 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "@cf/leonardo/lucid-origin")]
     pub fn set_cfleonardolucid_origin(this: &AiModels, val: &Base_Ai_Cf_Leonardo_Lucid_Origin);
     #[wasm_bindgen(method, getter, js_name = "@cf/deepgram/aura-1")]
-    pub fn cfdeepgramaura_1(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_1;
+    pub fn cfdeepgramaura1(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_1;
     #[wasm_bindgen(method, setter, js_name = "@cf/deepgram/aura-1")]
-    pub fn set_cfdeepgramaura_1(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_1);
+    pub fn set_cfdeepgramaura1(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_1);
     #[wasm_bindgen(method, getter, js_name = "@cf/ai4bharat/indictrans2-en-indic-1B")]
-    pub fn cfai_4_bharatindictrans_2_en_indic_1_b(
+    pub fn cfai4_bharatindictrans2_en_indic1_b(
         this: &AiModels,
     ) -> Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B;
     #[wasm_bindgen(method, setter, js_name = "@cf/ai4bharat/indictrans2-en-indic-1B")]
-    pub fn set_cfai_4_bharatindictrans_2_en_indic_1_b(
+    pub fn set_cfai4_bharatindictrans2_en_indic1_b(
         this: &AiModels,
         val: &Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/aisingapore/gemma-sea-lion-v4-27b-it")]
-    pub fn cfaisingaporegemma_sea_lion_v_4_27_b_it(
+    pub fn cfaisingaporegemma_sea_lion_v4_27_b_it(
         this: &AiModels,
     ) -> Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It;
     #[wasm_bindgen(method, setter, js_name = "@cf/aisingapore/gemma-sea-lion-v4-27b-it")]
-    pub fn set_cfaisingaporegemma_sea_lion_v_4_27_b_it(
+    pub fn set_cfaisingaporegemma_sea_lion_v4_27_b_it(
         this: &AiModels,
         val: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
     );
     #[wasm_bindgen(method, getter, js_name = "@cf/pfnet/plamo-embedding-1b")]
-    pub fn cfpfnetplamo_embedding_1_b(this: &AiModels) -> Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
+    pub fn cfpfnetplamo_embedding1_b(this: &AiModels) -> Base_Ai_Cf_Pfnet_Plamo_Embedding_1B;
     #[wasm_bindgen(method, setter, js_name = "@cf/pfnet/plamo-embedding-1b")]
-    pub fn set_cfpfnetplamo_embedding_1_b(
+    pub fn set_cfpfnetplamo_embedding1_b(
         this: &AiModels,
         val: &Base_Ai_Cf_Pfnet_Plamo_Embedding_1B,
     );
@@ -28896,198 +29017,197 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_cfdeepgramflux(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Flux);
     #[wasm_bindgen(method, getter, js_name = "@cf/deepgram/aura-2-en")]
-    pub fn cfdeepgramaura_2_en(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_2_En;
+    pub fn cfdeepgramaura2_en(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_2_En;
     #[wasm_bindgen(method, setter, js_name = "@cf/deepgram/aura-2-en")]
-    pub fn set_cfdeepgramaura_2_en(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_2_En);
+    pub fn set_cfdeepgramaura2_en(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_2_En);
     #[wasm_bindgen(method, getter, js_name = "@cf/deepgram/aura-2-es")]
-    pub fn cfdeepgramaura_2_es(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_2_Es;
+    pub fn cfdeepgramaura2_es(this: &AiModels) -> Base_Ai_Cf_Deepgram_Aura_2_Es;
     #[wasm_bindgen(method, setter, js_name = "@cf/deepgram/aura-2-es")]
-    pub fn set_cfdeepgramaura_2_es(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_2_Es);
+    pub fn set_cfdeepgramaura2_es(this: &AiModels, val: &Base_Ai_Cf_Deepgram_Aura_2_Es);
 }
 impl AiModels {
     pub fn new(
-        cfhuggingfacedistilbert_sst_2_int_8: &BaseAiTextClassification,
+        cfhuggingfacedistilbert_sst2_int8: &BaseAiTextClassification,
         cfstabilityaistable_diffusion_xl_base_10: &BaseAiTextToImage,
-        cfrunwaymlstable_diffusion_v_1_5_inpainting: &BaseAiTextToImage,
-        cfrunwaymlstable_diffusion_v_1_5_img_2_img: &BaseAiTextToImage,
-        cflykondreamshaper_8_lcm: &BaseAiTextToImage,
+        cfrunwaymlstable_diffusion_v1_5_inpainting: &BaseAiTextToImage,
+        cfrunwaymlstable_diffusion_v1_5_img2_img: &BaseAiTextToImage,
+        cflykondreamshaper8_lcm: &BaseAiTextToImage,
         cfbytedancestable_diffusion_xl_lightning: &BaseAiTextToImage,
         cfmyshell_aimelotts: &BaseAiTextToSpeech,
-        cfgoogleembeddinggemma_300_m: &BaseAiTextEmbeddings,
-        cfmicrosoftresnet_50: &BaseAiImageClassification,
-        cfmetallama_2_7_b_chat_int_8: &BaseAiTextGeneration,
-        cfmistralmistral_7_b_instruct_v_01: &BaseAiTextGeneration,
-        cfmetallama_2_7_b_chat_fp_16: &BaseAiTextGeneration,
-        hftheblokellama_2_13_b_chat_awq: &BaseAiTextGeneration,
-        hftheblokemistral_7_b_instruct_v_01_awq: &BaseAiTextGeneration,
-        hftheblokezephyr_7_b_beta_awq: &BaseAiTextGeneration,
-        hftheblokeopenhermes_25_mistral_7_b_awq: &BaseAiTextGeneration,
-        hftheblokeneural_chat_7_b_v_3_1_awq: &BaseAiTextGeneration,
-        hftheblokellamaguard_7_b_awq: &BaseAiTextGeneration,
+        cfgoogleembeddinggemma300_m: &BaseAiTextEmbeddings,
+        cfmicrosoftresnet50: &BaseAiImageClassification,
+        cfmetallama2_7_b_chat_int8: &BaseAiTextGeneration,
+        cfmistralmistral7_b_instruct_v_01: &BaseAiTextGeneration,
+        cfmetallama2_7_b_chat_fp16: &BaseAiTextGeneration,
+        hftheblokellama2_13_b_chat_awq: &BaseAiTextGeneration,
+        hftheblokemistral7_b_instruct_v_01_awq: &BaseAiTextGeneration,
+        hftheblokezephyr7_b_beta_awq: &BaseAiTextGeneration,
+        hftheblokeopenhermes_25_mistral7_b_awq: &BaseAiTextGeneration,
+        hftheblokeneural_chat7_b_v3_1_awq: &BaseAiTextGeneration,
+        hftheblokellamaguard7_b_awq: &BaseAiTextGeneration,
         hftheblokedeepseek_coder_67_b_base_awq: &BaseAiTextGeneration,
         hftheblokedeepseek_coder_67_b_instruct_awq: &BaseAiTextGeneration,
-        cfdeepseek_aideepseek_math_7_b_instruct: &BaseAiTextGeneration,
-        cfdefogsqlcoder_7_b_2: &BaseAiTextGeneration,
+        cfdeepseek_aideepseek_math7_b_instruct: &BaseAiTextGeneration,
+        cfdefogsqlcoder7_b2: &BaseAiTextGeneration,
         cfopenchatopenchat_35_0106: &BaseAiTextGeneration,
-        cftiiuaefalcon_7_b_instruct: &BaseAiTextGeneration,
-        cftheblokediscolm_german_7_b_v_1_awq: &BaseAiTextGeneration,
+        cftiiuaefalcon7_b_instruct: &BaseAiTextGeneration,
+        cftheblokediscolm_german7_b_v1_awq: &BaseAiTextGeneration,
         cfqwenqwen_15_05_b_chat: &BaseAiTextGeneration,
         cfqwenqwen_15_7_b_chat_awq: &BaseAiTextGeneration,
         cfqwenqwen_15_14_b_chat_awq: &BaseAiTextGeneration,
         cftinyllamatinyllama_11_b_chat_v_10: &BaseAiTextGeneration,
-        cfmicrosoftphi_2: &BaseAiTextGeneration,
+        cfmicrosoftphi2: &BaseAiTextGeneration,
         cfqwenqwen_15_18_b_chat: &BaseAiTextGeneration,
-        cfmistralmistral_7_b_instruct_v_02_lora: &BaseAiTextGeneration,
-        hfnousresearchhermes_2_pro_mistral_7_b: &BaseAiTextGeneration,
-        hfnexusflowstarling_lm_7_b_beta: &BaseAiTextGeneration,
-        hfgooglegemma_7_b_it: &BaseAiTextGeneration,
-        cfmeta_llamallama_2_7_b_chat_hf_lora: &BaseAiTextGeneration,
-        cfgooglegemma_2_b_it_lora: &BaseAiTextGeneration,
-        cfgooglegemma_7_b_it_lora: &BaseAiTextGeneration,
-        hfmistralmistral_7_b_instruct_v_02: &BaseAiTextGeneration,
-        cfmetallama_3_8_b_instruct: &BaseAiTextGeneration,
-        cffblgituna_cybertron_7_b_v_2_bf_16: &BaseAiTextGeneration,
-        cfmetallama_3_8_b_instruct_awq: &BaseAiTextGeneration,
-        cfmetallama_31_8_b_instruct_fp_8: &BaseAiTextGeneration,
+        cfmistralmistral7_b_instruct_v_02_lora: &BaseAiTextGeneration,
+        hfnousresearchhermes2_pro_mistral7_b: &BaseAiTextGeneration,
+        hfnexusflowstarling_lm7_b_beta: &BaseAiTextGeneration,
+        hfgooglegemma7_b_it: &BaseAiTextGeneration,
+        cfmeta_llamallama2_7_b_chat_hf_lora: &BaseAiTextGeneration,
+        cfgooglegemma2_b_it_lora: &BaseAiTextGeneration,
+        cfgooglegemma7_b_it_lora: &BaseAiTextGeneration,
+        hfmistralmistral7_b_instruct_v_02: &BaseAiTextGeneration,
+        cfmetallama3_8_b_instruct: &BaseAiTextGeneration,
+        cffblgituna_cybertron7_b_v2_bf16: &BaseAiTextGeneration,
+        cfmetallama3_8_b_instruct_awq: &BaseAiTextGeneration,
+        cfmetallama_31_8_b_instruct_fp8: &BaseAiTextGeneration,
         cfmetallama_31_8_b_instruct_awq: &BaseAiTextGeneration,
         cfmetallama_32_3_b_instruct: &BaseAiTextGeneration,
         cfmetallama_32_1_b_instruct: &BaseAiTextGeneration,
-        cfdeepseek_aideepseek_r_1_distill_qwen_32_b: &BaseAiTextGeneration,
+        cfdeepseek_aideepseek_r1_distill_qwen32_b: &BaseAiTextGeneration,
         cfibm_granitegranite_40_h_micro: &BaseAiTextGeneration,
         cffacebookbart_large_cnn: &BaseAiSummarization,
         cfllava_hfllava_15_7_b_hf: &BaseAiImageToText,
         cfbaaibge_base_en_v_15: &Base_Ai_Cf_Baai_Bge_Base_En_V1_5,
         cfopenaiwhisper: &Base_Ai_Cf_Openai_Whisper,
-        cfmetam_2_m_100_12_b: &Base_Ai_Cf_Meta_M2M100_1_2B,
+        cfmetam2_m100_12_b: &Base_Ai_Cf_Meta_M2M100_1_2B,
         cfbaaibge_small_en_v_15: &Base_Ai_Cf_Baai_Bge_Small_En_V1_5,
         cfbaaibge_large_en_v_15: &Base_Ai_Cf_Baai_Bge_Large_En_V1_5,
-        cfunumuform_gen_2_qwen_500_m: &Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M,
+        cfunumuform_gen2_qwen500_m: &Base_Ai_Cf_Unum_Uform_Gen2_Qwen_500M,
         cfopenaiwhisper_tiny_en: &Base_Ai_Cf_Openai_Whisper_Tiny_En,
-        cfopenaiwhisper_large_v_3_turbo: &Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo,
-        cfbaaibge_m_3: &Base_Ai_Cf_Baai_Bge_M3,
-        cfblack_forest_labsflux_1_schnell: &Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell,
+        cfopenaiwhisper_large_v3_turbo: &Base_Ai_Cf_Openai_Whisper_Large_V3_Turbo,
+        cfbaaibge_m3: &Base_Ai_Cf_Baai_Bge_M3,
+        cfblack_forest_labsflux1_schnell: &Base_Ai_Cf_Black_Forest_Labs_Flux_1_Schnell,
         cfmetallama_32_11_b_vision_instruct: &Base_Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct,
-        cfmetallama_33_70_b_instruct_fp_8_fast: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
-        cfmetallama_guard_3_8_b: &Base_Ai_Cf_Meta_Llama_Guard_3_8B,
+        cfmetallama_33_70_b_instruct_fp8_fast: &Base_Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast,
+        cfmetallama_guard3_8_b: &Base_Ai_Cf_Meta_Llama_Guard_3_8B,
         cfbaaibge_reranker_base: &Base_Ai_Cf_Baai_Bge_Reranker_Base,
-        cfqwenqwen_25_coder_32_b_instruct: &Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct,
-        cfqwenqwq_32_b: &Base_Ai_Cf_Qwen_Qwq_32B,
+        cfqwenqwen_25_coder32_b_instruct: &Base_Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct,
+        cfqwenqwq32_b: &Base_Ai_Cf_Qwen_Qwq_32B,
         cfmistralaimistral_small_31_24_b_instruct : & Base_Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct,
-        cfgooglegemma_3_12_b_it: &Base_Ai_Cf_Google_Gemma_3_12B_It,
-        cfmetallama_4_scout_17_b_16_e_instruct: &Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct,
-        cfqwenqwen_3_30_b_a_3_b_fp_8: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
-        cfdeepgramnova_3: &Base_Ai_Cf_Deepgram_Nova_3,
-        cfqwenqwen_3_embedding_06_b: &Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B,
-        cfpipecat_aismart_turn_v_2: &Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2,
-        cfopenaigpt_oss_120_b: &Base_Ai_Cf_Openai_Gpt_Oss_120B,
-        cfopenaigpt_oss_20_b: &Base_Ai_Cf_Openai_Gpt_Oss_20B,
+        cfgooglegemma3_12_b_it: &Base_Ai_Cf_Google_Gemma_3_12B_It,
+        cfmetallama4_scout17_b16_e_instruct: &Base_Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct,
+        cfqwenqwen3_30_b_a3_b_fp8: &Base_Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8,
+        cfdeepgramnova3: &Base_Ai_Cf_Deepgram_Nova_3,
+        cfqwenqwen3_embedding_06_b: &Base_Ai_Cf_Qwen_Qwen3_Embedding_0_6B,
+        cfpipecat_aismart_turn_v2: &Base_Ai_Cf_Pipecat_Ai_Smart_Turn_V2,
+        cfopenaigpt_oss120_b: &Base_Ai_Cf_Openai_Gpt_Oss_120B,
+        cfopenaigpt_oss20_b: &Base_Ai_Cf_Openai_Gpt_Oss_20B,
         cfleonardophoenix_10: &Base_Ai_Cf_Leonardo_Phoenix_1_0,
         cfleonardolucid_origin: &Base_Ai_Cf_Leonardo_Lucid_Origin,
-        cfdeepgramaura_1: &Base_Ai_Cf_Deepgram_Aura_1,
-        cfai_4_bharatindictrans_2_en_indic_1_b: &Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B,
-        cfaisingaporegemma_sea_lion_v_4_27_b_it: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
-        cfpfnetplamo_embedding_1_b: &Base_Ai_Cf_Pfnet_Plamo_Embedding_1B,
+        cfdeepgramaura1: &Base_Ai_Cf_Deepgram_Aura_1,
+        cfai4_bharatindictrans2_en_indic1_b: &Base_Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B,
+        cfaisingaporegemma_sea_lion_v4_27_b_it: &Base_Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It,
+        cfpfnetplamo_embedding1_b: &Base_Ai_Cf_Pfnet_Plamo_Embedding_1B,
         cfdeepgramflux: &Base_Ai_Cf_Deepgram_Flux,
-        cfdeepgramaura_2_en: &Base_Ai_Cf_Deepgram_Aura_2_En,
-        cfdeepgramaura_2_es: &Base_Ai_Cf_Deepgram_Aura_2_Es,
+        cfdeepgramaura2_en: &Base_Ai_Cf_Deepgram_Aura_2_En,
+        cfdeepgramaura2_es: &Base_Ai_Cf_Deepgram_Aura_2_Es,
     ) -> AiModels {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cfhuggingfacedistilbert_sst_2_int_8(cfhuggingfacedistilbert_sst_2_int_8);
+        inner.set_cfhuggingfacedistilbert_sst2_int8(cfhuggingfacedistilbert_sst2_int8);
         inner
             .set_cfstabilityaistable_diffusion_xl_base_10(cfstabilityaistable_diffusion_xl_base_10);
-        inner.set_cfrunwaymlstable_diffusion_v_1_5_inpainting(
-            cfrunwaymlstable_diffusion_v_1_5_inpainting,
+        inner.set_cfrunwaymlstable_diffusion_v1_5_inpainting(
+            cfrunwaymlstable_diffusion_v1_5_inpainting,
         );
-        inner.set_cfrunwaymlstable_diffusion_v_1_5_img_2_img(
-            cfrunwaymlstable_diffusion_v_1_5_img_2_img,
-        );
-        inner.set_cflykondreamshaper_8_lcm(cflykondreamshaper_8_lcm);
+        inner
+            .set_cfrunwaymlstable_diffusion_v1_5_img2_img(cfrunwaymlstable_diffusion_v1_5_img2_img);
+        inner.set_cflykondreamshaper8_lcm(cflykondreamshaper8_lcm);
         inner
             .set_cfbytedancestable_diffusion_xl_lightning(cfbytedancestable_diffusion_xl_lightning);
         inner.set_cfmyshell_aimelotts(cfmyshell_aimelotts);
-        inner.set_cfgoogleembeddinggemma_300_m(cfgoogleembeddinggemma_300_m);
-        inner.set_cfmicrosoftresnet_50(cfmicrosoftresnet_50);
-        inner.set_cfmetallama_2_7_b_chat_int_8(cfmetallama_2_7_b_chat_int_8);
-        inner.set_cfmistralmistral_7_b_instruct_v_01(cfmistralmistral_7_b_instruct_v_01);
-        inner.set_cfmetallama_2_7_b_chat_fp_16(cfmetallama_2_7_b_chat_fp_16);
-        inner.set_hftheblokellama_2_13_b_chat_awq(hftheblokellama_2_13_b_chat_awq);
-        inner.set_hftheblokemistral_7_b_instruct_v_01_awq(hftheblokemistral_7_b_instruct_v_01_awq);
-        inner.set_hftheblokezephyr_7_b_beta_awq(hftheblokezephyr_7_b_beta_awq);
-        inner.set_hftheblokeopenhermes_25_mistral_7_b_awq(hftheblokeopenhermes_25_mistral_7_b_awq);
-        inner.set_hftheblokeneural_chat_7_b_v_3_1_awq(hftheblokeneural_chat_7_b_v_3_1_awq);
-        inner.set_hftheblokellamaguard_7_b_awq(hftheblokellamaguard_7_b_awq);
+        inner.set_cfgoogleembeddinggemma300_m(cfgoogleembeddinggemma300_m);
+        inner.set_cfmicrosoftresnet50(cfmicrosoftresnet50);
+        inner.set_cfmetallama2_7_b_chat_int8(cfmetallama2_7_b_chat_int8);
+        inner.set_cfmistralmistral7_b_instruct_v_01(cfmistralmistral7_b_instruct_v_01);
+        inner.set_cfmetallama2_7_b_chat_fp16(cfmetallama2_7_b_chat_fp16);
+        inner.set_hftheblokellama2_13_b_chat_awq(hftheblokellama2_13_b_chat_awq);
+        inner.set_hftheblokemistral7_b_instruct_v_01_awq(hftheblokemistral7_b_instruct_v_01_awq);
+        inner.set_hftheblokezephyr7_b_beta_awq(hftheblokezephyr7_b_beta_awq);
+        inner.set_hftheblokeopenhermes_25_mistral7_b_awq(hftheblokeopenhermes_25_mistral7_b_awq);
+        inner.set_hftheblokeneural_chat7_b_v3_1_awq(hftheblokeneural_chat7_b_v3_1_awq);
+        inner.set_hftheblokellamaguard7_b_awq(hftheblokellamaguard7_b_awq);
         inner.set_hftheblokedeepseek_coder_67_b_base_awq(hftheblokedeepseek_coder_67_b_base_awq);
         inner.set_hftheblokedeepseek_coder_67_b_instruct_awq(
             hftheblokedeepseek_coder_67_b_instruct_awq,
         );
-        inner.set_cfdeepseek_aideepseek_math_7_b_instruct(cfdeepseek_aideepseek_math_7_b_instruct);
-        inner.set_cfdefogsqlcoder_7_b_2(cfdefogsqlcoder_7_b_2);
+        inner.set_cfdeepseek_aideepseek_math7_b_instruct(cfdeepseek_aideepseek_math7_b_instruct);
+        inner.set_cfdefogsqlcoder7_b2(cfdefogsqlcoder7_b2);
         inner.set_cfopenchatopenchat_35_0106(cfopenchatopenchat_35_0106);
-        inner.set_cftiiuaefalcon_7_b_instruct(cftiiuaefalcon_7_b_instruct);
-        inner.set_cftheblokediscolm_german_7_b_v_1_awq(cftheblokediscolm_german_7_b_v_1_awq);
+        inner.set_cftiiuaefalcon7_b_instruct(cftiiuaefalcon7_b_instruct);
+        inner.set_cftheblokediscolm_german7_b_v1_awq(cftheblokediscolm_german7_b_v1_awq);
         inner.set_cfqwenqwen_15_05_b_chat(cfqwenqwen_15_05_b_chat);
         inner.set_cfqwenqwen_15_7_b_chat_awq(cfqwenqwen_15_7_b_chat_awq);
         inner.set_cfqwenqwen_15_14_b_chat_awq(cfqwenqwen_15_14_b_chat_awq);
         inner.set_cftinyllamatinyllama_11_b_chat_v_10(cftinyllamatinyllama_11_b_chat_v_10);
-        inner.set_cfmicrosoftphi_2(cfmicrosoftphi_2);
+        inner.set_cfmicrosoftphi2(cfmicrosoftphi2);
         inner.set_cfqwenqwen_15_18_b_chat(cfqwenqwen_15_18_b_chat);
-        inner.set_cfmistralmistral_7_b_instruct_v_02_lora(cfmistralmistral_7_b_instruct_v_02_lora);
-        inner.set_hfnousresearchhermes_2_pro_mistral_7_b(hfnousresearchhermes_2_pro_mistral_7_b);
-        inner.set_hfnexusflowstarling_lm_7_b_beta(hfnexusflowstarling_lm_7_b_beta);
-        inner.set_hfgooglegemma_7_b_it(hfgooglegemma_7_b_it);
-        inner.set_cfmeta_llamallama_2_7_b_chat_hf_lora(cfmeta_llamallama_2_7_b_chat_hf_lora);
-        inner.set_cfgooglegemma_2_b_it_lora(cfgooglegemma_2_b_it_lora);
-        inner.set_cfgooglegemma_7_b_it_lora(cfgooglegemma_7_b_it_lora);
-        inner.set_hfmistralmistral_7_b_instruct_v_02(hfmistralmistral_7_b_instruct_v_02);
-        inner.set_cfmetallama_3_8_b_instruct(cfmetallama_3_8_b_instruct);
-        inner.set_cffblgituna_cybertron_7_b_v_2_bf_16(cffblgituna_cybertron_7_b_v_2_bf_16);
-        inner.set_cfmetallama_3_8_b_instruct_awq(cfmetallama_3_8_b_instruct_awq);
-        inner.set_cfmetallama_31_8_b_instruct_fp_8(cfmetallama_31_8_b_instruct_fp_8);
+        inner.set_cfmistralmistral7_b_instruct_v_02_lora(cfmistralmistral7_b_instruct_v_02_lora);
+        inner.set_hfnousresearchhermes2_pro_mistral7_b(hfnousresearchhermes2_pro_mistral7_b);
+        inner.set_hfnexusflowstarling_lm7_b_beta(hfnexusflowstarling_lm7_b_beta);
+        inner.set_hfgooglegemma7_b_it(hfgooglegemma7_b_it);
+        inner.set_cfmeta_llamallama2_7_b_chat_hf_lora(cfmeta_llamallama2_7_b_chat_hf_lora);
+        inner.set_cfgooglegemma2_b_it_lora(cfgooglegemma2_b_it_lora);
+        inner.set_cfgooglegemma7_b_it_lora(cfgooglegemma7_b_it_lora);
+        inner.set_hfmistralmistral7_b_instruct_v_02(hfmistralmistral7_b_instruct_v_02);
+        inner.set_cfmetallama3_8_b_instruct(cfmetallama3_8_b_instruct);
+        inner.set_cffblgituna_cybertron7_b_v2_bf16(cffblgituna_cybertron7_b_v2_bf16);
+        inner.set_cfmetallama3_8_b_instruct_awq(cfmetallama3_8_b_instruct_awq);
+        inner.set_cfmetallama_31_8_b_instruct_fp8(cfmetallama_31_8_b_instruct_fp8);
         inner.set_cfmetallama_31_8_b_instruct_awq(cfmetallama_31_8_b_instruct_awq);
         inner.set_cfmetallama_32_3_b_instruct(cfmetallama_32_3_b_instruct);
         inner.set_cfmetallama_32_1_b_instruct(cfmetallama_32_1_b_instruct);
-        inner.set_cfdeepseek_aideepseek_r_1_distill_qwen_32_b(
-            cfdeepseek_aideepseek_r_1_distill_qwen_32_b,
+        inner.set_cfdeepseek_aideepseek_r1_distill_qwen32_b(
+            cfdeepseek_aideepseek_r1_distill_qwen32_b,
         );
         inner.set_cfibm_granitegranite_40_h_micro(cfibm_granitegranite_40_h_micro);
         inner.set_cffacebookbart_large_cnn(cffacebookbart_large_cnn);
         inner.set_cfllava_hfllava_15_7_b_hf(cfllava_hfllava_15_7_b_hf);
         inner.set_cfbaaibge_base_en_v_15(cfbaaibge_base_en_v_15);
         inner.set_cfopenaiwhisper(cfopenaiwhisper);
-        inner.set_cfmetam_2_m_100_12_b(cfmetam_2_m_100_12_b);
+        inner.set_cfmetam2_m100_12_b(cfmetam2_m100_12_b);
         inner.set_cfbaaibge_small_en_v_15(cfbaaibge_small_en_v_15);
         inner.set_cfbaaibge_large_en_v_15(cfbaaibge_large_en_v_15);
-        inner.set_cfunumuform_gen_2_qwen_500_m(cfunumuform_gen_2_qwen_500_m);
+        inner.set_cfunumuform_gen2_qwen500_m(cfunumuform_gen2_qwen500_m);
         inner.set_cfopenaiwhisper_tiny_en(cfopenaiwhisper_tiny_en);
-        inner.set_cfopenaiwhisper_large_v_3_turbo(cfopenaiwhisper_large_v_3_turbo);
-        inner.set_cfbaaibge_m_3(cfbaaibge_m_3);
-        inner.set_cfblack_forest_labsflux_1_schnell(cfblack_forest_labsflux_1_schnell);
+        inner.set_cfopenaiwhisper_large_v3_turbo(cfopenaiwhisper_large_v3_turbo);
+        inner.set_cfbaaibge_m3(cfbaaibge_m3);
+        inner.set_cfblack_forest_labsflux1_schnell(cfblack_forest_labsflux1_schnell);
         inner.set_cfmetallama_32_11_b_vision_instruct(cfmetallama_32_11_b_vision_instruct);
-        inner.set_cfmetallama_33_70_b_instruct_fp_8_fast(cfmetallama_33_70_b_instruct_fp_8_fast);
-        inner.set_cfmetallama_guard_3_8_b(cfmetallama_guard_3_8_b);
+        inner.set_cfmetallama_33_70_b_instruct_fp8_fast(cfmetallama_33_70_b_instruct_fp8_fast);
+        inner.set_cfmetallama_guard3_8_b(cfmetallama_guard3_8_b);
         inner.set_cfbaaibge_reranker_base(cfbaaibge_reranker_base);
-        inner.set_cfqwenqwen_25_coder_32_b_instruct(cfqwenqwen_25_coder_32_b_instruct);
-        inner.set_cfqwenqwq_32_b(cfqwenqwq_32_b);
+        inner.set_cfqwenqwen_25_coder32_b_instruct(cfqwenqwen_25_coder32_b_instruct);
+        inner.set_cfqwenqwq32_b(cfqwenqwq32_b);
         inner.set_cfmistralaimistral_small_31_24_b_instruct(
             cfmistralaimistral_small_31_24_b_instruct,
         );
-        inner.set_cfgooglegemma_3_12_b_it(cfgooglegemma_3_12_b_it);
-        inner.set_cfmetallama_4_scout_17_b_16_e_instruct(cfmetallama_4_scout_17_b_16_e_instruct);
-        inner.set_cfqwenqwen_3_30_b_a_3_b_fp_8(cfqwenqwen_3_30_b_a_3_b_fp_8);
-        inner.set_cfdeepgramnova_3(cfdeepgramnova_3);
-        inner.set_cfqwenqwen_3_embedding_06_b(cfqwenqwen_3_embedding_06_b);
-        inner.set_cfpipecat_aismart_turn_v_2(cfpipecat_aismart_turn_v_2);
-        inner.set_cfopenaigpt_oss_120_b(cfopenaigpt_oss_120_b);
-        inner.set_cfopenaigpt_oss_20_b(cfopenaigpt_oss_20_b);
+        inner.set_cfgooglegemma3_12_b_it(cfgooglegemma3_12_b_it);
+        inner.set_cfmetallama4_scout17_b16_e_instruct(cfmetallama4_scout17_b16_e_instruct);
+        inner.set_cfqwenqwen3_30_b_a3_b_fp8(cfqwenqwen3_30_b_a3_b_fp8);
+        inner.set_cfdeepgramnova3(cfdeepgramnova3);
+        inner.set_cfqwenqwen3_embedding_06_b(cfqwenqwen3_embedding_06_b);
+        inner.set_cfpipecat_aismart_turn_v2(cfpipecat_aismart_turn_v2);
+        inner.set_cfopenaigpt_oss120_b(cfopenaigpt_oss120_b);
+        inner.set_cfopenaigpt_oss20_b(cfopenaigpt_oss20_b);
         inner.set_cfleonardophoenix_10(cfleonardophoenix_10);
         inner.set_cfleonardolucid_origin(cfleonardolucid_origin);
-        inner.set_cfdeepgramaura_1(cfdeepgramaura_1);
-        inner.set_cfai_4_bharatindictrans_2_en_indic_1_b(cfai_4_bharatindictrans_2_en_indic_1_b);
-        inner.set_cfaisingaporegemma_sea_lion_v_4_27_b_it(cfaisingaporegemma_sea_lion_v_4_27_b_it);
-        inner.set_cfpfnetplamo_embedding_1_b(cfpfnetplamo_embedding_1_b);
+        inner.set_cfdeepgramaura1(cfdeepgramaura1);
+        inner.set_cfai4_bharatindictrans2_en_indic1_b(cfai4_bharatindictrans2_en_indic1_b);
+        inner.set_cfaisingaporegemma_sea_lion_v4_27_b_it(cfaisingaporegemma_sea_lion_v4_27_b_it);
+        inner.set_cfpfnetplamo_embedding1_b(cfpfnetplamo_embedding1_b);
         inner.set_cfdeepgramflux(cfdeepgramflux);
-        inner.set_cfdeepgramaura_2_en(cfdeepgramaura_2_en);
-        inner.set_cfdeepgramaura_2_es(cfdeepgramaura_2_es);
+        inner.set_cfdeepgramaura2_en(cfdeepgramaura2_en);
+        inner.set_cfdeepgramaura2_es(cfdeepgramaura2_es);
         inner
     }
 }
@@ -29566,6 +29686,7 @@ extern "C" {
     pub fn skip_cache(this: &GatewayOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "skipCache")]
     pub fn set_skip_cache(this: &GatewayOptions, val: bool);
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null>"]
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &GatewayOptions) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
@@ -29656,6 +29777,7 @@ extern "C" {
     pub fn set_feedback(this: &AiGatewayPatchLog, val: f64);
     #[wasm_bindgen(method, setter, js_name = "feedback")]
     pub fn set_feedback_with_null(this: &AiGatewayPatchLog, val: &Null);
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null> | null"]
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &AiGatewayPatchLog) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
@@ -29766,6 +29888,7 @@ extern "C" {
     pub fn tokens_out(this: &AiGatewayLog) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_tokens_out(this: &AiGatewayLog, val: f64);
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null>"]
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &AiGatewayLog) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
@@ -29981,24 +30104,28 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AIGatewayHeaders;
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null> | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-metadata")]
     pub fn cf_aig_metadata(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
     pub fn set_cf_aig_metadata(this: &AIGatewayHeaders, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-metadata")]
     pub fn set_cf_aig_metadata_with_str(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: object | object | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-custom-cost")]
     pub fn cf_aig_custom_cost(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-custom-cost")]
     pub fn set_cf_aig_custom_cost(this: &AIGatewayHeaders, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-custom-cost")]
     pub fn set_cf_aig_custom_cost_with_str(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: number | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-cache-ttl")]
     pub fn cf_aig_cache_ttl(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-cache-ttl")]
     pub fn set_cf_aig_cache_ttl(this: &AIGatewayHeaders, val: f64);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-cache-ttl")]
     pub fn set_cf_aig_cache_ttl_with_str(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: boolean | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-skip-cache")]
     pub fn cf_aig_skip_cache(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-skip-cache")]
@@ -30013,18 +30140,21 @@ extern "C" {
     pub fn cf_aig_event_id(this: &AIGatewayHeaders) -> String;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-event-id")]
     pub fn set_cf_aig_event_id(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: number | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-request-timeout")]
     pub fn cf_aig_request_timeout(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-request-timeout")]
     pub fn set_cf_aig_request_timeout(this: &AIGatewayHeaders, val: f64);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-request-timeout")]
     pub fn set_cf_aig_request_timeout_with_str(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: number | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-max-attempts")]
     pub fn cf_aig_max_attempts(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-max-attempts")]
     pub fn set_cf_aig_max_attempts(this: &AIGatewayHeaders, val: f64);
     #[wasm_bindgen(method, setter, js_name = "cf-aig-max-attempts")]
     pub fn set_cf_aig_max_attempts_with_str(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: number | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-retry-delay")]
     pub fn cf_aig_retry_delay(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-retry-delay")]
@@ -30035,6 +30165,7 @@ extern "C" {
     pub fn cf_aig_backoff(this: &AIGatewayHeaders) -> String;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-backoff")]
     pub fn set_cf_aig_backoff(this: &AIGatewayHeaders, val: &str);
+    #[doc = " Returns: boolean | string"]
     #[wasm_bindgen(method, getter, js_name = "cf-aig-collect-log")]
     pub fn cf_aig_collect_log(this: &AIGatewayHeaders) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "cf-aig-collect-log")]
@@ -38024,6 +38155,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AIGatewayUniversalRequest;
+    #[doc = " Returns: AIGatewayProviders | string"]
     #[wasm_bindgen(method, getter)]
     pub fn provider(this: &AIGatewayUniversalRequest) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -38205,6 +38337,7 @@ extern "C" {
     pub fn type_(this: &ComparisonFilter) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &ComparisonFilter, val: &str);
+    #[doc = " Returns: string | number | boolean"]
     #[wasm_bindgen(method, getter)]
     pub fn value(this: &ComparisonFilter) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -38439,6 +38572,7 @@ extern "C" {
     pub fn query(this: &AutoRagSearchRequest) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_query(this: &AutoRagSearchRequest, val: &str);
+    #[doc = " Returns: CompoundFilter | ComparisonFilter"]
     #[wasm_bindgen(method, getter)]
     pub fn filters(this: &AutoRagSearchRequest) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -38641,6 +38775,8 @@ extern "C" {
     #[doc = " from the top. {fit: \"cover\", gravity: {x:0.5, y:0.2}} will crop each side to"]
     #[doc = " preserve as much as possible around a point at 20% of the height of the"]
     #[doc = " source image."]
+    #[doc = ""]
+    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | BasicImageTransformationsGravityCoordinates"]
     #[wasm_bindgen(method, getter)]
     pub fn gravity(this: &BasicImageTransformations) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -38830,10 +38966,10 @@ extern "C" {
     pub fn polish(this: &RequestInitCfProperties) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_polish(this: &RequestInitCfProperties, val: &str);
-    #[wasm_bindgen(method, getter, js_name = "r2")]
-    pub fn r_2(this: &RequestInitCfProperties) -> Option<RequestInitCfPropertiesR2>;
-    #[wasm_bindgen(method, setter, js_name = "r2")]
-    pub fn set_r_2(this: &RequestInitCfProperties, val: &RequestInitCfPropertiesR2);
+    #[wasm_bindgen(method, getter)]
+    pub fn r2(this: &RequestInitCfProperties) -> Option<RequestInitCfPropertiesR2>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_r2(this: &RequestInitCfProperties, val: &RequestInitCfPropertiesR2);
     #[doc = " Redirects the request to an alternate origin server. You can use this,"]
     #[doc = " for example, to implement load balancing across several origins."]
     #[doc = " (e.g.us-east.example.com)"]
@@ -38908,8 +39044,8 @@ impl RequestInitCfPropertiesBuilder {
         self.inner.set_polish(val);
         self
     }
-    pub fn r_2(self, val: &RequestInitCfPropertiesR2) -> Self {
-        self.inner.set_r_2(val);
+    pub fn r2(self, val: &RequestInitCfPropertiesR2) -> Self {
+        self.inner.set_r2(val);
         self
     }
     pub fn resolve_override(self, val: &str) -> Self {
@@ -38944,6 +39080,8 @@ extern "C" {
     #[doc = "   (form a line)."]
     #[doc = " - If set to \"y\", the overlay image will be tiled vertically only"]
     #[doc = "   (form a line)."]
+    #[doc = ""]
+    #[doc = " Returns: true | \"x\" | \"y\""]
     #[wasm_bindgen(method, getter)]
     pub fn repeat(this: &RequestInitCfPropertiesImageDraw) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -39052,6 +39190,8 @@ extern "C" {
     #[doc = "    - color: rgb or hex representation of the color you wish to trim (todo: verify the rgba bit)"]
     #[doc = "    - tolerance: difference from color to treat as color"]
     #[doc = "    - keep: the number of pixels of border to keep"]
+    #[doc = ""]
+    #[doc = " Returns: \"border\" | object"]
     #[wasm_bindgen(method, getter)]
     pub fn trim(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -39061,6 +39201,8 @@ extern "C" {
     #[doc = " Quality setting from 1-100 (useful values are in 60-90 range). Lower values"]
     #[doc = " make images look worse, but load faster. The default is 85. It applies only"]
     #[doc = " to JPEG and WebP images. It doesnâ€™t have any effect on PNG."]
+    #[doc = ""]
+    #[doc = " Returns: number | \"low\" | \"medium-low\" | \"medium-high\" | \"high\""]
     #[wasm_bindgen(method, getter)]
     pub fn quality(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -39139,6 +39281,8 @@ extern "C" {
     #[doc = " Adds a border around the image. The border is added after resizing. Border"]
     #[doc = " width takes dpr into account, and can be specified either using a single"]
     #[doc = " width property, or individually for each side."]
+    #[doc = ""]
+    #[doc = " Returns: object | object"]
     #[wasm_bindgen(method, getter)]
     pub fn border(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -39494,7 +39638,7 @@ impl IncomingRequestCfPropertiesBase {
     #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
     pub fn new(
         colo: &str,
-        edge_request_keep_alive_status: f64,
+        edge_request_keep_alive_status: &f64,
         http_protocol: &str,
         request_priority: &str,
         tls_version: &str,
@@ -39540,7 +39684,7 @@ impl IncomingRequestCfPropertiesBase {
     #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
     pub fn builder(
         colo: &str,
-        edge_request_keep_alive_status: f64,
+        edge_request_keep_alive_status: &f64,
         http_protocol: &str,
         request_priority: &str,
         tls_version: &str,
@@ -39771,6 +39915,8 @@ extern "C" {
     #[doc = ""]
     #[doc = " The property `certPresented` will be set to `\"1\"` when"]
     #[doc = " the object is populated (i.e. the above conditions were met)."]
+    #[doc = ""]
+    #[doc = " Returns: IncomingRequestCfPropertiesTLSClientAuth | IncomingRequestCfPropertiesTLSClientAuthPlaceholder"]
     #[wasm_bindgen(method, getter, js_name = "tlsClientAuth")]
     pub fn tls_client_auth(
         this: &IncomingRequestCfPropertiesCloudflareAccessOrApiShield,
@@ -39923,6 +40069,8 @@ extern "C" {
     #[doc = " The country code `\"T1\"` is used for requests originating on TOR."]
     #[doc = ""]
     #[doc = " @example \"GB\""]
+    #[doc = ""]
+    #[doc = " Returns: Iso3166Alpha2Code | \"T1\""]
     #[wasm_bindgen(method, getter)]
     pub fn country(this: &IncomingRequestCfPropertiesGeographicInformation) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -40127,16 +40275,16 @@ extern "C" {
     #[doc = ""]
     #[doc = " @example \"CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
     #[wasm_bindgen(method, getter, js_name = "certIssuerDNRFC2253")]
-    pub fn cert_issuer_dnrfc_2253(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
+    pub fn cert_issuer_dnrfc2253(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
     #[wasm_bindgen(method, setter, js_name = "certIssuerDNRFC2253")]
-    pub fn set_cert_issuer_dnrfc_2253(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
+    pub fn set_cert_issuer_dnrfc2253(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
     #[doc = " The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
     #[doc = ""]
     #[doc = " @example \"CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
     #[wasm_bindgen(method, getter, js_name = "certSubjectDNRFC2253")]
-    pub fn cert_subject_dnrfc_2253(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
+    pub fn cert_subject_dnrfc2253(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
     #[wasm_bindgen(method, setter, js_name = "certSubjectDNRFC2253")]
-    pub fn set_cert_subject_dnrfc_2253(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
+    pub fn set_cert_subject_dnrfc2253(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
     #[doc = " The certificate issuer's distinguished name (legacy policies)"]
     #[wasm_bindgen(method, getter, js_name = "certIssuerDNLegacy")]
     pub fn cert_issuer_dn_legacy(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
@@ -40179,16 +40327,16 @@ extern "C" {
     #[doc = ""]
     #[doc = " @example \"6b9109f323999e52259cda7373ff0b4d26bd232e\""]
     #[wasm_bindgen(method, getter, js_name = "certFingerprintSHA1")]
-    pub fn cert_fingerprint_sha_1(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
+    pub fn cert_fingerprint_sha1(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
     #[wasm_bindgen(method, setter, js_name = "certFingerprintSHA1")]
-    pub fn set_cert_fingerprint_sha_1(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
+    pub fn set_cert_fingerprint_sha1(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
     #[doc = " The certificate's SHA-256 fingerprint"]
     #[doc = ""]
     #[doc = " @example \"acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea\""]
     #[wasm_bindgen(method, getter, js_name = "certFingerprintSHA256")]
-    pub fn cert_fingerprint_sha_256(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
+    pub fn cert_fingerprint_sha256(this: &IncomingRequestCfPropertiesTLSClientAuth) -> String;
     #[wasm_bindgen(method, setter, js_name = "certFingerprintSHA256")]
-    pub fn set_cert_fingerprint_sha_256(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
+    pub fn set_cert_fingerprint_sha256(this: &IncomingRequestCfPropertiesTLSClientAuth, val: &str);
     #[doc = " The effective starting date of the certificate"]
     #[doc = ""]
     #[doc = " @example \"Dec 22 19:39:00 2018 GMT\""]
@@ -40222,10 +40370,10 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
     #[doc = " * `cert_subject_dn` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)"]
     #[doc = ""]
     #[doc = " @example \"CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
-    #[doc = " * `cert_issuer_dnrfc_2253` - The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
+    #[doc = " * `cert_issuer_dnrfc2253` - The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
     #[doc = ""]
     #[doc = " @example \"CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
-    #[doc = " * `cert_subject_dnrfc_2253` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
+    #[doc = " * `cert_subject_dnrfc2253` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
     #[doc = ""]
     #[doc = " @example \"CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
     #[doc = " * `cert_issuer_dn_legacy` - The certificate issuer's distinguished name (legacy policies)"]
@@ -40242,10 +40390,10 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
     #[doc = " * `cert_issuer_ski` - The certificate issuer's Subject Key Identifier"]
     #[doc = ""]
     #[doc = " @example \"BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4\""]
-    #[doc = " * `cert_fingerprint_sha_1` - The certificate's SHA-1 fingerprint"]
+    #[doc = " * `cert_fingerprint_sha1` - The certificate's SHA-1 fingerprint"]
     #[doc = ""]
     #[doc = " @example \"6b9109f323999e52259cda7373ff0b4d26bd232e\""]
-    #[doc = " * `cert_fingerprint_sha_256` - The certificate's SHA-256 fingerprint"]
+    #[doc = " * `cert_fingerprint_sha256` - The certificate's SHA-256 fingerprint"]
     #[doc = ""]
     #[doc = " @example \"acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea\""]
     #[doc = " * `cert_not_before` - The effective starting date of the certificate"]
@@ -40258,16 +40406,16 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
         cert_verified: &CertVerificationStatus,
         cert_issuer_dn: &str,
         cert_subject_dn: &str,
-        cert_issuer_dnrfc_2253: &str,
-        cert_subject_dnrfc_2253: &str,
+        cert_issuer_dnrfc2253: &str,
+        cert_subject_dnrfc2253: &str,
         cert_issuer_dn_legacy: &str,
         cert_subject_dn_legacy: &str,
         cert_serial: &str,
         cert_issuer_serial: &str,
         cert_ski: &str,
         cert_issuer_ski: &str,
-        cert_fingerprint_sha_1: &str,
-        cert_fingerprint_sha_256: &str,
+        cert_fingerprint_sha1: &str,
+        cert_fingerprint_sha256: &str,
         cert_not_before: &str,
         cert_not_after: &str,
     ) -> IncomingRequestCfPropertiesTLSClientAuth {
@@ -40277,16 +40425,16 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
         inner.set_cert_revoked("1");
         inner.set_cert_issuer_dn(cert_issuer_dn);
         inner.set_cert_subject_dn(cert_subject_dn);
-        inner.set_cert_issuer_dnrfc_2253(cert_issuer_dnrfc_2253);
-        inner.set_cert_subject_dnrfc_2253(cert_subject_dnrfc_2253);
+        inner.set_cert_issuer_dnrfc2253(cert_issuer_dnrfc2253);
+        inner.set_cert_subject_dnrfc2253(cert_subject_dnrfc2253);
         inner.set_cert_issuer_dn_legacy(cert_issuer_dn_legacy);
         inner.set_cert_subject_dn_legacy(cert_subject_dn_legacy);
         inner.set_cert_serial(cert_serial);
         inner.set_cert_issuer_serial(cert_issuer_serial);
         inner.set_cert_ski(cert_ski);
         inner.set_cert_issuer_ski(cert_issuer_ski);
-        inner.set_cert_fingerprint_sha_1(cert_fingerprint_sha_1);
-        inner.set_cert_fingerprint_sha_256(cert_fingerprint_sha_256);
+        inner.set_cert_fingerprint_sha1(cert_fingerprint_sha1);
+        inner.set_cert_fingerprint_sha256(cert_fingerprint_sha256);
         inner.set_cert_not_before(cert_not_before);
         inner.set_cert_not_after(cert_not_after);
         inner
@@ -40308,10 +40456,10 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
     #[doc = " * `cert_subject_dn` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html)"]
     #[doc = ""]
     #[doc = " @example \"CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
-    #[doc = " * `cert_issuer_dnrfc_2253` - The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
+    #[doc = " * `cert_issuer_dnrfc2253` - The certificate issuer's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
     #[doc = ""]
     #[doc = " @example \"CN=cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
-    #[doc = " * `cert_subject_dnrfc_2253` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
+    #[doc = " * `cert_subject_dnrfc2253` - The certificate subject's [distinguished name](https://knowledge.digicert.com/generalinformation/INFO1745.html) ([RFC 2253](https://www.rfc-editor.org/rfc/rfc2253.html) formatted)"]
     #[doc = ""]
     #[doc = " @example \"CN=*.cloudflareaccess.com, C=US, ST=Texas, L=Austin, O=Cloudflare\""]
     #[doc = " * `cert_issuer_dn_legacy` - The certificate issuer's distinguished name (legacy policies)"]
@@ -40328,10 +40476,10 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
     #[doc = " * `cert_issuer_ski` - The certificate issuer's Subject Key Identifier"]
     #[doc = ""]
     #[doc = " @example \"BB:AF:7E:02:3D:FA:A6:F1:3C:84:8E:AD:EE:38:98:EC:D9:32:32:D4\""]
-    #[doc = " * `cert_fingerprint_sha_1` - The certificate's SHA-1 fingerprint"]
+    #[doc = " * `cert_fingerprint_sha1` - The certificate's SHA-1 fingerprint"]
     #[doc = ""]
     #[doc = " @example \"6b9109f323999e52259cda7373ff0b4d26bd232e\""]
-    #[doc = " * `cert_fingerprint_sha_256` - The certificate's SHA-256 fingerprint"]
+    #[doc = " * `cert_fingerprint_sha256` - The certificate's SHA-256 fingerprint"]
     #[doc = ""]
     #[doc = " @example \"acf77cf37b4156a2708e34c4eb755f9b5dbbe5ebb55adfec8f11493438d19e6ad3f157f81fa3b98278453d5652b0c1fd1d71e5695ae4d709803a4d3f39de9dea\""]
     #[doc = " * `cert_not_before` - The effective starting date of the certificate"]
@@ -40344,16 +40492,16 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
         cert_verified: &CertVerificationStatus,
         cert_issuer_dn: &str,
         cert_subject_dn: &str,
-        cert_issuer_dnrfc_2253: &str,
-        cert_subject_dnrfc_2253: &str,
+        cert_issuer_dnrfc2253: &str,
+        cert_subject_dnrfc2253: &str,
         cert_issuer_dn_legacy: &str,
         cert_subject_dn_legacy: &str,
         cert_serial: &str,
         cert_issuer_serial: &str,
         cert_ski: &str,
         cert_issuer_ski: &str,
-        cert_fingerprint_sha_1: &str,
-        cert_fingerprint_sha_256: &str,
+        cert_fingerprint_sha1: &str,
+        cert_fingerprint_sha256: &str,
         cert_not_before: &str,
         cert_not_after: &str,
     ) -> IncomingRequestCfPropertiesTLSClientAuth {
@@ -40363,16 +40511,16 @@ impl IncomingRequestCfPropertiesTLSClientAuth {
         inner.set_cert_revoked("0");
         inner.set_cert_issuer_dn(cert_issuer_dn);
         inner.set_cert_subject_dn(cert_subject_dn);
-        inner.set_cert_issuer_dnrfc_2253(cert_issuer_dnrfc_2253);
-        inner.set_cert_subject_dnrfc_2253(cert_subject_dnrfc_2253);
+        inner.set_cert_issuer_dnrfc2253(cert_issuer_dnrfc2253);
+        inner.set_cert_subject_dnrfc2253(cert_subject_dnrfc2253);
         inner.set_cert_issuer_dn_legacy(cert_issuer_dn_legacy);
         inner.set_cert_subject_dn_legacy(cert_subject_dn_legacy);
         inner.set_cert_serial(cert_serial);
         inner.set_cert_issuer_serial(cert_issuer_serial);
         inner.set_cert_ski(cert_ski);
         inner.set_cert_issuer_ski(cert_issuer_ski);
-        inner.set_cert_fingerprint_sha_1(cert_fingerprint_sha_1);
-        inner.set_cert_fingerprint_sha_256(cert_fingerprint_sha_256);
+        inner.set_cert_fingerprint_sha1(cert_fingerprint_sha1);
+        inner.set_cert_fingerprint_sha256(cert_fingerprint_sha256);
         inner.set_cert_not_before(cert_not_before);
         inner.set_cert_not_after(cert_not_after);
         inner
@@ -40413,20 +40561,20 @@ extern "C" {
         val: &str,
     );
     #[wasm_bindgen(method, getter, js_name = "certIssuerDNRFC2253")]
-    pub fn cert_issuer_dnrfc_2253(
+    pub fn cert_issuer_dnrfc2253(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
     ) -> String;
     #[wasm_bindgen(method, setter, js_name = "certIssuerDNRFC2253")]
-    pub fn set_cert_issuer_dnrfc_2253(
+    pub fn set_cert_issuer_dnrfc2253(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
         val: &str,
     );
     #[wasm_bindgen(method, getter, js_name = "certSubjectDNRFC2253")]
-    pub fn cert_subject_dnrfc_2253(
+    pub fn cert_subject_dnrfc2253(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
     ) -> String;
     #[wasm_bindgen(method, setter, js_name = "certSubjectDNRFC2253")]
-    pub fn set_cert_subject_dnrfc_2253(
+    pub fn set_cert_subject_dnrfc2253(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
         val: &str,
     );
@@ -40472,20 +40620,20 @@ extern "C" {
         val: &str,
     );
     #[wasm_bindgen(method, getter, js_name = "certFingerprintSHA1")]
-    pub fn cert_fingerprint_sha_1(
+    pub fn cert_fingerprint_sha1(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
     ) -> String;
     #[wasm_bindgen(method, setter, js_name = "certFingerprintSHA1")]
-    pub fn set_cert_fingerprint_sha_1(
+    pub fn set_cert_fingerprint_sha1(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
         val: &str,
     );
     #[wasm_bindgen(method, getter, js_name = "certFingerprintSHA256")]
-    pub fn cert_fingerprint_sha_256(
+    pub fn cert_fingerprint_sha256(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
     ) -> String;
     #[wasm_bindgen(method, setter, js_name = "certFingerprintSHA256")]
-    pub fn set_cert_fingerprint_sha_256(
+    pub fn set_cert_fingerprint_sha256(
         this: &IncomingRequestCfPropertiesTLSClientAuthPlaceholder,
         val: &str,
     );
@@ -40531,16 +40679,16 @@ impl IncomingRequestCfPropertiesTLSClientAuthPlaceholder {
         inner.set_cert_revoked("0");
         inner.set_cert_issuer_dn("");
         inner.set_cert_subject_dn("");
-        inner.set_cert_issuer_dnrfc_2253("");
-        inner.set_cert_subject_dnrfc_2253("");
+        inner.set_cert_issuer_dnrfc2253("");
+        inner.set_cert_subject_dnrfc2253("");
         inner.set_cert_issuer_dn_legacy("");
         inner.set_cert_subject_dn_legacy("");
         inner.set_cert_serial("");
         inner.set_cert_issuer_serial("");
         inner.set_cert_ski("");
         inner.set_cert_issuer_ski("");
-        inner.set_cert_fingerprint_sha_1("");
-        inner.set_cert_fingerprint_sha_256("");
+        inner.set_cert_fingerprint_sha1("");
+        inner.set_cert_fingerprint_sha256("");
         inner.set_cert_not_before("");
         inner.set_cert_not_after("");
         inner
@@ -41353,7 +41501,7 @@ extern "C" {
     #[doc = ""]
     #[doc = " * `constraintOrBookmark` - Either the session constraint or the explicit bookmark to anchor the created session."]
     #[wasm_bindgen(method, js_name = "withSession")]
-    pub fn with_session_with_d_1_session_constraint(
+    pub fn with_session_with_d1_session_constraint(
         this: &D1Database,
         constraint_or_bookmark: &D1SessionConstraint,
     ) -> D1DatabaseSession;
@@ -41363,7 +41511,7 @@ extern "C" {
     #[doc = ""]
     #[doc = " * `constraintOrBookmark` - Either the session constraint or the explicit bookmark to anchor the created session."]
     #[wasm_bindgen(method, catch, js_name = "withSession")]
-    pub fn try_with_session_with_d_1_session_constraint(
+    pub fn try_with_session_with_d1_session_constraint(
         this: &D1Database,
         constraint_or_bookmark: &D1SessionConstraint,
     ) -> Result<D1DatabaseSession, JsValue>;
@@ -41429,7 +41577,7 @@ extern "C" {
         this: &D1PreparedStatement,
     ) -> Result<ArrayTuple<(Array<JsString>, Array)>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "raw")]
-    pub async fn raw_with_d_1_prepared_statement_options_2(
+    pub async fn raw_with_d1_prepared_statement_options2(
         this: &D1PreparedStatement,
         options: &D1PreparedStatementOptions2,
     ) -> Result<ArrayTuple<(Array<JsString>, Array)>, JsValue>;
@@ -41599,10 +41747,11 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type EmailAttachment;
+    #[doc = " Returns: string | ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &EmailAttachment) -> JsValue;
     #[wasm_bindgen(method, getter, js_name = "contentId")]
-    pub fn content_id(this: &EmailAttachment) -> Option<JsValue>;
+    pub fn content_id(this: &EmailAttachment) -> Option<String>;
     #[wasm_bindgen(method, getter)]
     pub fn disposition(this: &EmailAttachment) -> String;
     #[wasm_bindgen(method, getter)]
@@ -41618,7 +41767,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "contentId")]
     pub fn set_content_id(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, setter, js_name = "contentId")]
-    pub fn set_content_id_with_undefined(this: &EmailAttachment, val: &Undefined);
+    pub fn set_content_id_with_null(this: &EmailAttachment, val: &Null);
     #[wasm_bindgen(method, setter)]
     pub fn set_disposition(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, setter)]
@@ -41774,8 +41923,8 @@ impl EmailAttachmentBuilder {
         self.inner.set_content_id(val);
         self
     }
-    pub fn content_id_with_undefined(self, val: &Undefined) -> Self {
-        self.inner.set_content_id_with_undefined(val);
+    pub fn content_id_with_null(self, val: &Null) -> Self {
+        self.inner.set_content_id_with_null(val);
         self
     }
     pub fn build(self) -> EmailAttachment {
@@ -41825,12 +41974,14 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type SendEmailBuilder;
+    #[doc = " Returns: string | EmailAddress"]
     #[wasm_bindgen(method, getter)]
     pub fn from(this: &SendEmailBuilder) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_from(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "from")]
     pub fn set_from_with_email_address(this: &SendEmailBuilder, val: &EmailAddress);
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn to(this: &SendEmailBuilder) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -41841,18 +41992,21 @@ extern "C" {
     pub fn subject(this: &SendEmailBuilder) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_subject(this: &SendEmailBuilder, val: &str);
+    #[doc = " Returns: string | EmailAddress"]
     #[wasm_bindgen(method, getter, js_name = "replyTo")]
     pub fn reply_to(this: &SendEmailBuilder) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "replyTo")]
     pub fn set_reply_to(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "replyTo")]
     pub fn set_reply_to_with_email_address(this: &SendEmailBuilder, val: &EmailAddress);
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn cc(this: &SendEmailBuilder) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
     pub fn set_cc(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "cc")]
     pub fn set_cc_with_array(this: &SendEmailBuilder, val: &Array<JsString>);
+    #[doc = " Returns: string | string[]"]
     #[wasm_bindgen(method, getter)]
     pub fn bcc(this: &SendEmailBuilder) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -42143,6 +42297,7 @@ extern "C" {
     pub fn blur(this: &ImageTransform) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_blur(this: &ImageTransform, val: f64);
+    #[doc = " Returns: object | object"]
     #[wasm_bindgen(method, getter)]
     pub fn border(this: &ImageTransform) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -42171,6 +42326,7 @@ extern "C" {
     pub fn segment(this: &ImageTransform) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_segment(this: &ImageTransform, val: &str);
+    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | object"]
     #[wasm_bindgen(method, getter)]
     pub fn gravity(this: &ImageTransform) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -42189,6 +42345,7 @@ extern "C" {
     pub fn sharpen(this: &ImageTransform) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_sharpen(this: &ImageTransform, val: f64);
+    #[doc = " Returns: \"border\" | object"]
     #[wasm_bindgen(method, getter)]
     pub fn trim(this: &ImageTransform) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -42295,6 +42452,7 @@ extern "C" {
     pub fn opacity(this: &ImageDrawOptions) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_opacity(this: &ImageDrawOptions, val: f64);
+    #[doc = " Returns: boolean | string"]
     #[wasm_bindgen(method, getter)]
     pub fn repeat(this: &ImageDrawOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter)]
@@ -42903,7 +43061,7 @@ extern "C" {
     #[doc = ""]
     #[doc = " * `ImagesError` — if upload fails"]
     #[wasm_bindgen(method, catch, js_name = "upload")]
-    pub async fn upload_with_js_value_and_options(
+    pub async fn upload_with_readable_stream_and_options(
         this: &HostedImagesBinding,
         image: &ReadableStream,
         options: &ImageUploadOptions,
@@ -43109,7 +43267,7 @@ extern "C" {
     #[doc = " * `image` - The image (or transformer that will give the image) to draw"]
     #[doc = " * `options` - The options configuring how to draw the image"]
     #[wasm_bindgen(method, js_name = "draw")]
-    pub fn draw_with_js_value_and_options(
+    pub fn draw_with_readable_stream_and_options(
         this: &ImageTransformer,
         image: &ReadableStream,
         options: &ImageDrawOptions,
@@ -43120,7 +43278,7 @@ extern "C" {
     #[doc = " * `image` - The image (or transformer that will give the image) to draw"]
     #[doc = " * `options` - The options configuring how to draw the image"]
     #[wasm_bindgen(method, catch, js_name = "draw")]
-    pub fn try_draw_with_js_value_and_options(
+    pub fn try_draw_with_readable_stream_and_options(
         this: &ImageTransformer,
         image: &ReadableStream,
         options: &ImageDrawOptions,
@@ -43722,6 +43880,7 @@ extern "C" {
     pub fn content_type(this: &PubSubMessage) -> String;
     #[wasm_bindgen(method, getter, js_name = "payloadFormatIndicator")]
     pub fn payload_format_indicator(this: &PubSubMessage) -> f64;
+    #[doc = " Returns: string | Uint8Array"]
     #[wasm_bindgen(method, getter)]
     pub fn payload(this: &PubSubMessage) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -43933,8 +44092,10 @@ pub mod cloudflare_workers_module {
             this: &WorkerEntrypoint,
             message: &ForwardableEmailMessage,
         ) -> Result<Option<Promise<Undefined>>, JsValue>;
+        #[doc = " Returns: Response | Promise<Response>"]
         #[wasm_bindgen(method)]
         pub fn fetch(this: &WorkerEntrypoint, request: &Request) -> JsValue;
+        #[doc = " Returns: Response | Promise<Response>"]
         #[wasm_bindgen(method, catch, js_name = "fetch")]
         pub fn try_fetch(this: &WorkerEntrypoint, request: &Request) -> Result<JsValue, JsValue>;
         #[wasm_bindgen(method)]
@@ -43964,8 +44125,10 @@ pub mod cloudflare_workers_module {
             this: &WorkerEntrypoint,
             events: &Array<TraceItem>,
         ) -> Result<Option<Promise<Undefined>>, JsValue>;
+        #[doc = " Returns: TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>"]
         #[wasm_bindgen(method, js_name = "tailStream")]
         pub fn tail_stream(this: &WorkerEntrypoint, event: &TailEvent) -> JsValue;
+        #[doc = " Returns: TailStream.TailEventHandlerType | Promise<TailStream.TailEventHandlerType>"]
         #[wasm_bindgen(method, catch, js_name = "tailStream")]
         pub fn try_tail_stream(
             this: &WorkerEntrypoint,
@@ -44019,8 +44182,10 @@ pub mod cloudflare_workers_module {
             this: &DurableObject,
             alarm_info: &AlarmInvocationInfo,
         ) -> Result<Option<Promise<Undefined>>, JsValue>;
+        #[doc = " Returns: Response | Promise<Response>"]
         #[wasm_bindgen(method)]
         pub fn fetch(this: &DurableObject, request: &Request) -> JsValue;
+        #[doc = " Returns: Response | Promise<Response>"]
         #[wasm_bindgen(method, catch, js_name = "fetch")]
         pub fn try_fetch(this: &DurableObject, request: &Request) -> Result<JsValue, JsValue>;
         #[wasm_bindgen(method, js_name = "webSocketMessage")]
@@ -44113,6 +44278,7 @@ pub mod cloudflare_workers_module {
         pub fn retries(this: &WorkflowStepConfig) -> Option<Object>;
         #[wasm_bindgen(method, setter)]
         pub fn set_retries(this: &WorkflowStepConfig, val: &Object);
+        #[doc = " Returns: WorkflowTimeoutDuration | number"]
         #[wasm_bindgen(method, getter)]
         pub fn timeout(this: &WorkflowStepConfig) -> Option<JsValue>;
         #[wasm_bindgen(method, setter)]
@@ -44271,6 +44437,7 @@ pub mod cloudflare_workers_module {
         pub fn type_(this: &WorkflowStepOptions) -> String;
         #[wasm_bindgen(method, setter)]
         pub fn set_type(this: &WorkflowStepOptions, val: &str);
+        #[doc = " Returns: WorkflowTimeoutDuration | number"]
         #[wasm_bindgen(method, getter)]
         pub fn timeout(this: &WorkflowStepOptions) -> Option<JsValue>;
         #[wasm_bindgen(method, setter)]
@@ -46981,6 +47148,7 @@ pub mod tail_stream {
         pub type HibernatableWebSocketEventInfo;
         #[wasm_bindgen(method, getter, js_name = "type")]
         pub fn type_(this: &HibernatableWebSocketEventInfo) -> String;
+        #[doc = " Returns: HibernatableWebSocketEventInfoClose | HibernatableWebSocketEventInfoError | HibernatableWebSocketEventInfoMessage"]
         #[wasm_bindgen(method, getter)]
         pub fn info(this: &HibernatableWebSocketEventInfo) -> JsValue;
     }
@@ -47099,6 +47267,7 @@ pub mod tail_stream {
         pub fn script_tags(this: &Onset) -> Option<Array<JsString>>;
         #[wasm_bindgen(method, getter, js_name = "scriptVersion")]
         pub fn script_version(this: &Onset) -> Option<ScriptVersion>;
+        #[doc = " Returns: FetchEventInfo | JsRpcEventInfo | ScheduledEventInfo | AlarmEventInfo | QueueEventInfo | EmailEventInfo | TraceEventInfo | HibernatableWebSocketEventInfo | CustomEventInfo"]
         #[wasm_bindgen(method, getter)]
         pub fn info(this: &Onset) -> JsValue;
     }
@@ -47145,6 +47314,7 @@ pub mod tail_stream {
         pub fn name(this: &SpanOpen) -> String;
         #[wasm_bindgen(method, getter, js_name = "spanId")]
         pub fn span_id(this: &SpanOpen) -> String;
+        #[doc = " Returns: FetchEventInfo | JsRpcEventInfo | Attributes"]
         #[wasm_bindgen(method, getter)]
         pub fn info(this: &SpanOpen) -> Option<JsValue>;
     }
@@ -47305,6 +47475,7 @@ pub mod tail_stream {
         pub type Attribute;
         #[wasm_bindgen(method, getter)]
         pub fn name(this: &Attribute) -> String;
+        #[doc = " Returns: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[]"]
         #[wasm_bindgen(method, getter)]
         pub fn value(this: &Attribute) -> JsValue;
     }
@@ -47578,6 +47749,7 @@ extern "C" {
     pub fn return_values(this: &VectorizeQueryOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "returnValues")]
     pub fn set_return_values(this: &VectorizeQueryOptions, val: bool);
+    #[doc = " Returns: boolean | VectorizeMetadataRetrievalLevel"]
     #[wasm_bindgen(method, getter, js_name = "returnMetadata")]
     pub fn return_metadata(this: &VectorizeQueryOptions) -> Option<JsValue>;
     #[wasm_bindgen(method, setter, js_name = "returnMetadata")]
@@ -47780,6 +47952,8 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &VectorizeVector, val: &str);
     #[doc = " The vector values"]
+    #[doc = ""]
+    #[doc = " Returns: VectorFloatArray | number[]"]
     #[wasm_bindgen(method, getter)]
     pub fn values(this: &VectorizeVector) -> JsValue;
     #[wasm_bindgen(method, setter)]
@@ -47802,7 +47976,7 @@ extern "C" {
 impl VectorizeVector {
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
     #[doc = " * `values` - The vector values"]
-    pub fn new(id: &str, values: &JsValue) -> VectorizeVector {
+    pub fn new(id: &str, values: &&JsValue) -> VectorizeVector {
         Self::builder(id, values).build()
     }
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
@@ -47812,7 +47986,7 @@ impl VectorizeVector {
     }
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
     #[doc = " * `values` - The vector values"]
-    pub fn builder(id: &str, values: &JsValue) -> VectorizeVectorBuilder {
+    pub fn builder(id: &str, values: &&JsValue) -> VectorizeVectorBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_values(values);

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -3060,7 +3060,7 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AnalyticsEngineDataPoint;
-    #[doc = " Returns: (ArrayBuffer | string | null)[]"]
+    #[doc = " Returns: (ArrayBuffer | string | null)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn indexes(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -3069,7 +3069,7 @@ extern "C" {
     pub fn doubles(this: &AnalyticsEngineDataPoint) -> Option<Array<Number>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_doubles(this: &AnalyticsEngineDataPoint, val: &Array<Number>);
-    #[doc = " Returns: (ArrayBuffer | string | null)[]"]
+    #[doc = " Returns: (ArrayBuffer | string | null)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn blobs(this: &AnalyticsEngineDataPoint) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -3627,7 +3627,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn reason(this: &AbortSignal) -> JsValue;
     #[wasm_bindgen(method, getter)]
-    pub fn onabort(this: &AbortSignal) -> Option<JsValue>;
+    pub fn onabort(this: &AbortSignal) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_onabort(this: &AbortSignal, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "onabort")]
@@ -3741,7 +3741,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_composed(this: &CustomEventCustomEventInit, val: bool);
     #[wasm_bindgen(method, getter)]
-    pub fn detail(this: &CustomEventCustomEventInit) -> Option<JsValue>;
+    pub fn detail(this: &CustomEventCustomEventInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_detail(this: &CustomEventCustomEventInit, val: &JsValue);
 }
@@ -5053,9 +5053,9 @@ extern "C" {
     pub fn name(this: &SubtleCryptoDeriveKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoDeriveKeyAlgorithm, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn salt(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
+    pub fn salt(this: &SubtleCryptoDeriveKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_salt(this: &SubtleCryptoDeriveKeyAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "salt")]
@@ -5067,9 +5067,9 @@ extern "C" {
     pub fn iterations(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_iterations(this: &SubtleCryptoDeriveKeyAlgorithm, val: f64);
-    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn hash(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
+    pub fn hash(this: &SubtleCryptoDeriveKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_hash(this: &SubtleCryptoDeriveKeyAlgorithm, val: &str);
     #[wasm_bindgen(method, setter, js_name = "hash")]
@@ -5081,9 +5081,9 @@ extern "C" {
     pub fn public(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<CryptoKey>;
     #[wasm_bindgen(method, setter)]
     pub fn set_public(this: &SubtleCryptoDeriveKeyAlgorithm, val: &CryptoKey);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn info(this: &SubtleCryptoDeriveKeyAlgorithm) -> Option<JsValue>;
+    pub fn info(this: &SubtleCryptoDeriveKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_info(this: &SubtleCryptoDeriveKeyAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "info")]
@@ -5151,9 +5151,9 @@ extern "C" {
     pub fn name(this: &SubtleCryptoEncryptAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoEncryptAlgorithm, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn iv(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
+    pub fn iv(this: &SubtleCryptoEncryptAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_iv(this: &SubtleCryptoEncryptAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "iv")]
@@ -5161,9 +5161,9 @@ extern "C" {
         this: &SubtleCryptoEncryptAlgorithm,
         val: &T,
     );
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter, js_name = "additionalData")]
-    pub fn additional_data(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
+    pub fn additional_data(this: &SubtleCryptoEncryptAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "additionalData")]
     pub fn set_additional_data(this: &SubtleCryptoEncryptAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "additionalData")]
@@ -5175,9 +5175,9 @@ extern "C" {
     pub fn tag_length(this: &SubtleCryptoEncryptAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter, js_name = "tagLength")]
     pub fn set_tag_length(this: &SubtleCryptoEncryptAlgorithm, val: f64);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn counter(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
+    pub fn counter(this: &SubtleCryptoEncryptAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_counter(this: &SubtleCryptoEncryptAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "counter")]
@@ -5189,9 +5189,9 @@ extern "C" {
     pub fn length(this: &SubtleCryptoEncryptAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_length(this: &SubtleCryptoEncryptAlgorithm, val: f64);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn label(this: &SubtleCryptoEncryptAlgorithm) -> Option<JsValue>;
+    pub fn label(this: &SubtleCryptoEncryptAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_label(this: &SubtleCryptoEncryptAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "label")]
@@ -5267,9 +5267,9 @@ extern "C" {
     pub fn name(this: &SubtleCryptoGenerateKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoGenerateKeyAlgorithm, val: &str);
-    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn hash(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<JsValue>;
+    pub fn hash(this: &SubtleCryptoGenerateKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_hash(this: &SubtleCryptoGenerateKeyAlgorithm, val: &str);
     #[wasm_bindgen(method, setter, js_name = "hash")]
@@ -5281,9 +5281,9 @@ extern "C" {
     pub fn modulus_length(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<f64>;
     #[wasm_bindgen(method, setter, js_name = "modulusLength")]
     pub fn set_modulus_length(this: &SubtleCryptoGenerateKeyAlgorithm, val: f64);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | undefined"]
     #[wasm_bindgen(method, getter, js_name = "publicExponent")]
-    pub fn public_exponent(this: &SubtleCryptoGenerateKeyAlgorithm) -> Option<JsValue>;
+    pub fn public_exponent(this: &SubtleCryptoGenerateKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "publicExponent")]
     pub fn set_public_exponent(this: &SubtleCryptoGenerateKeyAlgorithm, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "publicExponent")]
@@ -5372,9 +5372,9 @@ extern "C" {
     pub fn name(this: &SubtleCryptoImportKeyAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoImportKeyAlgorithm, val: &str);
-    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn hash(this: &SubtleCryptoImportKeyAlgorithm) -> Option<JsValue>;
+    pub fn hash(this: &SubtleCryptoImportKeyAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_hash(this: &SubtleCryptoImportKeyAlgorithm, val: &str);
     #[wasm_bindgen(method, setter, js_name = "hash")]
@@ -5442,9 +5442,9 @@ extern "C" {
     pub fn name(this: &SubtleCryptoSignAlgorithm) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &SubtleCryptoSignAlgorithm, val: &str);
-    #[doc = " Returns: string | SubtleCryptoHashAlgorithm"]
+    #[doc = " Returns: string | SubtleCryptoHashAlgorithm | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn hash(this: &SubtleCryptoSignAlgorithm) -> Option<JsValue>;
+    pub fn hash(this: &SubtleCryptoSignAlgorithm) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_hash(this: &SubtleCryptoSignAlgorithm, val: &str);
     #[wasm_bindgen(method, setter, js_name = "hash")]
@@ -5992,7 +5992,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_colno(this: &ErrorEventErrorEventInit, val: f64);
     #[wasm_bindgen(method, getter)]
-    pub fn error(this: &ErrorEventErrorEventInit) -> Option<JsValue>;
+    pub fn error(this: &ErrorEventErrorEventInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_error(this: &ErrorEventErrorEventInit, val: &JsValue);
 }
@@ -6166,14 +6166,14 @@ extern "C" {
     #[doc = ""]
     #[doc = " Returns: File | string | null"]
     #[wasm_bindgen(method)]
-    pub fn get(this: &FormData, name: &str) -> Option<JsValue>;
+    pub fn get(this: &FormData, name: &str) -> JsValue;
     #[doc = " The **`get()`** method of the FormData interface returns the first value associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get)"]
     #[doc = ""]
     #[doc = " Returns: File | string | null"]
     #[wasm_bindgen(method, catch, js_name = "get")]
-    pub fn try_get(this: &FormData, name: &str) -> Result<Option<JsValue>, JsValue>;
+    pub fn try_get(this: &FormData, name: &str) -> Result<JsValue, JsValue>;
     #[doc = " The **`getAll()`** method of the FormData interface returns all the values associated with a given key from within a `FormData` object."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/getAll)"]
@@ -7501,7 +7501,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "webSocket")]
     pub fn set_web_socket_with_null(this: &Response, val: &Null);
     #[wasm_bindgen(method, getter)]
-    pub fn cf(this: &Response) -> Option<JsValue>;
+    pub fn cf(this: &Response) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_cf(this: &Response, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "cf")]
@@ -7528,7 +7528,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "statusText")]
     pub fn set_status_text(this: &ResponseInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &ResponseInit) -> Option<JsValue>;
+    pub fn headers(this: &ResponseInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &ResponseInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
@@ -7536,7 +7536,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &ResponseInit, val: &Object<JsString>);
     #[wasm_bindgen(method, getter)]
-    pub fn cf(this: &ResponseInit) -> Option<JsValue>;
+    pub fn cf(this: &ResponseInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_cf(this: &ResponseInit, val: &JsValue);
     #[wasm_bindgen(method, getter, js_name = "webSocket")]
@@ -7661,7 +7661,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_redirect(this: &Request, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn fetcher(this: &Request) -> Option<JsValue>;
+    pub fn fetcher(this: &Request) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_fetcher(this: &Request, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "fetcher")]
@@ -7709,7 +7709,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_method(this: &RequestInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn headers(this: &RequestInit) -> Option<JsValue>;
+    pub fn headers(this: &RequestInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_headers(this: &RequestInit, val: &Headers);
     #[wasm_bindgen(method, setter, js_name = "headers")]
@@ -7717,7 +7717,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "headers")]
     pub fn set_headers_with_record(this: &RequestInit, val: &Object<JsString>);
     #[wasm_bindgen(method, getter)]
-    pub fn body(this: &RequestInit) -> Option<JsValue>;
+    pub fn body(this: &RequestInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_body(this: &RequestInit, val: &ReadableStream);
     #[wasm_bindgen(method, setter, js_name = "body")]
@@ -7743,7 +7743,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_redirect(this: &RequestInit, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn fetcher(this: &RequestInit) -> Option<JsValue>;
+    pub fn fetcher(this: &RequestInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_fetcher(this: &RequestInit, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "fetcher")]
@@ -8249,7 +8249,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "expirationTtl")]
     pub fn set_expiration_ttl(this: &KVNamespacePutOptions, val: f64);
     #[wasm_bindgen(method, getter)]
-    pub fn metadata(this: &KVNamespacePutOptions) -> Option<JsValue>;
+    pub fn metadata(this: &KVNamespacePutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_metadata(this: &KVNamespacePutOptions, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "metadata")]
@@ -9138,23 +9138,23 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2GetOptions;
-    #[doc = " Returns: R2Conditional | Headers"]
+    #[doc = " Returns: R2Conditional | Headers | undefined"]
     #[wasm_bindgen(method, getter, js_name = "onlyIf")]
-    pub fn only_if(this: &R2GetOptions) -> Option<JsValue>;
+    pub fn only_if(this: &R2GetOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if(this: &R2GetOptions, val: &R2Conditional);
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if_with_headers(this: &R2GetOptions, val: &Headers);
-    #[doc = " Returns: R2Range | Headers"]
+    #[doc = " Returns: R2Range | Headers | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn range(this: &R2GetOptions) -> Option<JsValue>;
+    pub fn range(this: &R2GetOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_range(this: &R2GetOptions, val: &R2Range);
     #[wasm_bindgen(method, setter, js_name = "range")]
     pub fn set_range_with_headers(this: &R2GetOptions, val: &Headers);
-    #[doc = " Returns: ArrayBuffer | string"]
+    #[doc = " Returns: ArrayBuffer | string | undefined"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
-    pub fn ssec_key(this: &R2GetOptions) -> Option<JsValue>;
+    pub fn ssec_key(this: &R2GetOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
     pub fn set_ssec_key(this: &R2GetOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9207,16 +9207,16 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2PutOptions;
-    #[doc = " Returns: R2Conditional | Headers"]
+    #[doc = " Returns: R2Conditional | Headers | undefined"]
     #[wasm_bindgen(method, getter, js_name = "onlyIf")]
-    pub fn only_if(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn only_if(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if(this: &R2PutOptions, val: &R2Conditional);
     #[wasm_bindgen(method, setter, js_name = "onlyIf")]
     pub fn set_only_if_with_headers(this: &R2PutOptions, val: &Headers);
-    #[doc = " Returns: R2HTTPMetadata | Headers"]
+    #[doc = " Returns: R2HTTPMetadata | Headers | undefined"]
     #[wasm_bindgen(method, getter, js_name = "httpMetadata")]
-    pub fn http_metadata(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn http_metadata(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
     pub fn set_http_metadata(this: &R2PutOptions, val: &R2HTTPMetadata);
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
@@ -9225,45 +9225,45 @@ extern "C" {
     pub fn custom_metadata(this: &R2PutOptions) -> Option<Object<JsString>>;
     #[wasm_bindgen(method, setter, js_name = "customMetadata")]
     pub fn set_custom_metadata(this: &R2PutOptions, val: &Object<JsString>);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn md5(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn md5(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_md5(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "md5")]
     pub fn set_md5_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "md5")]
     pub fn set_md5_with_str(this: &R2PutOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn sha1(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn sha1(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_sha1(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha1")]
     pub fn set_sha1_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha1")]
     pub fn set_sha1_with_str(this: &R2PutOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn sha256(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn sha256(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_sha256(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha256")]
     pub fn set_sha256_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha256")]
     pub fn set_sha256_with_str(this: &R2PutOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn sha384(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn sha384(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_sha384(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha384")]
     pub fn set_sha384_with_typed_array<T: ::js_sys::TypedArray>(this: &R2PutOptions, val: &T);
     #[wasm_bindgen(method, setter, js_name = "sha384")]
     pub fn set_sha384_with_str(this: &R2PutOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string"]
+    #[doc = " Returns: ArrayBuffer | ArrayBufferView | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn sha512(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn sha512(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_sha512(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "sha512")]
@@ -9274,9 +9274,9 @@ extern "C" {
     pub fn storage_class(this: &R2PutOptions) -> Option<String>;
     #[wasm_bindgen(method, setter, js_name = "storageClass")]
     pub fn set_storage_class(this: &R2PutOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | string"]
+    #[doc = " Returns: ArrayBuffer | string | undefined"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
-    pub fn ssec_key(this: &R2PutOptions) -> Option<JsValue>;
+    pub fn ssec_key(this: &R2PutOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
     pub fn set_ssec_key(this: &R2PutOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9397,9 +9397,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2MultipartOptions;
-    #[doc = " Returns: R2HTTPMetadata | Headers"]
+    #[doc = " Returns: R2HTTPMetadata | Headers | undefined"]
     #[wasm_bindgen(method, getter, js_name = "httpMetadata")]
-    pub fn http_metadata(this: &R2MultipartOptions) -> Option<JsValue>;
+    pub fn http_metadata(this: &R2MultipartOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
     pub fn set_http_metadata(this: &R2MultipartOptions, val: &R2HTTPMetadata);
     #[wasm_bindgen(method, setter, js_name = "httpMetadata")]
@@ -9412,9 +9412,9 @@ extern "C" {
     pub fn storage_class(this: &R2MultipartOptions) -> Option<String>;
     #[wasm_bindgen(method, setter, js_name = "storageClass")]
     pub fn set_storage_class(this: &R2MultipartOptions, val: &str);
-    #[doc = " Returns: ArrayBuffer | string"]
+    #[doc = " Returns: ArrayBuffer | string | undefined"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
-    pub fn ssec_key(this: &R2MultipartOptions) -> Option<JsValue>;
+    pub fn ssec_key(this: &R2MultipartOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
     pub fn set_ssec_key(this: &R2MultipartOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9625,9 +9625,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2UploadPartOptions;
-    #[doc = " Returns: ArrayBuffer | string"]
+    #[doc = " Returns: ArrayBuffer | string | undefined"]
     #[wasm_bindgen(method, getter, js_name = "ssecKey")]
-    pub fn ssec_key(this: &R2UploadPartOptions) -> Option<JsValue>;
+    pub fn ssec_key(this: &R2UploadPartOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
     pub fn set_ssec_key(this: &R2UploadPartOptions, val: &ArrayBuffer);
     #[wasm_bindgen(method, setter, js_name = "ssecKey")]
@@ -9692,9 +9692,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type QueuingStrategy;
-    #[doc = " Returns: number | bigint"]
+    #[doc = " Returns: number | bigint | undefined"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
-    pub fn high_water_mark(this: &QueuingStrategy) -> Option<JsValue>;
+    pub fn high_water_mark(this: &QueuingStrategy) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
     pub fn set_high_water_mark(this: &QueuingStrategy, val: f64);
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -9944,9 +9944,9 @@ extern "C" {
         this: &UnderlyingSource,
         val: &Function<fn(JsValue) -> JsOption<Promise<Undefined>>>,
     );
-    #[doc = " Returns: number | bigint"]
+    #[doc = " Returns: number | bigint | undefined"]
     #[wasm_bindgen(method, getter, js_name = "expectedLength")]
-    pub fn expected_length(this: &UnderlyingSource) -> Option<JsValue>;
+    pub fn expected_length(this: &UnderlyingSource) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "expectedLength")]
     pub fn set_expected_length(this: &UnderlyingSource, val: f64);
     #[wasm_bindgen(method, setter, js_name = "expectedLength")]
@@ -10973,9 +10973,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type IdentityTransformStreamQueuingStrategy;
-    #[doc = " Returns: number | bigint"]
+    #[doc = " Returns: number | bigint | undefined"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
-    pub fn high_water_mark(this: &IdentityTransformStreamQueuingStrategy) -> Option<JsValue>;
+    pub fn high_water_mark(this: &IdentityTransformStreamQueuingStrategy) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
     pub fn set_high_water_mark(this: &IdentityTransformStreamQueuingStrategy, val: f64);
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -11247,7 +11247,7 @@ extern "C" {
     pub type TraceItem;
     #[doc = " Returns: TraceItemFetchEventInfo | TraceItemJsRpcEventInfo | TraceItemScheduledEventInfo | TraceItemAlarmEventInfo | TraceItemQueueEventInfo | TraceItemEmailEventInfo | TraceItemTailEventInfo | TraceItemCustomEventInfo | TraceItemHibernatableWebSocketEventInfo | null"]
     #[wasm_bindgen(method, getter)]
-    pub fn event(this: &TraceItem) -> Option<JsValue>;
+    pub fn event(this: &TraceItem) -> JsValue;
     #[wasm_bindgen(method, getter, js_name = "eventTimestamp")]
     pub fn event_timestamp(this: &TraceItem) -> Option<f64>;
     #[wasm_bindgen(method, getter)]
@@ -11429,7 +11429,7 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type TraceItemFetchEventInfoRequest;
     #[wasm_bindgen(method, getter)]
-    pub fn cf(this: &TraceItemFetchEventInfoRequest) -> Option<JsValue>;
+    pub fn cf(this: &TraceItemFetchEventInfoRequest) -> JsValue;
     #[wasm_bindgen(method, getter)]
     pub fn headers(this: &TraceItemFetchEventInfoRequest) -> Object<JsString>;
     #[wasm_bindgen(method, getter)]
@@ -12603,9 +12603,9 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "serializeAttachment")]
     pub fn try_serialize_attachment(this: &WebSocket, attachment: &JsValue) -> Result<(), JsValue>;
     #[wasm_bindgen(method, js_name = "deserializeAttachment")]
-    pub fn deserialize_attachment(this: &WebSocket) -> Option<JsValue>;
+    pub fn deserialize_attachment(this: &WebSocket) -> JsValue;
     #[wasm_bindgen(method, catch, js_name = "deserializeAttachment")]
-    pub fn try_deserialize_attachment(this: &WebSocket) -> Result<Option<JsValue>, JsValue>;
+    pub fn try_deserialize_attachment(this: &WebSocket) -> Result<JsValue, JsValue>;
     #[doc = " The **`WebSocket.readyState`** read-only property returns the current state of the WebSocket connection."]
     #[doc = ""]
     #[doc = " [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/readyState)"]
@@ -12798,9 +12798,9 @@ extern "C" {
     pub fn allow_half_open(this: &SocketOptions) -> bool;
     #[wasm_bindgen(method, setter, js_name = "allowHalfOpen")]
     pub fn set_allow_half_open(this: &SocketOptions, val: bool);
-    #[doc = " Returns: number | bigint"]
+    #[doc = " Returns: number | bigint | undefined"]
     #[wasm_bindgen(method, getter, js_name = "highWaterMark")]
-    pub fn high_water_mark(this: &SocketOptions) -> Option<JsValue>;
+    pub fn high_water_mark(this: &SocketOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
     pub fn set_high_water_mark(this: &SocketOptions, val: f64);
     #[wasm_bindgen(method, setter, js_name = "highWaterMark")]
@@ -12968,19 +12968,19 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = "readyState")]
     pub fn ready_state(this: &EventSource) -> f64;
     #[wasm_bindgen(method, getter)]
-    pub fn onopen(this: &EventSource) -> Option<JsValue>;
+    pub fn onopen(this: &EventSource) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_onopen(this: &EventSource, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "onopen")]
     pub fn set_onopen_with_null(this: &EventSource, val: &Null);
     #[wasm_bindgen(method, getter)]
-    pub fn onmessage(this: &EventSource) -> Option<JsValue>;
+    pub fn onmessage(this: &EventSource) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_onmessage(this: &EventSource, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "onmessage")]
     pub fn set_onmessage_with_null(this: &EventSource, val: &Null);
     #[wasm_bindgen(method, getter)]
-    pub fn onerror(this: &EventSource) -> Option<JsValue>;
+    pub fn onerror(this: &EventSource) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_onerror(this: &EventSource, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "onerror")]
@@ -13006,7 +13006,7 @@ extern "C" {
     #[wasm_bindgen(method, setter, js_name = "withCredentials")]
     pub fn set_with_credentials(this: &EventSourceEventSourceInit, val: bool);
     #[wasm_bindgen(method, getter)]
-    pub fn fetcher(this: &EventSourceEventSourceInit) -> Option<JsValue>;
+    pub fn fetcher(this: &EventSourceEventSourceInit) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_fetcher(this: &EventSourceEventSourceInit, val: &JsValue);
 }
@@ -13110,9 +13110,9 @@ extern "C" {
     pub fn env(this: &ContainerStartupOptions) -> Option<Object<JsString>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_env(this: &ContainerStartupOptions, val: &Object<JsString>);
-    #[doc = " Returns: number | bigint"]
+    #[doc = " Returns: number | bigint | undefined"]
     #[wasm_bindgen(method, getter, js_name = "hardTimeout")]
-    pub fn hard_timeout(this: &ContainerStartupOptions) -> Option<JsValue>;
+    pub fn hard_timeout(this: &ContainerStartupOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "hardTimeout")]
     pub fn set_hard_timeout(this: &ContainerStartupOptions, val: f64);
     #[wasm_bindgen(method, setter, js_name = "hardTimeout")]
@@ -13230,7 +13230,7 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name = "start")]
     pub fn try_start(this: &MessagePort) -> Result<(), JsValue>;
     #[wasm_bindgen(method, getter)]
-    pub fn onmessage(this: &MessagePort) -> Option<JsValue>;
+    pub fn onmessage(this: &MessagePort) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_onmessage(this: &MessagePort, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "onmessage")]
@@ -13298,9 +13298,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type SyncKvStorage;
     #[wasm_bindgen(method)]
-    pub fn get(this: &SyncKvStorage, key: &str) -> Option<JsValue>;
+    pub fn get(this: &SyncKvStorage, key: &str) -> JsValue;
     #[wasm_bindgen(method, catch, js_name = "get")]
-    pub fn try_get(this: &SyncKvStorage, key: &str) -> Result<Option<JsValue>, JsValue>;
+    pub fn try_get(this: &SyncKvStorage, key: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(method)]
     pub fn list(this: &SyncKvStorage) -> Iterable;
     #[wasm_bindgen(method, catch, js_name = "list")]
@@ -13425,7 +13425,7 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type WorkerStubEntrypointOptions;
     #[wasm_bindgen(method, getter)]
-    pub fn props(this: &WorkerStubEntrypointOptions) -> Option<JsValue>;
+    pub fn props(this: &WorkerStubEntrypointOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_props(this: &WorkerStubEntrypointOptions, val: &JsValue);
 }
@@ -13495,7 +13495,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_data(this: &WorkerLoaderModule, val: &ArrayBuffer);
     #[wasm_bindgen(method, getter)]
-    pub fn json(this: &WorkerLoaderModule) -> Option<JsValue>;
+    pub fn json(this: &WorkerLoaderModule) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json(this: &WorkerLoaderModule, val: &JsValue);
     #[wasm_bindgen(method, getter)]
@@ -13580,11 +13580,11 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_modules(this: &WorkerLoaderWorkerCode, val: &Object);
     #[wasm_bindgen(method, getter)]
-    pub fn env(this: &WorkerLoaderWorkerCode) -> Option<JsValue>;
+    pub fn env(this: &WorkerLoaderWorkerCode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_env(this: &WorkerLoaderWorkerCode, val: &JsValue);
     #[wasm_bindgen(method, getter, js_name = "globalOutbound")]
-    pub fn global_outbound(this: &WorkerLoaderWorkerCode) -> Option<JsValue>;
+    pub fn global_outbound(this: &WorkerLoaderWorkerCode) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "globalOutbound")]
     pub fn set_global_outbound(this: &WorkerLoaderWorkerCode, val: &JsValue);
     #[wasm_bindgen(method, setter, js_name = "globalOutbound")]
@@ -14982,7 +14982,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &AiTextGenerationResponseFormat, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &AiTextGenerationResponseFormat) -> Option<JsValue>;
+    pub fn json_schema(this: &AiTextGenerationResponseFormat) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &AiTextGenerationResponseFormat, val: &JsValue);
 }
@@ -15065,9 +15065,9 @@ extern "C" {
     pub fn response_format(this: &AiTextGenerationInput) -> Option<AiTextGenerationResponseFormat>;
     #[wasm_bindgen(method, setter)]
     pub fn set_response_format(this: &AiTextGenerationInput, val: &AiTextGenerationResponseFormat);
-    #[doc = " Returns: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[] | object & unknown"]
+    #[doc = " Returns: AiTextGenerationToolInput[] | AiTextGenerationToolLegacyInput[] | object & unknown | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn tools(this: &AiTextGenerationInput) -> Option<JsValue>;
+    pub fn tools(this: &AiTextGenerationInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_tools(this: &AiTextGenerationInput, val: &Array<AiTextGenerationToolInput>);
     #[wasm_bindgen(method, setter, js_name = "tools")]
@@ -15258,7 +15258,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_response(this: &AiTextGenerationOutput, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn tool_calls(this: &AiTextGenerationOutput) -> Option<JsValue>;
+    pub fn tool_calls(this: &AiTextGenerationOutput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_tool_calls(this: &AiTextGenerationOutput, val: &JsValue);
     #[wasm_bindgen(method, getter)]
@@ -15588,7 +15588,7 @@ extern "C" {
     pub fn set_background_with_null(this: &ResponsesInput, val: &Null);
     #[doc = " Returns: string | ResponseConversationParam | null"]
     #[wasm_bindgen(method, getter)]
-    pub fn conversation(this: &ResponsesInput) -> Option<JsValue>;
+    pub fn conversation(this: &ResponsesInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_conversation(this: &ResponsesInput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "conversation")]
@@ -15604,9 +15604,9 @@ extern "C" {
     pub fn set_include(this: &ResponsesInput, val: &Array<ResponseIncludable>);
     #[wasm_bindgen(method, setter, js_name = "include")]
     pub fn set_include_with_null(this: &ResponsesInput, val: &Null);
-    #[doc = " Returns: string | ResponseInput"]
+    #[doc = " Returns: string | ResponseInput | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn input(this: &ResponsesInput) -> Option<JsValue>;
+    pub fn input(this: &ResponsesInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_input(this: &ResponsesInput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "input")]
@@ -15677,9 +15677,9 @@ extern "C" {
     pub fn text(this: &ResponsesInput) -> Option<ResponseTextConfig>;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &ResponsesInput, val: &ResponseTextConfig);
-    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction"]
+    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn tool_choice(this: &ResponsesInput) -> Option<JsValue>;
+    pub fn tool_choice(this: &ResponsesInput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_tool_choice(this: &ResponsesInput, val: &ToolChoiceOptions);
     #[wasm_bindgen(method, setter, js_name = "tool_choice")]
@@ -15905,7 +15905,7 @@ extern "C" {
     pub fn set_incomplete_details_with_null(this: &ResponsesOutput, val: &Null);
     #[doc = " Returns: string | Array<ResponseInputItem> | null"]
     #[wasm_bindgen(method, getter)]
-    pub fn instructions(this: &ResponsesOutput) -> Option<JsValue>;
+    pub fn instructions(this: &ResponsesOutput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_instructions(this: &ResponsesOutput, val: &str);
     #[wasm_bindgen(method, setter, js_name = "instructions")]
@@ -15930,9 +15930,9 @@ extern "C" {
     pub fn set_temperature(this: &ResponsesOutput, val: f64);
     #[wasm_bindgen(method, setter, js_name = "temperature")]
     pub fn set_temperature_with_null(this: &ResponsesOutput, val: &Null);
-    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction"]
+    #[doc = " Returns: ToolChoiceOptions | ToolChoiceFunction | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn tool_choice(this: &ResponsesOutput) -> Option<JsValue>;
+    pub fn tool_choice(this: &ResponsesOutput) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_tool_choice(this: &ResponsesOutput, val: &ToolChoiceOptions);
     #[wasm_bindgen(method, setter, js_name = "tool_choice")]
@@ -18542,7 +18542,7 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ResponseTextConfig;
     #[wasm_bindgen(method, getter)]
-    pub fn format(this: &ResponseTextConfig) -> Option<JsValue>;
+    pub fn format(this: &ResponseTextConfig) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_format(this: &ResponseTextConfig, val: &ResponseFormatText);
     #[wasm_bindgen(method, setter, js_name = "format")]
@@ -18904,9 +18904,9 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<Array<Object>>;
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn text(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<JsValue>;
+    pub fn text(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter)]
@@ -19208,9 +19208,9 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<Array<Object>>;
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn text(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<JsValue>;
+    pub fn text(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter)]
@@ -19322,9 +19322,9 @@ extern "C" {
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<Array<Object>>;
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn text(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<JsValue>;
+    pub fn text(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter)]
@@ -20243,9 +20243,9 @@ extern "C" {
     pub fn prompt(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_prompt(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt, val: &str);
-    #[doc = " Returns: number[] | string & unknown"]
+    #[doc = " Returns: number[] | string & unknown | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt) -> Option<JsValue>;
+    pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Prompt, val: &Array<Number>);
     #[wasm_bindgen(method, setter, js_name = "image")]
@@ -20397,9 +20397,9 @@ extern "C" {
         this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages,
         val: &Array<Object>,
     );
-    #[doc = " Returns: number[] | string & unknown"]
+    #[doc = " Returns: number[] | string & unknown | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<JsValue>;
+    pub fn image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_image(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages, val: &Array<Number>);
     #[wasm_bindgen(method, setter, js_name = "image")]
@@ -20418,7 +20418,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_2_11B_Vision_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -20799,9 +20799,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode,
@@ -20858,7 +20856,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -21025,9 +21023,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_1,
@@ -21107,9 +21103,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Meta_Llama_3_3_70B_Instruct_Fp8_Fast_JSON_Mode_2,
@@ -21287,9 +21281,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Meta_Llama_Guard_3_8B_Output;
-    #[doc = " Returns: string | object"]
+    #[doc = " Returns: string | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn response(this: &Ai_Cf_Meta_Llama_Guard_3_8B_Output) -> Option<JsValue>;
+    pub fn response(this: &Ai_Cf_Meta_Llama_Guard_3_8B_Output) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_response(this: &Ai_Cf_Meta_Llama_Guard_3_8B_Output, val: &str);
     #[wasm_bindgen(method, setter, js_name = "response")]
@@ -21601,7 +21595,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode, val: &JsValue);
 }
@@ -21652,7 +21646,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -21802,8 +21796,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1)
-        -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen2_5_Coder_32B_Instruct_JSON_Mode_1, val: &JsValue);
 }
@@ -22058,7 +22051,7 @@ extern "C" {
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwq_32B_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwq_32B_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -22441,7 +22434,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Mistralai_Mistral_Small_3_1_24B_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -22834,7 +22827,7 @@ extern "C" {
     pub fn set_functions(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Google_Gemma_3_12B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -23209,9 +23202,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_JSON_Mode,
@@ -23268,7 +23259,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -23648,7 +23639,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Meta_Llama_4_Scout_17B_16E_Instruct_Messages_Inner) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -24072,7 +24063,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode, val: &JsValue);
 }
@@ -24118,7 +24109,7 @@ extern "C" {
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -24265,7 +24256,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_1, val: &JsValue);
 }
@@ -24466,7 +24457,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_2, val: &JsValue);
 }
@@ -24512,7 +24503,7 @@ extern "C" {
     pub fn set_functions(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1, val: &Array<Object>);
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -24659,7 +24650,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(this: &Ai_Cf_Qwen_Qwen3_30B_A3B_Fp8_JSON_Mode_3, val: &JsValue);
 }
@@ -25354,9 +25345,9 @@ extern "C" {
     # [wasm_bindgen (extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input;
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn queries(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
+    pub fn queries(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_queries(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "queries")]
@@ -25369,9 +25360,9 @@ extern "C" {
     pub fn instruction(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_instruction(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input, val: &str);
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn documents(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
+    pub fn documents(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_documents(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "documents")]
@@ -25379,9 +25370,9 @@ extern "C" {
         this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input,
         val: &Array<JsString>,
     );
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn text(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> Option<JsValue>;
+    pub fn text(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &Ai_Cf_Qwen_Qwen3_Embedding_0_6B_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "text")]
@@ -27038,9 +27029,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode,
@@ -27097,7 +27086,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -27264,9 +27253,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_1,
@@ -27488,9 +27475,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_2,
@@ -27547,7 +27532,7 @@ extern "C" {
     );
     #[doc = " A list of tools available for the assistant to use."]
     #[doc = ""]
-    #[doc = " Returns: (object | object)[]"]
+    #[doc = " Returns: (object | object)[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn tools(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_Messages_1) -> Option<Array>;
     #[wasm_bindgen(method, setter)]
@@ -27715,9 +27700,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn json_schema(
-        this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3,
-    ) -> Option<JsValue>;
+    pub fn json_schema(this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_json_schema(
         this: &Ai_Cf_Aisingapore_Gemma_Sea_Lion_V4_27B_It_JSON_Mode_3,
@@ -29686,7 +29669,7 @@ extern "C" {
     pub fn skip_cache(this: &GatewayOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "skipCache")]
     pub fn set_skip_cache(this: &GatewayOptions, val: bool);
-    #[doc = " Returns: Record<string, number | string | boolean | bigint | null>"]
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null> | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &GatewayOptions) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
@@ -29888,7 +29871,7 @@ extern "C" {
     pub fn tokens_out(this: &AiGatewayLog) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_tokens_out(this: &AiGatewayLog, val: f64);
-    #[doc = " Returns: Record<string, number | string | boolean | bigint | null>"]
+    #[doc = " Returns: Record<string, number | string | boolean | bigint | null> | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn metadata(this: &AiGatewayLog) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
@@ -38266,7 +38249,7 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiGatewayOptions;
     #[wasm_bindgen(method, getter)]
-    pub fn gateway(this: &AiGatewayOptions) -> Option<JsValue>;
+    pub fn gateway(this: &AiGatewayOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_gateway(this: &AiGatewayOptions, val: &JsValue);
     #[wasm_bindgen(method, getter, js_name = "extraHeaders")]
@@ -38572,9 +38555,9 @@ extern "C" {
     pub fn query(this: &AutoRagSearchRequest) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_query(this: &AutoRagSearchRequest, val: &str);
-    #[doc = " Returns: CompoundFilter | ComparisonFilter"]
+    #[doc = " Returns: CompoundFilter | ComparisonFilter | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn filters(this: &AutoRagSearchRequest) -> Option<JsValue>;
+    pub fn filters(this: &AutoRagSearchRequest) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_filters(this: &AutoRagSearchRequest, val: &CompoundFilter);
     #[wasm_bindgen(method, setter, js_name = "filters")]
@@ -38776,9 +38759,9 @@ extern "C" {
     #[doc = " preserve as much as possible around a point at 20% of the height of the"]
     #[doc = " source image."]
     #[doc = ""]
-    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | BasicImageTransformationsGravityCoordinates"]
+    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | BasicImageTransformationsGravityCoordinates | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn gravity(this: &BasicImageTransformations) -> Option<JsValue>;
+    pub fn gravity(this: &BasicImageTransformations) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_gravity(this: &BasicImageTransformations, val: &str);
     #[wasm_bindgen(method, setter, js_name = "gravity")]
@@ -39081,9 +39064,9 @@ extern "C" {
     #[doc = " - If set to \"y\", the overlay image will be tiled vertically only"]
     #[doc = "   (form a line)."]
     #[doc = ""]
-    #[doc = " Returns: true | \"x\" | \"y\""]
+    #[doc = " Returns: true | \"x\" | \"y\" | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn repeat(this: &RequestInitCfPropertiesImageDraw) -> Option<JsValue>;
+    pub fn repeat(this: &RequestInitCfPropertiesImageDraw) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_repeat(this: &RequestInitCfPropertiesImageDraw, val: bool);
     #[wasm_bindgen(method, setter, js_name = "repeat")]
@@ -39191,9 +39174,9 @@ extern "C" {
     #[doc = "    - tolerance: difference from color to treat as color"]
     #[doc = "    - keep: the number of pixels of border to keep"]
     #[doc = ""]
-    #[doc = " Returns: \"border\" | object"]
+    #[doc = " Returns: \"border\" | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn trim(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
+    pub fn trim(this: &RequestInitCfPropertiesImage) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_trim(this: &RequestInitCfPropertiesImage, val: &str);
     #[wasm_bindgen(method, setter, js_name = "trim")]
@@ -39202,9 +39185,9 @@ extern "C" {
     #[doc = " make images look worse, but load faster. The default is 85. It applies only"]
     #[doc = " to JPEG and WebP images. It doesnâ€™t have any effect on PNG."]
     #[doc = ""]
-    #[doc = " Returns: number | \"low\" | \"medium-low\" | \"medium-high\" | \"high\""]
+    #[doc = " Returns: number | \"low\" | \"medium-low\" | \"medium-high\" | \"high\" | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn quality(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
+    pub fn quality(this: &RequestInitCfPropertiesImage) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_quality(this: &RequestInitCfPropertiesImage, val: f64);
     #[wasm_bindgen(method, setter, js_name = "quality")]
@@ -39282,9 +39265,9 @@ extern "C" {
     #[doc = " width takes dpr into account, and can be specified either using a single"]
     #[doc = " width property, or individually for each side."]
     #[doc = ""]
-    #[doc = " Returns: object | object"]
+    #[doc = " Returns: object | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn border(this: &RequestInitCfPropertiesImage) -> Option<JsValue>;
+    pub fn border(this: &RequestInitCfPropertiesImage) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_border(this: &RequestInitCfPropertiesImage, val: &Object);
     #[doc = " Increase brightness by a factor. A value of 1.0 equals no change, a value"]
@@ -40070,9 +40053,9 @@ extern "C" {
     #[doc = ""]
     #[doc = " @example \"GB\""]
     #[doc = ""]
-    #[doc = " Returns: Iso3166Alpha2Code | \"T1\""]
+    #[doc = " Returns: Iso3166Alpha2Code | \"T1\" | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn country(this: &IncomingRequestCfPropertiesGeographicInformation) -> Option<JsValue>;
+    pub fn country(this: &IncomingRequestCfPropertiesGeographicInformation) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_country(
         this: &IncomingRequestCfPropertiesGeographicInformation,
@@ -41378,7 +41361,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_meta(this: &D1Response, val: &JsValue);
     #[wasm_bindgen(method, getter)]
-    pub fn error(this: &D1Response) -> Option<JsValue>;
+    pub fn error(this: &D1Response) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_error(this: &D1Response, val: &JsValue);
 }
@@ -41992,23 +41975,23 @@ extern "C" {
     pub fn subject(this: &SendEmailBuilder) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_subject(this: &SendEmailBuilder, val: &str);
-    #[doc = " Returns: string | EmailAddress"]
+    #[doc = " Returns: string | EmailAddress | undefined"]
     #[wasm_bindgen(method, getter, js_name = "replyTo")]
-    pub fn reply_to(this: &SendEmailBuilder) -> Option<JsValue>;
+    pub fn reply_to(this: &SendEmailBuilder) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "replyTo")]
     pub fn set_reply_to(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "replyTo")]
     pub fn set_reply_to_with_email_address(this: &SendEmailBuilder, val: &EmailAddress);
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn cc(this: &SendEmailBuilder) -> Option<JsValue>;
+    pub fn cc(this: &SendEmailBuilder) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_cc(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "cc")]
     pub fn set_cc_with_array(this: &SendEmailBuilder, val: &Array<JsString>);
-    #[doc = " Returns: string | string[]"]
+    #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn bcc(this: &SendEmailBuilder) -> Option<JsValue>;
+    pub fn bcc(this: &SendEmailBuilder) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_bcc(this: &SendEmailBuilder, val: &str);
     #[wasm_bindgen(method, setter, js_name = "bcc")]
@@ -42297,9 +42280,9 @@ extern "C" {
     pub fn blur(this: &ImageTransform) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_blur(this: &ImageTransform, val: f64);
-    #[doc = " Returns: object | object"]
+    #[doc = " Returns: object | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn border(this: &ImageTransform) -> Option<JsValue>;
+    pub fn border(this: &ImageTransform) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_border(this: &ImageTransform, val: &Object);
     #[wasm_bindgen(method, getter)]
@@ -42326,9 +42309,9 @@ extern "C" {
     pub fn segment(this: &ImageTransform) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_segment(this: &ImageTransform, val: &str);
-    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | object"]
+    #[doc = " Returns: \"face\" | \"left\" | \"right\" | \"top\" | \"bottom\" | \"center\" | \"auto\" | \"entropy\" | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn gravity(this: &ImageTransform) -> Option<JsValue>;
+    pub fn gravity(this: &ImageTransform) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_gravity(this: &ImageTransform, val: &str);
     #[wasm_bindgen(method, setter, js_name = "gravity")]
@@ -42345,9 +42328,9 @@ extern "C" {
     pub fn sharpen(this: &ImageTransform) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_sharpen(this: &ImageTransform, val: f64);
-    #[doc = " Returns: \"border\" | object"]
+    #[doc = " Returns: \"border\" | object | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn trim(this: &ImageTransform) -> Option<JsValue>;
+    pub fn trim(this: &ImageTransform) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_trim(this: &ImageTransform, val: &str);
     #[wasm_bindgen(method, setter, js_name = "trim")]
@@ -42452,9 +42435,9 @@ extern "C" {
     pub fn opacity(this: &ImageDrawOptions) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_opacity(this: &ImageDrawOptions, val: f64);
-    #[doc = " Returns: boolean | string"]
+    #[doc = " Returns: boolean | string | undefined"]
     #[wasm_bindgen(method, getter)]
-    pub fn repeat(this: &ImageDrawOptions) -> Option<JsValue>;
+    pub fn repeat(this: &ImageDrawOptions) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_repeat(this: &ImageDrawOptions, val: bool);
     #[wasm_bindgen(method, setter, js_name = "repeat")]
@@ -44278,9 +44261,9 @@ pub mod cloudflare_workers_module {
         pub fn retries(this: &WorkflowStepConfig) -> Option<Object>;
         #[wasm_bindgen(method, setter)]
         pub fn set_retries(this: &WorkflowStepConfig, val: &Object);
-        #[doc = " Returns: WorkflowTimeoutDuration | number"]
+        #[doc = " Returns: WorkflowTimeoutDuration | number | undefined"]
         #[wasm_bindgen(method, getter)]
-        pub fn timeout(this: &WorkflowStepConfig) -> Option<JsValue>;
+        pub fn timeout(this: &WorkflowStepConfig) -> JsValue;
         #[wasm_bindgen(method, setter)]
         pub fn set_timeout(this: &WorkflowStepConfig, val: &JsValue);
         #[wasm_bindgen(method, setter, js_name = "timeout")]
@@ -44437,9 +44420,9 @@ pub mod cloudflare_workers_module {
         pub fn type_(this: &WorkflowStepOptions) -> String;
         #[wasm_bindgen(method, setter)]
         pub fn set_type(this: &WorkflowStepOptions, val: &str);
-        #[doc = " Returns: WorkflowTimeoutDuration | number"]
+        #[doc = " Returns: WorkflowTimeoutDuration | number | undefined"]
         #[wasm_bindgen(method, getter)]
-        pub fn timeout(this: &WorkflowStepOptions) -> Option<JsValue>;
+        pub fn timeout(this: &WorkflowStepOptions) -> JsValue;
         #[wasm_bindgen(method, setter)]
         pub fn set_timeout(this: &WorkflowStepOptions, val: &JsValue);
         #[wasm_bindgen(method, setter, js_name = "timeout")]
@@ -47314,9 +47297,9 @@ pub mod tail_stream {
         pub fn name(this: &SpanOpen) -> String;
         #[wasm_bindgen(method, getter, js_name = "spanId")]
         pub fn span_id(this: &SpanOpen) -> String;
-        #[doc = " Returns: FetchEventInfo | JsRpcEventInfo | Attributes"]
+        #[doc = " Returns: FetchEventInfo | JsRpcEventInfo | Attributes | undefined"]
         #[wasm_bindgen(method, getter)]
-        pub fn info(this: &SpanOpen) -> Option<JsValue>;
+        pub fn info(this: &SpanOpen) -> JsValue;
     }
     impl SpanOpen {
         #[allow(clippy::new_without_default)]
@@ -47749,9 +47732,9 @@ extern "C" {
     pub fn return_values(this: &VectorizeQueryOptions) -> Option<bool>;
     #[wasm_bindgen(method, setter, js_name = "returnValues")]
     pub fn set_return_values(this: &VectorizeQueryOptions, val: bool);
-    #[doc = " Returns: boolean | VectorizeMetadataRetrievalLevel"]
+    #[doc = " Returns: boolean | VectorizeMetadataRetrievalLevel | undefined"]
     #[wasm_bindgen(method, getter, js_name = "returnMetadata")]
-    pub fn return_metadata(this: &VectorizeQueryOptions) -> Option<JsValue>;
+    pub fn return_metadata(this: &VectorizeQueryOptions) -> JsValue;
     #[wasm_bindgen(method, setter, js_name = "returnMetadata")]
     pub fn set_return_metadata(this: &VectorizeQueryOptions, val: bool);
     #[wasm_bindgen(method, setter, js_name = "returnMetadata")]
@@ -48685,7 +48668,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_error(this: &InstanceStatus, val: &Object);
     #[wasm_bindgen(method, getter)]
-    pub fn output(this: &InstanceStatus) -> Option<JsValue>;
+    pub fn output(this: &InstanceStatus) -> JsValue;
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &InstanceStatus, val: &JsValue);
 }


### PR DESCRIPTION
The IR now mirrors TypeScript's own type system: only the syntactic constructs from the grammar get dedicated `TypeRef` variants. The 22-odd dedicated variants for built-in JS classes (`Date`, `RegExp`, `Error`, `TypeError`, `RangeError`, all typed arrays, `ArrayBuffer`, `DataView`, `Promise`, `Map`, `Set`, `Record`, `Named`, `GenericInstantiation`) collapse into a single `TypeRef::Reference { segments, generic_args }` variant. Resolution happens at codegen time against the scope chain, exactly the way TypeScript itself resolves names.

This started as the doc-augmentation feature (`Returns: <ts-shape>` on return types that erase to `JsValue`) but exposed several pre-existing IR bugs — most visibly, every JS error subclass (`TypeError`, `RangeError`, `SyntaxError`, ...) collapsed to a single `TypeRef::Error` at parse time, so a `TypeError | RangeError` union showed up as `Error | Error` in the IR. With the new shape they retain their identity, `BUILTIN_PARENTS` walks them properly, and `format_ts` renders the original names.

## TypeRef shape

```rs
pub enum TypeRef {
    // Primitives — non-trivial Rust-side lowering
    Boolean, Number, String, BigInt, Void, Undefined, Null,
    Any, Unknown, Object, Symbol,

    // TS-only synthetic
    ArrayBufferView,

    // Syntactic constructs
    Array(Box<TypeRef>),         // T[] - never goes through name resolution
    Nullable(Box<TypeRef>),
    Union(Vec<TypeRef>),
    Intersection(Vec<TypeRef>),
    Tuple(Vec<TypeRef>),
    Function(FunctionSig),

    // Literals
    StringLiteral(String),
    NumberLiteral(f64),
    BooleanLiteral(bool),

    // Named type reference — possibly qualified, possibly generic
    Reference {
        segments: Vec<String>,
        generic_args: Vec<TypeRef>,
    },

    Unresolved(String),
}
```

`Reference` is the only variant for nominal names. It covers every shape uniformly:

* `Foo` → `Reference { segments: ["Foo"], generic_args: [] }`
* `Foo<T>` → `Reference { segments: ["Foo"], generic_args: [T] }`
* `A.B.C` → `Reference { segments: ["A","B","C"], generic_args: [] }`
* `A.B.C<T>` → `Reference { segments: ["A","B","C"], generic_args: [T] }`

`T[]` and `Array<T>` are intentionally **distinct** at the IR level (matching TS): `T[]` is the syntactic shortcut and never goes through name resolution, while `Array<T>` is a `Reference` that *does* resolve through the scope chain. So `type Array = 5; foo(bar: Items[])` works correctly — the user's local `Array` shadows nothing because `T[]` doesn't consult it.

Convenience helpers on `TypeRef`:

```rs
TypeRef::ident("Foo")                          // single-segment, no args
TypeRef::generic("Promise", vec![T])           // single-segment, with args
ty.as_ident()                                  // -> Option<&str> for single-segment, no args
ty.as_generic_head("Promise")                  // -> Option<&[TypeRef]>
ty.as_promise_inner()                          // shortcut for Promise<T>
ty.format_ts()                                 // TS-like rendering
ty.canonical_name()                            // for subtyping LUB
```

## Returns: doc augmentation

When a return-position type contains a union that erases to `JsValue` (no useful LUB), the generated doc gets a synthesized `Returns: <ts-shape>` line so callers can see the original TS shape:

```rs
#[doc = " Returns: string | ArrayBuffer | ArrayBufferView"]
pub fn content(this: &EmailAttachment) -> JsValue;

#[doc = " Returns: Array<32 | \"foo\">"]
pub fn tags(this: &Foo) -> Array;

#[doc = " Returns: 32 | \"foo\""]
pub async fn fetch_value() -> Result<JsValue, JsValue>;
```

The detector walks the whole return type and fires when any nested union erases. Async returns use the post-Promise-unwrap inner. LUB-narrowed unions (e.g. `TypeError | RangeError` → `Error`) don't fire — the static type already conveys the necessary info. If the JSDoc already has a `Returns:` line, it's preserved verbatim.

## Other fixes

* `literal_union::union_member_types` now calls `simplify_union` for per-property merges, so `string | undefined` from union-of-literal-branches coalesces to `Nullable<string>` like a hand-written union does. Fixes `EmailAttachment.contentId` being `Option<JsValue>` instead of `Option<String>`.
* `to_snake_case` keeps trailing digits attached to a word (`Float32Array` → `float32_array`, not `float_32_array`). Matches the historical wasm-bindgen convention.

## Snapshot diffs

* `workers-types.rs` sees substantial improvements where unions now resolve correctly through the LUB lattice (no more `fetch_with_js_value_and_init` when the input is `Request`).
* User-defined type aliases that pointed at function shapes previously emitted both the alias decl and a redundant `use JsValue as <Name>;` — the `JsValue` alias is gone now since the proper alias decl is used.
* Many getters gain `Returns:` doc lines documenting the original TS union shape for erased return types.

## Tests

* 166 unit tests pass, including 9 new `format_ts` tests, 8 new `return_type_has_erased_union` tests, and a new naming test for the digit-trailing snake-case rule.
* Snapshot tests pass. New focused fixture/snapshot pair at `tests/{fixtures,snapshots}/erased-return-doc.{d.ts,rs}`.
* `CONVENTIONS.md` updated under `Subtyping LUB` with a `Returns:` doc augmentation subsection.

Clippy + rustfmt clean.