### PR TITLE
Promote literal-discriminated unions to a first-class kind

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,6 +24,7 @@ in sync with the snapshot fixtures (`tests/fixtures/*.d.ts` paired with
 * [Interfaces (class-like vs dictionary)](#interfaces-class-like-vs-dictionary)
 * [Dictionary builders](#dictionary-builders)
 * [Anonymous interface synthesis](#anonymous-interface-synthesis)
+* [Discriminated unions](#discriminated-unions)
 * [`var X: { new(...): T }` patterns](#var-x--new-t-patterns)
 * [Module-scoped constructor variables](#module-scoped-constructor-variables)
 * [Signature flattening](#signature-flattening)
@@ -349,6 +350,35 @@ EmailAttachment::new_inline(content, filename, type_)        // disposition bake
 EmailAttachment::new(disposition: &str, content, filename, type_)  // catch-all
 ```
 
+### Per-branch required fields in discriminated unions
+
+When a union qualifies as a [discriminated union](#discriminated-unions),
+each `new_<discriminator>` / `builder_<discriminator>` factory derives
+its required-field set from **its own branch**, not from the merged
+shape. For
+
+```ts
+type EmailAttachment =
+  | { disposition: "inline";     contentId: string;     filename: string; type: string; content: string | ArrayBuffer; }
+  | { disposition: "attachment"; contentId?: undefined; filename: string; type: string; content: string | ArrayBuffer; };
+```
+
+`contentId` is required in the `inline` branch and absent (`?:
+undefined`) in the `attachment` branch. The factory pair reflects
+that:
+
+```rust
+EmailAttachment::new_inline(content_id: &str, filename: &str, type_: &str, content: &str)
+EmailAttachment::new_attachment(filename: &str, type_: &str, content: &str)
+```
+
+The builder wrapper (`EmailAttachmentBuilder`) still exposes a fluent
+`content_id(self, val)` setter — it reflects the merged-shape view
+that the field is optional on the type as a whole, so callers going
+through `builder_attachment(...).content_id(x).build()` aren't
+prevented from setting it. The branch invariant is enforced at the
+`new_<discriminator>` boundary, not inside the builder.
+
 ### Has any `readonly` property → `new()` only, no builder
 
 A dictionary that exposes a `readonly` property can't be fully
@@ -436,7 +466,7 @@ to anything else (named types, primitives, function types, generics,
 ### Union of inline literals
 
 When every branch of a union is itself an inline literal, the branches
-are **structurally merged** into a single interface body. The merge
+are **structurally merged** into a single member set. The merge
 covers both positions above:
 
 ```ts
@@ -445,11 +475,7 @@ type EmailAttachment =
   | { disposition: "attachment"; contentId?: undefined; filename: string; … };
 ```
 
-becomes a single `interface EmailAttachment { … }` whose members are
-the union of every branch's properties, with optionality and types
-adjusted so the merged shape is valid against every branch.
-
-The merge rules:
+The merge rules apply to the unified shape:
 
 * **Property optionality**: a property is required iff it is present
   and non-optional in **every** branch. If any branch declares it
@@ -467,14 +493,18 @@ The merge rules:
 * **Index signatures**: dedup by structural equality; the first one
   wins on conflict.
 
-The synthesized type then inherits every other rule that applies to
-interfaces: dictionary-vs-class-like classification (see
-[Interfaces](#interfaces-class-like-vs-dictionary)), the dictionary-
-builder treatment for property-only shapes (see
-[Dictionary builders](#dictionary-builders)), and the union-typed
-setter expansion (see [Signature flattening](#signature-flattening))
-that turns `from: string | EmailAddress` into separate setter and
-builder methods.
+The synthesized type lands in one of two kinds depending on whether a
+discriminator is detected (see [Discriminated unions](#discriminated-unions)):
+
+* **`InterfaceDecl`** when no shared literal-typed required field
+  exists — falls through the regular dictionary-vs-class-like
+  pipeline, the dictionary-builder treatment for property-only
+  shapes, and the union-typed setter expansion that turns
+  `from: string | EmailAddress` into separate setter and builder
+  methods.
+* **`DiscriminatedUnionDecl`** when at least one shared literal-typed
+  required field exists — gets the per-branch factory rules described
+  in the next section.
 
 ### Naming
 
@@ -504,6 +534,101 @@ synthesized. Anonymous types nested inside a generic, an array,
 — they follow the regular type-mapping rules and erase to `Object`.
 Inline literals inside the *body* of a hoisted interface are themselves
 hoisted recursively, using the synthesized parent's name.
+
+## Discriminated unions
+
+A type alias `type Foo = A | B | …` whose branches share at least one
+**required, literal-typed** property is promoted to a
+`DiscriminatedUnionDecl` rather than a plain `InterfaceDecl`.
+
+A property qualifies as a discriminator when, in **every** branch, it
+is present, required (no `?:` marker), and typed as a string, number,
+or boolean literal. TypeScript's narrowing accepts all three; the
+codegen rule matches.
+
+```ts
+// String discriminator
+type EmailAttachment =
+  | { disposition: "inline";     contentId: string;     … }
+  | { disposition: "attachment"; contentId?: undefined; … };
+
+// Boolean discriminator
+type ReadableStreamReadResult<R = any> =
+  | { done: false; value: R }
+  | { done: true;  value?: undefined };
+
+// Number discriminator
+type Status =
+  | { code: 200; body: string }
+  | { code: 404; reason: string };
+```
+
+### Codegen shape
+
+The extern block is the same as for any other dictionary — a single
+`pub type Foo;` plus getter/setter bindings for the merged shape.
+
+The `impl Foo` block emits **per-branch** `new_*` and (when useful)
+`builder_*` factories. Each variant's required positional parameters
+are derived from **its own branch**, not from the merged shape — so
+the `EmailAttachment` `inline` branch's `contentId: string` shows up
+as a required argument in `new_inline(...)` even though the merged
+shape marks `contentId` optional.
+
+```rust
+EmailAttachment::new_inline(content_id: &str, filename: &str, type_: &str, content: &str)
+EmailAttachment::new_inline_with_array_buffer(content_id: &str, filename: &str, type_: &str, content: &ArrayBuffer)
+
+EmailAttachment::new_attachment(filename: &str, type_: &str, content: &str)
+EmailAttachment::new_attachment_with_array_buffer(filename: &str, type_: &str, content: &ArrayBuffer)
+```
+
+The literal-collapse, value-union expansion, and `_with_<type>`
+suffixing rules described in [Dictionary builders](#dictionary-builders)
+all apply *within each branch* — branches don't influence each
+other's suffix decisions.
+
+### Wrapper builder remains merged
+
+The wrapper struct (`EmailAttachmentBuilder`) and its fluent setters
+are computed from the **merged-shape optional set**, not per branch.
+For `EmailAttachment` this means
+`EmailAttachmentBuilder::content_id(self, val)` is always available,
+even after `builder_attachment(...)`. The branch invariant is enforced
+at the `new_<discriminator>` boundary; once you're past that, the
+wrapper exposes the runtime-permissive view of the type. Calling
+`.content_id(x)` after `builder_attachment(...)` writes through to
+the JS object exactly as `set_content_id` would on the bare type —
+no special branch enforcement.
+
+### `builder_<branch>` suppression
+
+A `builder_<branch>` is only emitted when **at least one merged-optional
+field isn't already required by that branch**. If a branch's required
+set covers every merged-optional field, going through the wrapper
+would have nothing to chain — so the `new_<branch>` body is inlined
+directly:
+
+```rust
+// inline branch covers `contentId` (the only merged-optional), so no builder_inline:
+EmailAttachment::new_inline(content_id, filename, type_, content) {
+    let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+    inner.set_disposition("inline");
+    inner.set_content_id(content_id);
+    // …
+    inner
+}
+
+// attachment branch leaves `contentId` to the wrapper, so builder_attachment exists:
+EmailAttachment::new_attachment(filename, type_, content) {
+    Self::builder_attachment(filename, type_, content).build()
+}
+```
+
+This collapses to the existing all-required dictionary rule (see
+[Dictionary builders](#dictionary-builders)) when the type has no
+optional fields at all — there's nothing to chain, so `new(reqs)` is
+emitted with an inlined body and no builder type is generated.
 
 ## `var X: { new(...): T }` patterns
 

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -41,7 +41,7 @@ use crate::parse::scope::ScopeId;
 use crate::util::naming::to_snake_case;
 
 /// Configuration for generating a class-like extern block.
-struct ClassConfig<'a> {
+pub(crate) struct ClassConfig<'a> {
     /// Rust type name.
     rust_name: String,
     /// JS class name (for `js_name` / `js_class` attributes).
@@ -114,6 +114,34 @@ impl<'a> ClassConfig<'a> {
             rust_name: decl.name.clone(),
             js_name: decl.js_name.clone(),
             extends,
+            module,
+            js_namespace: None,
+            is_abstract: false,
+            members: decl.members.clone(),
+            cgctx,
+            scope,
+        }
+    }
+
+    /// Build a `ClassConfig` from a [`DiscriminatedUnionDecl`]. Members
+    /// are the merged shape — used for the extern block (one getter /
+    /// setter set covering every property across branches). Per-branch
+    /// information is passed alongside through
+    /// [`generate_dictionary_factory_with_passes`] in the caller.
+    pub(crate) fn from_discriminated_union(
+        decl: &crate::ir::DiscriminatedUnionDecl,
+        ctx: &ModuleContext,
+        cgctx: Option<&'a CodegenContext>,
+        scope: ScopeId,
+    ) -> Self {
+        let module = match ctx {
+            ModuleContext::Module(m) => Some(m.clone()),
+            ModuleContext::Global => None,
+        };
+        ClassConfig {
+            rust_name: decl.name.clone(),
+            js_name: decl.js_name.clone(),
+            extends: vec![quote! { Object }],
             module,
             js_namespace: None,
             is_abstract: false,
@@ -237,6 +265,29 @@ pub fn generate_dictionary_extern(
 /// }
 /// ```
 fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
+    generate_dictionary_factory_with_passes(config, None)
+}
+
+/// Same as [`generate_dictionary_factory`] but lets the caller override
+/// the **required-field passes** that drive `new_*` / `builder_*`
+/// generation.
+///
+/// * `None` — single pass over the merged required-getter set. This is
+///   the regular-interface and dictionary path.
+/// * `Some(passes)` — one pass per entry; each entry's getters drive
+///   one cohort of `new_*` / `builder_*` variants. Used for
+///   discriminated unions, where each branch contributes a distinct
+///   required-field pass and produces its own per-discriminant
+///   factories.
+///
+/// The wrapper struct's fluent setters (the
+/// `optional`-fields-on-the-merged-shape side) are unchanged across
+/// passes — they always reflect the merged optional set, which is the
+/// runtime-permissive view callers can always tweak.
+pub(crate) fn generate_dictionary_factory_with_passes(
+    config: &ClassConfig,
+    factory_required_overrides: Option<Vec<Vec<&crate::ir::GetterMember>>>,
+) -> TokenStream {
     let rust_type = super::typemap::make_ident(&config.effective_rust_name());
     let builder_name = super::typemap::make_ident(&format!("{}Builder", config.rust_name));
 
@@ -286,8 +337,10 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
         })
         .collect();
 
-    // Partition getters: required ones become positional `builder(...)`
-    // arguments, optional ones become fluent setter methods.
+    // Partition getters by the merged-shape `optional` flag. This
+    // partition drives the wrapper's fluent setters (optional set) and
+    // is the default required-field pass when no per-branch override is
+    // supplied.
     let mut required_getters: Vec<&crate::ir::GetterMember> = Vec::new();
     let mut optional_getters: Vec<&crate::ir::GetterMember> = Vec::new();
     for g in &getters {
@@ -298,11 +351,25 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
         }
     }
 
+    // The list of required-field passes drives `new_*` / `builder_*`
+    // generation. Plain interfaces / dictionaries get a single pass
+    // (the merged required set). Discriminated unions thread one pass
+    // per branch via `factory_required_overrides` so that each
+    // branch's required fields surface as positional args in its own
+    // `new_<discriminator>(...)` variant — see
+    // [`generate_dictionary_factory_with_passes`].
+    let required_passes: Vec<Vec<&crate::ir::GetterMember>> =
+        factory_required_overrides.unwrap_or_else(|| vec![required_getters.clone()]);
+
     // When every property is required, the builder type is dead weight: it
     // would carry only `pub fn build(self) -> Foo` with nothing to chain,
     // so we suppress it. `new(reqs)` still gets emitted but inlines the
     // construction directly. See the dictionary-builder convention in
     // `CONVENTIONS.md` for the rule.
+    //
+    // For discriminated unions the merged-shape optional set is what
+    // populates the wrapper's setters, so the decision keys off
+    // `optional_getters` regardless of the per-branch `required_passes`.
     let emit_builder = !optional_getters.is_empty();
 
     // Resolve each getter through the setter pipeline. Multi-overload
@@ -377,139 +444,125 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
         }
     }
 
-    let mut field_dims: Vec<FieldDim> = Vec::new();
-    for g in &required_getters {
-        let param_name = to_snake_case(&g.js_name);
-        let setters = resolve_setter_sigs(g);
-        if setters.is_empty() {
-            continue;
-        }
+    // Helper that turns one required-getter list into a list of
+    // `FieldDim`s — the cartesian product axes for that pass.
+    let build_field_dims = |required: &[&crate::ir::GetterMember]| -> Vec<FieldDim> {
+        let mut field_dims: Vec<FieldDim> = Vec::new();
+        for g in required {
+            let param_name = to_snake_case(&g.js_name);
+            let setters = resolve_setter_sigs(g);
+            if setters.is_empty() {
+                continue;
+            }
 
-        // Each member of the union (or the single non-union type) maps
-        // to one option. Literals find their setter by matching the
-        // setter's param type_ref structurally; non-literals get their
-        // own option with an `expand_signatures`-compatible param.
-        let mut options: Vec<FieldOption> = Vec::new();
-        let members = split_union(&g.type_ref);
-        let any_literal = members.iter().any(|m| {
-            matches!(
-                m,
-                crate::ir::TypeRef::StringLiteral(_)
-                    | crate::ir::TypeRef::NumberLiteral(_)
-                    | crate::ir::TypeRef::BooleanLiteral(_)
-            )
-        });
-        let value_members: Vec<&crate::ir::TypeRef> = members
-            .iter()
-            .copied()
-            .filter(|m| {
-                !matches!(
+            // Each member of the union (or the single non-union type) maps
+            // to one option. Literals find their setter by matching the
+            // setter's param type_ref structurally; non-literals get their
+            // own option with an `expand_signatures`-compatible param.
+            let mut options: Vec<FieldOption> = Vec::new();
+            let members = split_union(&g.type_ref);
+            let any_literal = members.iter().any(|m| {
+                matches!(
                     m,
                     crate::ir::TypeRef::StringLiteral(_)
                         | crate::ir::TypeRef::NumberLiteral(_)
                         | crate::ir::TypeRef::BooleanLiteral(_)
                 )
-            })
-            .collect();
-
-        let pick_setter = |target: &crate::ir::TypeRef| -> Option<syn::Ident> {
-            setters
-                .iter()
-                .find(|sig| sig.params.first().is_some_and(|p| &p.type_ref == target))
-                .map(|sig| super::typemap::make_ident(&sig.rust_name))
-        };
-        // Fallback for fields without per-member setter granularity: the
-        // first setter handles everything (typical when the IR only
-        // synthesised one setter for the whole union).
-        let default_setter = super::typemap::make_ident(&setters[0].rust_name);
-
-        for m in &members {
-            match m {
-                crate::ir::TypeRef::StringLiteral(s) => {
-                    let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
-                    options.push(FieldOption::Literal {
-                        field_js_name: g.js_name.clone(),
-                        field_doc: g.doc.clone(),
-                        literal_display: format!("\"{s}\""),
-                        suffix: format!("_{}", to_snake_case(s)),
-                        setter_ident,
-                        literal_expr: quote! { #s },
-                    });
-                }
-                crate::ir::TypeRef::NumberLiteral(n) => {
-                    let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
-                    let lit = syn::LitFloat::new(&n.to_string(), proc_macro2::Span::call_site());
-                    options.push(FieldOption::Literal {
-                        field_js_name: g.js_name.clone(),
-                        field_doc: g.doc.clone(),
-                        literal_display: n.to_string(),
-                        suffix: format!("_{}", n.to_string().replace(['.', '-'], "_")),
-                        setter_ident,
-                        literal_expr: quote! { #lit },
-                    });
-                }
-                crate::ir::TypeRef::BooleanLiteral(b) => {
-                    let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
-                    options.push(FieldOption::Literal {
-                        field_js_name: g.js_name.clone(),
-                        field_doc: g.doc.clone(),
-                        literal_display: b.to_string(),
-                        suffix: format!("_{}", b),
-                        setter_ident,
-                        literal_expr: quote! { #b },
-                    });
-                }
-                _ => {}
-            }
-        }
-        // Non-literal members: if the union mixed literals with concrete
-        // types, those concrete types still need their own value options
-        // (e.g. `disposition: "inline" | string` → `new_inline()` plus a
-        // catch-all `new(disposition: &str)`). For purely non-literal
-        // unions we emit one value option per member.
-        let value_targets: Vec<&crate::ir::TypeRef> = if any_literal {
-            value_members
-        } else {
-            members.clone()
-        };
-        for m in value_targets {
-            let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
-            let param = ConcreteParam {
-                name: param_name.clone(),
-                type_ref: m.clone(),
-                variadic: false,
-            };
-            options.push(FieldOption::Value {
-                field_doc: g.doc.clone(),
-                param,
-                setter_ident,
             });
-        }
-        if options.is_empty() {
-            continue;
-        }
-        field_dims.push(FieldDim { options });
-    }
-
-    // Cartesian product across field dimensions → list of combos
-    // (each is a Vec<&FieldOption>).
-    let combos: Vec<Vec<&FieldOption>> = if field_dims.is_empty() {
-        vec![vec![]]
-    } else {
-        let mut acc: Vec<Vec<&FieldOption>> = vec![vec![]];
-        for dim in &field_dims {
-            acc = acc
-                .into_iter()
-                .flat_map(|prefix| {
-                    dim.options.iter().map(move |opt| {
-                        let mut next = prefix.clone();
-                        next.push(opt);
-                        next
-                    })
+            let value_members: Vec<&crate::ir::TypeRef> = members
+                .iter()
+                .copied()
+                .filter(|m| {
+                    !matches!(
+                        m,
+                        crate::ir::TypeRef::StringLiteral(_)
+                            | crate::ir::TypeRef::NumberLiteral(_)
+                            | crate::ir::TypeRef::BooleanLiteral(_)
+                    )
                 })
                 .collect();
+
+            let pick_setter = |target: &crate::ir::TypeRef| -> Option<syn::Ident> {
+                setters
+                    .iter()
+                    .find(|sig| sig.params.first().is_some_and(|p| &p.type_ref == target))
+                    .map(|sig| super::typemap::make_ident(&sig.rust_name))
+            };
+            // Fallback for fields without per-member setter granularity:
+            // the first setter handles everything (typical when the IR
+            // only synthesised one setter for the whole union).
+            let default_setter = super::typemap::make_ident(&setters[0].rust_name);
+
+            for m in &members {
+                match m {
+                    crate::ir::TypeRef::StringLiteral(s) => {
+                        let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
+                        options.push(FieldOption::Literal {
+                            field_js_name: g.js_name.clone(),
+                            field_doc: g.doc.clone(),
+                            literal_display: format!("\"{s}\""),
+                            suffix: format!("_{}", to_snake_case(s)),
+                            setter_ident,
+                            literal_expr: quote! { #s },
+                        });
+                    }
+                    crate::ir::TypeRef::NumberLiteral(n) => {
+                        let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
+                        let lit =
+                            syn::LitFloat::new(&n.to_string(), proc_macro2::Span::call_site());
+                        options.push(FieldOption::Literal {
+                            field_js_name: g.js_name.clone(),
+                            field_doc: g.doc.clone(),
+                            literal_display: n.to_string(),
+                            suffix: format!("_{}", n.to_string().replace(['.', '-'], "_")),
+                            setter_ident,
+                            literal_expr: quote! { #lit },
+                        });
+                    }
+                    crate::ir::TypeRef::BooleanLiteral(b) => {
+                        let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
+                        options.push(FieldOption::Literal {
+                            field_js_name: g.js_name.clone(),
+                            field_doc: g.doc.clone(),
+                            literal_display: b.to_string(),
+                            suffix: format!("_{}", b),
+                            setter_ident,
+                            literal_expr: quote! { #b },
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            // Non-literal members: if the union mixed literals with
+            // concrete types, those concrete types still need their own
+            // value options (e.g. `disposition: "inline" | string` →
+            // `new_inline()` plus a catch-all `new(disposition: &str)`).
+            // For purely non-literal unions we emit one value option
+            // per member.
+            let value_targets: Vec<&crate::ir::TypeRef> = if any_literal {
+                value_members
+            } else {
+                members.clone()
+            };
+            for m in value_targets {
+                let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
+                let param = ConcreteParam {
+                    name: param_name.clone(),
+                    type_ref: m.clone(),
+                    variadic: false,
+                };
+                options.push(FieldOption::Value {
+                    field_doc: g.doc.clone(),
+                    param,
+                    setter_ident,
+                });
+            }
+            if options.is_empty() {
+                continue;
+            }
+            field_dims.push(FieldDim { options });
         }
-        acc
+        field_dims
     };
 
     // For each combo: collect the value params (literals contribute
@@ -529,178 +582,230 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
         /// caller-provided fields.
         provided_doc_bullets: Vec<String>,
     }
-    let mut plans: Vec<ComboPlan> = Vec::with_capacity(combos.len());
-    for combo in &combos {
-        let mut literal_suffix = String::new();
-        let mut value_params: Vec<ConcreteParam> = Vec::new();
-        let mut init_calls: Vec<TokenStream> = Vec::new();
-        let mut arg_idents: Vec<syn::Ident> = Vec::new();
-        let mut literal_doc_bullets: Vec<String> = Vec::new();
-        let mut provided_doc_bullets: Vec<String> = Vec::new();
-        for opt in combo {
-            match opt {
-                FieldOption::Literal {
-                    field_js_name,
-                    field_doc,
-                    literal_display,
-                    suffix,
-                    setter_ident,
-                    literal_expr,
-                } => {
-                    literal_suffix.push_str(suffix);
-                    init_calls.push(quote! { inner.#setter_ident(#literal_expr); });
-                    let bullet_head = format!("`{field_js_name}: {literal_display}`");
-                    literal_doc_bullets.push(match field_doc {
-                        Some(doc) => format!("* {bullet_head} - {}", doc.trim()),
-                        None => format!("* {bullet_head}"),
-                    });
-                }
-                FieldOption::Value {
-                    field_doc,
-                    param,
-                    setter_ident,
-                } => {
-                    let arg_ident = super::typemap::make_ident(&param.name);
-                    arg_idents.push(arg_ident.clone());
-                    init_calls.push(quote! { inner.#setter_ident(#arg_ident); });
-                    value_params.push(param.clone());
-                    if let Some(doc) = field_doc {
-                        let bullet_head = format!("`{}`", param.name);
-                        provided_doc_bullets.push(format!("* {bullet_head} - {}", doc.trim()));
-                    }
-                }
-            }
-        }
-        plans.push(ComboPlan {
-            literal_suffix,
-            value_params,
-            init_calls,
-            arg_idents,
-            literal_doc_bullets,
-            provided_doc_bullets,
-        });
-    }
-
-    // Compute `_with_X[_and_Y]` suffixes ONLY across combos sharing the
-    // same literal prefix. Combos with distinct literal prefixes are
-    // already disambiguated by the prefix, so they shouldn't influence
-    // each other's `_with_*` decisions.
-    let mut value_suffixes: Vec<String> = vec![String::new(); plans.len()];
-    let mut by_prefix: HashMap<String, Vec<usize>> = HashMap::new();
-    for (i, p) in plans.iter().enumerate() {
-        by_prefix
-            .entry(p.literal_suffix.clone())
-            .or_default()
-            .push(i);
-    }
-    for indices in by_prefix.values() {
-        let group_params: Vec<Vec<ConcreteParam>> = indices
-            .iter()
-            .map(|&i| plans[i].value_params.clone())
-            .collect();
-        let group_suffixes = crate::codegen::signatures::compute_suffixes_pub(&group_params);
-        for (suffix, &i) in group_suffixes.iter().zip(indices) {
-            value_suffixes[i] = suffix.clone();
-        }
-    }
 
     let mut builder_variants: Vec<TokenStream> = Vec::new();
     let mut new_variants: Vec<TokenStream> = Vec::new();
+    // Shared across passes so a discriminator combo emitted by branch A
+    // doesn't get re-emitted under the same name by branch B.
     let mut emitted_names: HashSet<String> = HashSet::new();
-    for (plan, value_suffix) in plans.iter().zip(&value_suffixes) {
-        let full_suffix = format!("{}{}", plan.literal_suffix, value_suffix);
-        // Dedup combos that produce the same final name (e.g. when a
-        // discriminator collapse plus a value collapse converge).
-        if !emitted_names.insert(full_suffix.clone()) {
-            continue;
-        }
-        let new_ident = super::typemap::make_ident(&format!("new{full_suffix}"));
-        let (generics, params_tokens) = generate_dictionary_params(
-            &plan.value_params,
-            config.cgctx,
-            config.scope,
-            &config.from_module(),
-        );
-        let init_calls = &plan.init_calls;
-        let arg_idents = &plan.arg_idents;
 
-        // Compose the doc block. `# Inlined fields` lists the literal
-        // discriminants baked into the function name (no parameter on
-        // the call). `# Parameters` lists the caller-supplied fields
-        // that show up in the actual signature. Either section is
-        // skipped when its bullet list is empty.
-        let mut doc_text = String::new();
-        if !plan.literal_doc_bullets.is_empty() {
-            doc_text.push_str("## Inlined fields\n\n");
-            doc_text.push_str(&plan.literal_doc_bullets.join("\n"));
-        }
-        if !plan.provided_doc_bullets.is_empty() {
-            if !doc_text.is_empty() {
-                doc_text.push_str("\n\n");
-            }
-            doc_text.push_str(&plan.provided_doc_bullets.join("\n"));
-        }
-        let doc_attr = if doc_text.is_empty() {
-            quote! {}
+    for required_pass in &required_passes {
+        // A pass that covers every merged-optional field doesn't need
+        // a `builder_<suffix>` companion — going through it would
+        // immediately call `.build()` since there are no fluent
+        // setters left to chain. Inline the construction into `new_*`
+        // and skip the builder variant for that pass.
+        //
+        // For plain interfaces (single pass over the merged required
+        // set) this collapses to the existing `!emit_builder` rule:
+        // when no merged optional exists at all, `pass_covers_optionals`
+        // is trivially true and we fall through the inlined-body path.
+        let pass_covers_optionals = optional_getters
+            .iter()
+            .all(|opt| required_pass.iter().any(|req| req.js_name == opt.js_name));
+        let pass_emit_builder = emit_builder && !pass_covers_optionals;
+
+        let field_dims = build_field_dims(required_pass);
+
+        // Cartesian product across field dimensions → list of combos
+        // (each is a Vec<&FieldOption>).
+        let combos: Vec<Vec<&FieldOption>> = if field_dims.is_empty() {
+            vec![vec![]]
         } else {
-            super::doc_tokens(&Some(doc_text))
+            let mut acc: Vec<Vec<&FieldOption>> = vec![vec![]];
+            for dim in &field_dims {
+                acc = acc
+                    .into_iter()
+                    .flat_map(|prefix| {
+                        dim.options.iter().map(move |opt| {
+                            let mut next = prefix.clone();
+                            next.push(opt);
+                            next
+                        })
+                    })
+                    .collect();
+            }
+            acc
         };
 
-        if emit_builder {
-            // `builder*` returns the wrapper struct so callers can chain
-            // setters; `new*` is just `Self::builder(reqs).build()`.
-            //
-            // No-required case has zero `init_calls`, so we inline the
-            // factory directly into the struct literal where the field type
-            // pins inference. The required-args case keeps a `let inner:
-            // Self` so setter calls type-resolve before construction.
-            let builder_body = if init_calls.is_empty() {
-                quote! {
-                    #builder_name {
-                        inner: JsCast::unchecked_into(js_sys::Object::new()),
+        let mut plans: Vec<ComboPlan> = Vec::with_capacity(combos.len());
+        for combo in &combos {
+            let mut literal_suffix = String::new();
+            let mut value_params: Vec<ConcreteParam> = Vec::new();
+            let mut init_calls: Vec<TokenStream> = Vec::new();
+            let mut arg_idents: Vec<syn::Ident> = Vec::new();
+            let mut literal_doc_bullets: Vec<String> = Vec::new();
+            let mut provided_doc_bullets: Vec<String> = Vec::new();
+            for opt in combo {
+                match opt {
+                    FieldOption::Literal {
+                        field_js_name,
+                        field_doc,
+                        literal_display,
+                        suffix,
+                        setter_ident,
+                        literal_expr,
+                    } => {
+                        literal_suffix.push_str(suffix);
+                        init_calls.push(quote! { inner.#setter_ident(#literal_expr); });
+                        let bullet_head = format!("`{field_js_name}: {literal_display}`");
+                        literal_doc_bullets.push(match field_doc {
+                            Some(doc) => format!("* {bullet_head} - {}", doc.trim()),
+                            None => format!("* {bullet_head}"),
+                        });
+                    }
+                    FieldOption::Value {
+                        field_doc,
+                        param,
+                        setter_ident,
+                    } => {
+                        let arg_ident = super::typemap::make_ident(&param.name);
+                        arg_idents.push(arg_ident.clone());
+                        init_calls.push(quote! { inner.#setter_ident(#arg_ident); });
+                        value_params.push(param.clone());
+                        if let Some(doc) = field_doc {
+                            let bullet_head = format!("`{}`", param.name);
+                            provided_doc_bullets.push(format!("* {bullet_head} - {}", doc.trim()));
+                        }
                     }
                 }
+            }
+            plans.push(ComboPlan {
+                literal_suffix,
+                value_params,
+                init_calls,
+                arg_idents,
+                literal_doc_bullets,
+                provided_doc_bullets,
+            });
+        }
+
+        // Compute `_with_X[_and_Y]` suffixes ONLY across combos sharing
+        // the same literal prefix within this pass. Combos with
+        // distinct literal prefixes are already disambiguated by the
+        // prefix; combos in different passes can collide on prefix but
+        // are deduped via `emitted_names` below.
+        let mut value_suffixes: Vec<String> = vec![String::new(); plans.len()];
+        let mut by_prefix: HashMap<String, Vec<usize>> = HashMap::new();
+        for (i, p) in plans.iter().enumerate() {
+            by_prefix
+                .entry(p.literal_suffix.clone())
+                .or_default()
+                .push(i);
+        }
+        for indices in by_prefix.values() {
+            let group_params: Vec<Vec<ConcreteParam>> = indices
+                .iter()
+                .map(|&i| plans[i].value_params.clone())
+                .collect();
+            let group_suffixes = crate::codegen::signatures::compute_suffixes_pub(&group_params);
+            for (suffix, &i) in group_suffixes.iter().zip(indices) {
+                value_suffixes[i] = suffix.clone();
+            }
+        }
+
+        for (plan, value_suffix) in plans.iter().zip(&value_suffixes) {
+            let full_suffix = format!("{}{}", plan.literal_suffix, value_suffix);
+            // Dedup combos that produce the same final name (e.g. when
+            // a discriminator collapse plus a value collapse converge,
+            // or when two passes happen to compute the same combo).
+            if !emitted_names.insert(full_suffix.clone()) {
+                continue;
+            }
+            let new_ident = super::typemap::make_ident(&format!("new{full_suffix}"));
+            let (generics, params_tokens) = generate_dictionary_params(
+                &plan.value_params,
+                config.cgctx,
+                config.scope,
+                &config.from_module(),
+            );
+            let init_calls = &plan.init_calls;
+            let arg_idents = &plan.arg_idents;
+
+            // Compose the doc block. `# Inlined fields` lists the
+            // literal discriminants baked into the function name (no
+            // parameter on the call). `# Parameters` lists the
+            // caller-supplied fields that show up in the actual
+            // signature. Either section is skipped when its bullet
+            // list is empty.
+            let mut doc_text = String::new();
+            if !plan.literal_doc_bullets.is_empty() {
+                doc_text.push_str("## Inlined fields\n\n");
+                doc_text.push_str(&plan.literal_doc_bullets.join("\n"));
+            }
+            if !plan.provided_doc_bullets.is_empty() {
+                if !doc_text.is_empty() {
+                    doc_text.push_str("\n\n");
+                }
+                doc_text.push_str(&plan.provided_doc_bullets.join("\n"));
+            }
+            let doc_attr = if doc_text.is_empty() {
+                quote! {}
             } else {
-                quote! {
-                    let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-                    #(#init_calls)*
-                    #builder_name { inner }
-                }
+                super::doc_tokens(&Some(doc_text))
             };
-            let builder_ident = super::typemap::make_ident(&format!("builder{full_suffix}"));
-            builder_variants.push(quote! {
-                #doc_attr
-                pub fn #builder_ident #generics (#params_tokens) -> #builder_name {
-                    #builder_body
-                }
-            });
-            new_variants.push(quote! {
-                #doc_attr
-                pub fn #new_ident #generics (#params_tokens) -> #rust_type {
-                    Self::#builder_ident(#(#arg_idents),*).build()
-                }
-            });
-        } else {
-            // All-required dictionary: no builder to delegate to, so
-            // construction is inlined directly into `new*`. Returns
-            // `Self` rather than the wrapper struct.
-            let body = if init_calls.is_empty() {
-                quote! {
-                    JsCast::unchecked_into(js_sys::Object::new())
-                }
+
+            if pass_emit_builder {
+                // `builder*` returns the wrapper struct so callers can
+                // chain setters; `new*` is just
+                // `Self::builder(reqs).build()`.
+                //
+                // No-required case has zero `init_calls`, so we inline
+                // the factory directly into the struct literal where
+                // the field type pins inference. The required-args
+                // case keeps a `let inner: Self` so setter calls
+                // type-resolve before construction.
+                let builder_body = if init_calls.is_empty() {
+                    quote! {
+                        #builder_name {
+                            inner: JsCast::unchecked_into(js_sys::Object::new()),
+                        }
+                    }
+                } else {
+                    quote! {
+                        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+                        #(#init_calls)*
+                        #builder_name { inner }
+                    }
+                };
+                let builder_ident = super::typemap::make_ident(&format!("builder{full_suffix}"));
+                builder_variants.push(quote! {
+                    #doc_attr
+                    pub fn #builder_ident #generics (#params_tokens) -> #builder_name {
+                        #builder_body
+                    }
+                });
+                new_variants.push(quote! {
+                    #doc_attr
+                    pub fn #new_ident #generics (#params_tokens) -> #rust_type {
+                        Self::#builder_ident(#(#arg_idents),*).build()
+                    }
+                });
             } else {
-                quote! {
-                    let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-                    #(#init_calls)*
-                    inner
-                }
-            };
-            new_variants.push(quote! {
-                #doc_attr
-                pub fn #new_ident #generics (#params_tokens) -> #rust_type {
-                    #body
-                }
-            });
+                // No useful builder for this pass: either the type has
+                // no optional fields at all (plain dictionary,
+                // `!emit_builder`) or this branch's required set
+                // already covers every merged-optional field
+                // (`pass_covers_optionals`). Inline the construction
+                // into `new_*` and skip the redundant `builder_*`.
+                let body = if init_calls.is_empty() {
+                    quote! {
+                        JsCast::unchecked_into(js_sys::Object::new())
+                    }
+                } else {
+                    quote! {
+                        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+                        #(#init_calls)*
+                        inner
+                    }
+                };
+                new_variants.push(quote! {
+                    #doc_attr
+                    pub fn #new_ident #generics (#params_tokens) -> #rust_type {
+                        #body
+                    }
+                });
+            }
         }
     }
 
@@ -774,7 +879,7 @@ fn generate_dictionary_factory(config: &ClassConfig) -> TokenStream {
 ///
 /// Each name — including `try_` variants — is assigned via `dedupe_name`, which
 /// guarantees uniqueness by appending numeric suffixes on collision.
-fn generate_extern_block(config: &ClassConfig) -> TokenStream {
+pub(crate) fn generate_extern_block(config: &ClassConfig) -> TokenStream {
     use crate::ir::{ConstructorMember, MethodMember, Param, StaticMethodMember};
     use std::collections::HashMap;
 

--- a/src/codegen/discriminated_unions.rs
+++ b/src/codegen/discriminated_unions.rs
@@ -1,0 +1,92 @@
+//! Codegen for [`crate::ir::DiscriminatedUnionDecl`].
+//!
+//! A discriminated union is rendered very similarly to a dictionary
+//! interface: a single `pub type Foo;` with getter/setter bindings for
+//! every property in the merged shape, plus an `impl Foo` block of
+//! `new_*` / `builder_*` factories and a `FooBuilder` wrapper carrying
+//! the merged-optional fluent setters.
+//!
+//! The only material difference from the regular dictionary path is the
+//! per-branch required-field set used to drive the factory variants.
+//! For the merged-shape `Interface` path, a single pass over
+//! `optional == false` getters drives all `new_*` variants. For a
+//! discriminated union, each branch contributes its own required-field
+//! pass, so an `EmailAttachment` whose `inline` branch requires
+//! `contentId` and `attachment` branch makes it optional emits
+//!
+//! ```rust,ignore
+//! impl EmailAttachment {
+//!     pub fn new_inline(content_id: &str, filename: &str, type_: &str, content: &str) -> Self;
+//!     pub fn new_attachment(filename: &str, type_: &str, content: &str) -> Self;
+//!     // ...plus the `_with_<type>` value-union variants on each branch.
+//! }
+//! ```
+//!
+//! The wrapper `EmailAttachmentBuilder` still exposes a fluent
+//! `content_id(self, val)` setter — matching the merged-shape view that
+//! the field is optional on the type as a whole — so callers who go
+//! through `builder_attachment(...).content_id(x).build()` aren't
+//! prevented from setting it. The branch invariant is enforced at the
+//! `new_<discriminator>` boundary, not inside the builder.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::ir::{DiscriminatedUnionDecl, GetterMember, Member, ModuleContext};
+use crate::parse::scope::ScopeId;
+
+use super::classes::{generate_dictionary_factory_with_passes, generate_extern_block, ClassConfig};
+use super::typemap::CodegenContext;
+
+/// Generate the full `extern` block + factory impls for a
+/// [`DiscriminatedUnionDecl`].
+pub fn generate_discriminated_union(
+    decl: &DiscriminatedUnionDecl,
+    ctx: &ModuleContext,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> TokenStream {
+    let config = ClassConfig::from_discriminated_union(decl, ctx, cgctx, scope);
+    let extern_block = generate_extern_block(&config);
+
+    // For each branch, derive its required-getter list. A property
+    // qualifies as required for that branch when:
+    //
+    // * It's present (some branches may omit a property entirely).
+    // * It's non-optional (no `?:` marker) in that branch.
+    //
+    // We pass the **branch's own getter** rather than the merged-shape
+    // getter so the factory pipeline sees the branch-specific type.
+    // For example `EmailAttachment.contentId` is `string` in the
+    // `inline` branch but `Nullable<String>` in the merged shape; using
+    // the branch getter ensures `new_inline(content_id: &str, ...)`
+    // takes the narrower type rather than `Option<&str>`.
+    //
+    // Branch types are typically narrower than merged setter types
+    // (the merged type is a LUB across branches). The factory layer
+    // handles this by structurally matching the branch type against
+    // the merged setter overloads via `pick_setter`; the wrapper-level
+    // `.into()` calls inserted in the generated body bridge any
+    // remaining gap when the branch type doesn't equal but does
+    // convert to the setter param type.
+    let required_passes: Vec<Vec<&GetterMember>> = decl
+        .branches
+        .iter()
+        .map(|branch| {
+            branch
+                .iter()
+                .filter_map(|m| match m {
+                    Member::Getter(g) if !g.optional => Some(g),
+                    _ => None,
+                })
+                .collect()
+        })
+        .collect();
+
+    let factory = generate_dictionary_factory_with_passes(&config, Some(required_passes));
+
+    quote! {
+        #extern_block
+        #factory
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4,6 +4,7 @@
 //! and produces formatted Rust source code as a string.
 
 pub mod classes;
+pub mod discriminated_unions;
 pub mod enums;
 pub mod functions;
 pub mod signatures;
@@ -269,6 +270,14 @@ fn generate_declaration(decl: &TypeDeclaration, cgctx: &CodegenContext) -> Optio
                 decl.scope_id,
             )),
         },
+        TypeKind::DiscriminatedUnion(d) => {
+            Some(discriminated_unions::generate_discriminated_union(
+                d,
+                &decl.module_context,
+                Some(cgctx),
+                decl.scope_id,
+            ))
+        }
         TypeKind::StringEnum(e) => Some(enums::generate_string_enum(e)),
         TypeKind::NumericEnum(e) => Some(enums::generate_numeric_enum(e)),
         TypeKind::Function(f) => Some(functions::generate_function(
@@ -425,6 +434,18 @@ fn generate_ns_declaration(
                 decl.scope_id,
             )),
         },
+        TypeKind::DiscriminatedUnion(d) => {
+            // Discriminated unions don't currently support `js_namespace`
+            // (no observed cases in the wild). Emit without the namespace
+            // attribute — if a real case shows up we can thread it
+            // through `ClassConfig::js_namespace` like the others.
+            Some(discriminated_unions::generate_discriminated_union(
+                d,
+                &decl.module_context,
+                Some(cgctx),
+                decl.scope_id,
+            ))
+        }
         TypeKind::Function(f) => Some(functions::generate_function_with_js_namespace(
             f,
             &decl.module_context,

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -319,6 +319,10 @@ impl<'a> CodegenContext<'a> {
                 self.local_types.insert(i.name.clone(), mctx.clone());
                 self.local_type_ids.insert(type_id);
             }
+            ir::TypeKind::DiscriminatedUnion(d) => {
+                self.local_types.insert(d.name.clone(), mctx.clone());
+                self.local_type_ids.insert(type_id);
+            }
             ir::TypeKind::StringEnum(e) => {
                 self.local_types.insert(e.name.clone(), mctx.clone());
                 self.local_type_ids.insert(type_id);
@@ -355,6 +359,9 @@ impl<'a> CodegenContext<'a> {
             }
             ir::TypeKind::Interface(i) => {
                 self.local_types.insert(i.name.clone(), mctx.clone());
+            }
+            ir::TypeKind::DiscriminatedUnion(d) => {
+                self.local_types.insert(d.name.clone(), mctx.clone());
             }
             ir::TypeKind::StringEnum(e) => {
                 self.local_types.insert(e.name.clone(), mctx.clone());

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -339,6 +339,9 @@ pub struct TypeDeclaration {
 pub enum TypeKind {
     Class(ClassDecl),
     Interface(InterfaceDecl),
+    /// A `type X = A | B | ...` whose branches share a string-literal
+    /// discriminant property — see [`DiscriminatedUnionDecl`].
+    DiscriminatedUnion(DiscriminatedUnionDecl),
     TypeAlias(TypeAliasDecl),
     StringEnum(StringEnumDecl),
     NumericEnum(NumericEnumDecl),
@@ -388,6 +391,46 @@ pub enum InterfaceClassification {
     Dictionary,
     /// Mixed or unclear — treat as class-like.
     Unclassified,
+}
+
+// ─── Discriminated Union ─────────────────────────────────────────────
+
+/// A type alias `type Foo = A | B | ...` whose branches share at least
+/// one **required** property typed as a string literal — that property
+/// is the discriminator.
+///
+/// Modeled as its own kind (separate from `Interface`) because a
+/// faithful binding must respect per-branch shape rather than the
+/// merged-shape required-vs-optional split. For example
+///
+/// ```ts
+/// type EmailAttachment =
+///   | { disposition: "inline";     contentId: string;     filename: string; ... }
+///   | { disposition: "attachment"; contentId?: undefined; filename: string; ... };
+/// ```
+///
+/// requires `contentId` in the `inline` branch but not in `attachment`.
+/// Treating the merge as a flat interface erases that distinction —
+/// codegen would mark `contentId` optional everywhere, then `new_inline`
+/// wouldn't take it as a parameter even though the source contract
+/// requires it.
+#[derive(Clone, Debug)]
+
+pub struct DiscriminatedUnionDecl {
+    pub name: String,
+    pub js_name: String,
+    pub type_params: Vec<TypeParam>,
+    /// Pre-merge per-branch member sets. Order matches source order;
+    /// every branch contributes a (possibly empty) set of members.
+    pub branches: Vec<Vec<Member>>,
+    /// Merged member view — useful for the regular extern-block
+    /// emission (one `pub type Foo;` plus a getter/setter per property
+    /// across all branches). The branch-specific factories use
+    /// [`branches`] instead.
+    pub members: Vec<Member>,
+    /// JS names of properties that act as discriminators — present and
+    /// required in every branch with a string-literal type.
+    pub discriminators: Vec<String>,
 }
 
 // ─── Type Alias ──────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,17 @@ fn print_declaration(decl: &ts_gen::ir::TypeDeclaration, indent: usize) {
                 print_member(member, indent + 1);
             }
         }
+        ts_gen::ir::TypeKind::DiscriminatedUnion(d) => {
+            eprintln!(
+                "{prefix}[{ctx}] discriminated_union {} ({} branches, discriminators: {:?})",
+                d.name,
+                d.branches.len(),
+                d.discriminators,
+            );
+            for member in &d.members {
+                print_member(member, indent + 1);
+            }
+        }
         ts_gen::ir::TypeKind::TypeAlias(t) => {
             eprintln!("{prefix}[{ctx}] type {} = {:?}", t.name, t.target);
         }

--- a/src/parse/first_pass/populate.rs
+++ b/src/parse/first_pass/populate.rs
@@ -425,11 +425,13 @@ impl<'a> PopulateCtx<'a> {
         }
 
         // `type Foo = { ... }` / `type Foo = { ... } | { ... }` are
-        // structurally interfaces — promote them so consumers get the
-        // dictionary-builder treatment instead of an opaque type alias to
-        // `Object`. The alias's own name becomes the synthesized type.
-        if let Some(iface) = self.try_synthesize_alias_interface(&name, &alias.type_annotation) {
-            declarations.push(dcx.decl(ir::TypeKind::Interface(iface), doc));
+        // structurally interfaces (or discriminated unions, if the
+        // branches share a string-literal discriminator) — promote them
+        // so consumers get the dictionary-builder / variant-factory
+        // treatment instead of an opaque type alias to `Object`. The
+        // alias's own name becomes the synthesized type.
+        if let Some(kind) = self.try_synthesize_alias_decl(&name, &alias.type_annotation) {
+            declarations.push(dcx.decl(kind, doc));
             return;
         }
 
@@ -447,14 +449,20 @@ impl<'a> PopulateCtx<'a> {
     }
 
     /// Promote `type Foo = { ... }` or `type Foo = { ... } | { ... }`
-    /// into a named `InterfaceDecl`, going through the same merge rules
-    /// as anonymous-parameter union synthesis. Returns `None` if the
-    /// target shape doesn't match either form.
-    fn try_synthesize_alias_interface(
+    /// into either a named `InterfaceDecl` or a `DiscriminatedUnionDecl`,
+    /// going through the same merge rules as anonymous-parameter union
+    /// synthesis. Returns `None` if the target shape matches neither
+    /// form.
+    ///
+    /// Discriminated-union promotion happens when every branch is a
+    /// type literal AND there's a shared required string-literal-typed
+    /// property — see [`literal_union::detect_discriminators`].
+    /// Otherwise the merge produces a plain `InterfaceDecl` as before.
+    fn try_synthesize_alias_decl(
         &mut self,
         alias_name: &str,
         target: &ast::TSType<'_>,
-    ) -> Option<ir::InterfaceDecl> {
+    ) -> Option<ir::TypeKind> {
         match target {
             ast::TSType::TSTypeLiteral(literal) => {
                 let mut synth: Vec<ir::InterfaceDecl> = Vec::new();
@@ -482,7 +490,7 @@ impl<'a> PopulateCtx<'a> {
                     // doesn't carry methods that hoist.
                     let _ = inner;
                 }
-                Some(iface)
+                Some(ir::TypeKind::Interface(iface))
             }
             ast::TSType::TSUnionType(union)
                 if union
@@ -514,16 +522,34 @@ impl<'a> PopulateCtx<'a> {
                     })
                     .collect();
                 let merged = crate::parse::literal_union::merge_member_branches(&branches);
-                let classification = crate::parse::classify::classify_interface(&merged);
                 self.used_type_names.insert(alias_name.to_string());
-                Some(ir::InterfaceDecl {
-                    name: alias_name.to_string(),
-                    js_name: alias_name.to_string(),
-                    type_params: Vec::new(),
-                    extends: Vec::new(),
-                    members: merged,
-                    classification,
-                })
+
+                // Promote to a discriminated union when the branches
+                // share a string-literal discriminator. Otherwise fall
+                // back to the plain merged interface.
+                let discriminators = crate::parse::literal_union::detect_discriminators(&branches);
+                if !discriminators.is_empty() {
+                    Some(ir::TypeKind::DiscriminatedUnion(
+                        ir::DiscriminatedUnionDecl {
+                            name: alias_name.to_string(),
+                            js_name: alias_name.to_string(),
+                            type_params: Vec::new(),
+                            branches,
+                            members: merged,
+                            discriminators,
+                        },
+                    ))
+                } else {
+                    let classification = crate::parse::classify::classify_interface(&merged);
+                    Some(ir::TypeKind::Interface(ir::InterfaceDecl {
+                        name: alias_name.to_string(),
+                        js_name: alias_name.to_string(),
+                        type_params: Vec::new(),
+                        extends: Vec::new(),
+                        members: merged,
+                        classification,
+                    }))
+                }
             }
             _ => None,
         }

--- a/src/parse/literal_union.rs
+++ b/src/parse/literal_union.rs
@@ -130,11 +130,20 @@ pub(crate) fn merge_member_branches(branches: &[Vec<Member>]) -> Vec<Member> {
 
     let mut out = Vec::new();
 
-    // Getters: optional if missing in any branch or optional in any branch.
-    for (name, slots) in &getters {
+    // Walk properties in source order, emitting each property's getter
+    // and (when applicable) setter together. The non-merged interface
+    // path already produces getter-then-setter per property, so this
+    // keeps the literal-union output consistent with the rest of the
+    // pipeline rather than emitting all getters then all setters.
+    //
+    // Drives off the getter ordering since every writable property has
+    // a matching getter in the merged shape; setter-only properties
+    // (extremely rare in TS) are picked up in a tail loop below.
+    let getter_emitted = |name: &str| -> Option<Member> {
+        let slots = getters.get(name)?;
         let present: Vec<&GetterMember> = slots.iter().filter_map(|s| *s).collect();
         if present.is_empty() {
-            continue;
+            return None;
         }
         let absent_in_any = slots.iter().any(|s| s.is_none());
         let optional_in_any = present.iter().any(|g| g.optional);
@@ -143,41 +152,59 @@ pub(crate) fn merge_member_branches(branches: &[Vec<Member>]) -> Vec<Member> {
         let type_ref = union_member_types(present.iter().map(|g| g.type_ref.clone()));
         let doc = present.iter().find_map(|g| g.doc.clone());
 
-        out.push(Member::Getter(GetterMember {
-            js_name: name.clone(),
+        Some(Member::Getter(GetterMember {
+            js_name: name.to_string(),
             type_ref,
             optional,
             doc,
-        }));
-    }
+        }))
+    };
 
-    // Setters: emit only when at least one branch had a setter for this
-    // name — a `readonly` branch suppresses the setter merge-wide.
-    for (name, slots) in &setters {
+    // Emit a setter when one exists and isn't suppressed by a `readonly`
+    // branch. A getter-without-setter in any branch downgrades the
+    // merged property to read-only, since writing through the merged
+    // setter would be invalid for the readonly branch.
+    let setter_emitted = |name: &str| -> Option<Member> {
+        let slots = setters.get(name)?;
         let present: Vec<&SetterMember> = slots.iter().filter_map(|s| *s).collect();
         if present.is_empty() {
-            continue;
+            return None;
         }
-        // If a branch had a getter for this name but no setter, treat the
-        // merged property as readonly (drop the setter). This keeps
-        // soundness — writing through the merged setter would be invalid
-        // for the readonly branch.
         if let Some(getter_slots) = getters.get(name) {
             let any_branch_readonly = getter_slots
                 .iter()
                 .zip(slots.iter())
                 .any(|(g, s)| g.is_some() && s.is_none());
             if any_branch_readonly {
-                continue;
+                return None;
             }
         }
         let type_ref = union_member_types(present.iter().map(|s| s.type_ref.clone()));
         let doc = present.iter().find_map(|s| s.doc.clone());
-        out.push(Member::Setter(SetterMember {
-            js_name: name.clone(),
+        Some(Member::Setter(SetterMember {
+            js_name: name.to_string(),
             type_ref,
             doc,
-        }));
+        }))
+    };
+
+    for name in getters.keys() {
+        if let Some(g) = getter_emitted(name) {
+            out.push(g);
+        }
+        if let Some(s) = setter_emitted(name) {
+            out.push(s);
+        }
+    }
+    // Setter-only properties (no matching getter in any branch). The
+    // earlier loop didn't visit these since it keys off getter names.
+    for name in setters.keys() {
+        if getters.contains_key(name) {
+            continue;
+        }
+        if let Some(s) = setter_emitted(name) {
+            out.push(s);
+        }
     }
 
     // Methods: keep every signature. The flattening pipeline downstream
@@ -227,4 +254,68 @@ fn union_member_types(types: impl IntoIterator<Item = TypeRef>) -> TypeRef {
         return all.into_iter().next().unwrap();
     }
     crate::parse::types::simplify_union(all)
+}
+
+/// Identify discriminator properties across a set of branches.
+///
+/// A property qualifies as a discriminator when:
+///
+/// * It appears as a **required** (non-optional) getter in **every**
+///   branch.
+/// * Its type in every branch is a string, number, or boolean literal.
+///
+/// TypeScript narrows on all three literal kinds (e.g. `disposition:
+/// "inline"`, `done: false`, `status: 200`), so the codegen rule
+/// matches.
+///
+/// Returns the JS names of qualifying properties in source order
+/// (first-appearance across branches).
+pub(crate) fn detect_discriminators(branches: &[Vec<Member>]) -> Vec<String> {
+    if branches.len() < 2 {
+        return Vec::new();
+    }
+    // Collect every property name with its per-branch (optional?, type)
+    // pair, in first-appearance order.
+    let mut order: Vec<String> = Vec::new();
+    let mut per_branch: indexmap::IndexMap<String, Vec<Option<&GetterMember>>> =
+        indexmap::IndexMap::new();
+    for branch in branches {
+        for m in branch {
+            if let Member::Getter(g) = m {
+                if !per_branch.contains_key(&g.js_name) {
+                    order.push(g.js_name.clone());
+                }
+                per_branch.entry(g.js_name.clone()).or_default();
+            }
+        }
+    }
+    for branch in branches {
+        for slot_name in per_branch.keys().cloned().collect::<Vec<_>>() {
+            let found = branch.iter().find_map(|m| match m {
+                Member::Getter(g) if g.js_name == slot_name => Some(g),
+                _ => None,
+            });
+            per_branch.get_mut(&slot_name).unwrap().push(found);
+        }
+    }
+
+    order
+        .into_iter()
+        .filter(|name| {
+            let slots = &per_branch[name];
+            // Must be present, required, and literal-typed in every
+            // branch.
+            slots.iter().all(|slot| {
+                slot.is_some_and(|g| {
+                    !g.optional
+                        && matches!(
+                            g.type_ref,
+                            TypeRef::StringLiteral(_)
+                                | TypeRef::NumberLiteral(_)
+                                | TypeRef::BooleanLiteral(_)
+                        )
+                })
+            })
+        })
+        .collect()
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -502,6 +502,7 @@ fn declaration_name(kind: &crate::ir::TypeKind) -> Option<String> {
     match kind {
         TypeKind::Class(c) => Some(c.name.clone()),
         TypeKind::Interface(i) => Some(i.name.clone()),
+        TypeKind::DiscriminatedUnion(d) => Some(d.name.clone()),
         TypeKind::TypeAlias(a) => Some(a.name.clone()),
         TypeKind::StringEnum(e) => Some(e.name.clone()),
         TypeKind::NumericEnum(e) => Some(e.name.clone()),

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -7838,18 +7838,18 @@ extern "C" {
     pub type KVNamespaceListResult;
     #[wasm_bindgen(method, getter)]
     pub fn list_complete(this: &KVNamespaceListResult) -> bool;
-    #[wasm_bindgen(method, getter)]
-    pub fn keys(this: &KVNamespaceListResult) -> Array<KVNamespaceListKey>;
-    #[wasm_bindgen(method, getter)]
-    pub fn cursor(this: &KVNamespaceListResult) -> Option<String>;
-    #[wasm_bindgen(method, getter, js_name = "cacheStatus")]
-    pub fn cache_status(this: &KVNamespaceListResult) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_list_complete(this: &KVNamespaceListResult, val: bool);
+    #[wasm_bindgen(method, getter)]
+    pub fn keys(this: &KVNamespaceListResult) -> Array<KVNamespaceListKey>;
     #[wasm_bindgen(method, setter)]
     pub fn set_keys(this: &KVNamespaceListResult, val: &Array<KVNamespaceListKey>);
+    #[wasm_bindgen(method, getter)]
+    pub fn cursor(this: &KVNamespaceListResult) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_cursor(this: &KVNamespaceListResult, val: &str);
+    #[wasm_bindgen(method, getter, js_name = "cacheStatus")]
+    pub fn cache_status(this: &KVNamespaceListResult) -> Option<String>;
     #[wasm_bindgen(method, setter, js_name = "cacheStatus")]
     pub fn set_cache_status(this: &KVNamespaceListResult, val: &str);
 }
@@ -7859,9 +7859,15 @@ impl KVNamespaceListResult {
     #[doc = " * `list_complete: false`"]
     pub fn new_false(
         keys: &Array<KVNamespaceListKey>,
+        cursor: &str,
         cache_status: Option<&str>,
     ) -> KVNamespaceListResult {
-        Self::builder_false(keys, cache_status).build()
+        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_list_complete(false);
+        inner.set_keys(keys);
+        inner.set_cursor(cursor);
+        inner.set_cache_status(cache_status);
+        inner
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -7871,19 +7877,6 @@ impl KVNamespaceListResult {
         cache_status: Option<&str>,
     ) -> KVNamespaceListResult {
         Self::builder_true(keys, cache_status).build()
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `list_complete: false`"]
-    pub fn builder_false(
-        keys: &Array<KVNamespaceListKey>,
-        cache_status: Option<&str>,
-    ) -> KVNamespaceListResultBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_list_complete(false);
-        inner.set_keys(keys);
-        inner.set_cache_status(cache_status);
-        KVNamespaceListResultBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -8884,14 +8877,14 @@ extern "C" {
     pub type R2Range;
     #[wasm_bindgen(method, getter)]
     pub fn offset(this: &R2Range) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn length(this: &R2Range) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn suffix(this: &R2Range) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_offset(this: &R2Range, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn length(this: &R2Range) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_length(this: &R2Range, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn suffix(this: &R2Range) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_suffix(this: &R2Range, val: f64);
 }
@@ -10041,10 +10034,10 @@ extern "C" {
     pub type ReadableStreamReadResult;
     #[wasm_bindgen(method, getter)]
     pub fn done(this: &ReadableStreamReadResult) -> bool;
-    #[wasm_bindgen(method, getter)]
-    pub fn value(this: &ReadableStreamReadResult) -> Option<R>;
     #[wasm_bindgen(method, setter)]
     pub fn set_done(this: &ReadableStreamReadResult, val: bool);
+    #[wasm_bindgen(method, getter)]
+    pub fn value(this: &ReadableStreamReadResult) -> Option<R>;
     #[wasm_bindgen(method, setter)]
     pub fn set_value(this: &ReadableStreamReadResult, val: &R);
 }
@@ -10052,22 +10045,17 @@ impl ReadableStreamReadResult {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `done: false`"]
-    pub fn new_false() -> ReadableStreamReadResult {
-        Self::builder_false().build()
+    pub fn new_false(value: &R) -> ReadableStreamReadResult {
+        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_done(false);
+        inner.set_value(value);
+        inner
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `done: true`"]
     pub fn new_true() -> ReadableStreamReadResult {
         Self::builder_true().build()
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `done: false`"]
-    pub fn builder_false() -> ReadableStreamReadResultBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_done(false);
-        ReadableStreamReadResultBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -18475,18 +18463,18 @@ extern "C" {
     #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> JsValue;
-    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
-    #[wasm_bindgen(method, getter)]
-    pub fn pooling(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<String>;
-    #[doc = " Batch of the embeddings requests to run using async-queue"]
-    #[wasm_bindgen(method, getter)]
-    pub fn requests(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "text")]
     pub fn set_text_with_array(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input, val: &Array<JsString>);
+    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
+    #[wasm_bindgen(method, getter)]
+    pub fn pooling(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input, val: &str);
+    #[doc = " Batch of the embeddings requests to run using async-queue"]
+    #[wasm_bindgen(method, getter)]
+    pub fn requests(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_requests(this: &Ai_Cf_Baai_Bge_Base_En_V1_5_Input, val: &Array<Object>);
 }
@@ -18665,21 +18653,21 @@ extern "C" {
     #[doc = " The text to be translated"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Meta_M2M100_1_2B_Input) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_text(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
     #[doc = " The language code of the source text (e.g., 'en' for English). Defaults to 'en' if not specified"]
     #[wasm_bindgen(method, getter)]
     pub fn source_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_source_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
     #[doc = " The language code to translate the text into (e.g., 'es' for Spanish)"]
     #[wasm_bindgen(method, getter)]
     pub fn target_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input) -> Option<String>;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_target_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
     #[doc = " Batch of the embeddings requests to run using async-queue"]
     #[wasm_bindgen(method, getter)]
     pub fn requests(this: &Ai_Cf_Meta_M2M100_1_2B_Input) -> Option<Array<Object>>;
-    #[wasm_bindgen(method, setter)]
-    pub fn set_text(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
-    #[wasm_bindgen(method, setter)]
-    pub fn set_source_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
-    #[wasm_bindgen(method, setter)]
-    pub fn set_target_lang(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &str);
     #[wasm_bindgen(method, setter)]
     pub fn set_requests(this: &Ai_Cf_Meta_M2M100_1_2B_Input, val: &Array<Object>);
 }
@@ -18779,18 +18767,18 @@ extern "C" {
     #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> JsValue;
-    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
-    #[wasm_bindgen(method, getter)]
-    pub fn pooling(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<String>;
-    #[doc = " Batch of the embeddings requests to run using async-queue"]
-    #[wasm_bindgen(method, getter)]
-    pub fn requests(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "text")]
     pub fn set_text_with_array(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input, val: &Array<JsString>);
+    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
+    #[wasm_bindgen(method, getter)]
+    pub fn pooling(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input, val: &str);
+    #[doc = " Batch of the embeddings requests to run using async-queue"]
+    #[wasm_bindgen(method, getter)]
+    pub fn requests(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_requests(this: &Ai_Cf_Baai_Bge_Small_En_V1_5_Input, val: &Array<Object>);
 }
@@ -18893,18 +18881,18 @@ extern "C" {
     #[doc = " Returns: string | string[] | undefined"]
     #[wasm_bindgen(method, getter)]
     pub fn text(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> JsValue;
-    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
-    #[wasm_bindgen(method, getter)]
-    pub fn pooling(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<String>;
-    #[doc = " Batch of the embeddings requests to run using async-queue"]
-    #[wasm_bindgen(method, getter)]
-    pub fn requests(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_text(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input, val: &str);
     #[wasm_bindgen(method, setter, js_name = "text")]
     pub fn set_text_with_array(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input, val: &Array<JsString>);
+    #[doc = " The pooling method used in the embedding process. `cls` pooling will generate more accurate embeddings on larger inputs - however, embeddings created with cls pooling are not compatible with embeddings generated with mean pooling. The default pooling method is `mean` in order for this to not be a breaking change, but we highly suggest using the new `cls` pooling for better accuracy."]
+    #[wasm_bindgen(method, getter)]
+    pub fn pooling(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_pooling(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input, val: &str);
+    #[doc = " Batch of the embeddings requests to run using async-queue"]
+    #[wasm_bindgen(method, getter)]
+    pub fn requests(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input) -> Option<Array<Object>>;
     #[wasm_bindgen(method, setter)]
     pub fn set_requests(this: &Ai_Cf_Baai_Bge_Large_En_V1_5_Input, val: &Array<Object>);
 }
@@ -25063,13 +25051,13 @@ extern "C" {
     #[doc = " Returns: object | string"]
     #[wasm_bindgen(method, getter)]
     pub fn audio(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input) -> JsValue;
-    #[doc = " type of data PCM data that's sent to the inference server as raw array"]
-    #[wasm_bindgen(method, getter)]
-    pub fn dtype(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_audio(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input, val: &Object);
     #[wasm_bindgen(method, setter, js_name = "audio")]
     pub fn set_audio_with_str(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input, val: &str);
+    #[doc = " type of data PCM data that's sent to the inference server as raw array"]
+    #[wasm_bindgen(method, getter)]
+    pub fn dtype(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_dtype(this: &Ai_Cf_Pipecat_Ai_Smart_Turn_V2_Input, val: &str);
 }
@@ -41266,23 +41254,23 @@ extern "C" {
     pub type EmailAttachment;
     #[wasm_bindgen(method, getter)]
     pub fn disposition(this: &EmailAttachment) -> String;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_disposition(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, getter, js_name = "contentId")]
     pub fn content_id(this: &EmailAttachment) -> Option<String>;
+    #[wasm_bindgen(method, setter, js_name = "contentId")]
+    pub fn set_content_id(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, getter)]
     pub fn filename(this: &EmailAttachment) -> String;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_filename(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &EmailAttachment) -> String;
+    #[wasm_bindgen(method, setter)]
+    pub fn set_type(this: &EmailAttachment, val: &str);
     #[doc = " Returns: string | ArrayBuffer | ArrayBufferView"]
     #[wasm_bindgen(method, getter)]
     pub fn content(this: &EmailAttachment) -> JsValue;
-    #[wasm_bindgen(method, setter)]
-    pub fn set_disposition(this: &EmailAttachment, val: &str);
-    #[wasm_bindgen(method, setter, js_name = "contentId")]
-    pub fn set_content_id(this: &EmailAttachment, val: &str);
-    #[wasm_bindgen(method, setter)]
-    pub fn set_filename(this: &EmailAttachment, val: &str);
-    #[wasm_bindgen(method, setter)]
-    pub fn set_type(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, setter)]
     pub fn set_content(this: &EmailAttachment, val: &str);
     #[wasm_bindgen(method, setter, js_name = "content")]
@@ -41294,28 +41282,53 @@ impl EmailAttachment {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `disposition: \"inline\"`"]
-    pub fn new_inline(filename: &str, r#type: &str, content: &str) -> EmailAttachment {
-        Self::builder_inline(filename, r#type, content).build()
+    pub fn new_inline(
+        content_id: &str,
+        filename: &str,
+        r#type: &str,
+        content: &str,
+    ) -> EmailAttachment {
+        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_disposition("inline");
+        inner.set_content_id(content_id);
+        inner.set_filename(filename);
+        inner.set_type(r#type);
+        inner.set_content(content);
+        inner
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `disposition: \"inline\"`"]
     pub fn new_inline_with_array_buffer(
+        content_id: &str,
         filename: &str,
         r#type: &str,
         content: &ArrayBuffer,
     ) -> EmailAttachment {
-        Self::builder_inline_with_array_buffer(filename, r#type, content).build()
+        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_disposition("inline");
+        inner.set_content_id(content_id);
+        inner.set_filename(filename);
+        inner.set_type(r#type);
+        inner.set_content_with_array_buffer(content);
+        inner
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `disposition: \"inline\"`"]
     pub fn new_inline_with_typed_array<T: ::js_sys::TypedArray>(
+        content_id: &str,
         filename: &str,
         r#type: &str,
         content: &T,
     ) -> EmailAttachment {
-        Self::builder_inline_with_typed_array(filename, r#type, content).build()
+        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_disposition("inline");
+        inner.set_content_id(content_id);
+        inner.set_filename(filename);
+        inner.set_type(r#type);
+        inner.set_content_with_typed_array(content);
+        inner
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -41342,47 +41355,6 @@ impl EmailAttachment {
         content: &T,
     ) -> EmailAttachment {
         Self::builder_attachment_with_typed_array(filename, r#type, content).build()
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `disposition: \"inline\"`"]
-    pub fn builder_inline(filename: &str, r#type: &str, content: &str) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_disposition("inline");
-        inner.set_filename(filename);
-        inner.set_type(r#type);
-        inner.set_content(content);
-        EmailAttachmentBuilder { inner }
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `disposition: \"inline\"`"]
-    pub fn builder_inline_with_array_buffer(
-        filename: &str,
-        r#type: &str,
-        content: &ArrayBuffer,
-    ) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_disposition("inline");
-        inner.set_filename(filename);
-        inner.set_type(r#type);
-        inner.set_content_with_array_buffer(content);
-        EmailAttachmentBuilder { inner }
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `disposition: \"inline\"`"]
-    pub fn builder_inline_with_typed_array<T: ::js_sys::TypedArray>(
-        filename: &str,
-        r#type: &str,
-        content: &T,
-    ) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_disposition("inline");
-        inner.set_filename(filename);
-        inner.set_type(r#type);
-        inner.set_content_with_typed_array(content);
-        EmailAttachmentBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -41728,18 +41700,18 @@ extern "C" {
     pub type ImageInfoResponse;
     #[wasm_bindgen(method, getter)]
     pub fn format(this: &ImageInfoResponse) -> String;
-    #[wasm_bindgen(method, getter, js_name = "fileSize")]
-    pub fn file_size(this: &ImageInfoResponse) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn width(this: &ImageInfoResponse) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn height(this: &ImageInfoResponse) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_format(this: &ImageInfoResponse, val: &str);
+    #[wasm_bindgen(method, getter, js_name = "fileSize")]
+    pub fn file_size(this: &ImageInfoResponse) -> Option<f64>;
     #[wasm_bindgen(method, setter, js_name = "fileSize")]
     pub fn set_file_size(this: &ImageInfoResponse, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn width(this: &ImageInfoResponse) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_width(this: &ImageInfoResponse, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn height(this: &ImageInfoResponse) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_height(this: &ImageInfoResponse, val: f64);
 }
@@ -46097,30 +46069,30 @@ extern "C" {
     pub type ConversionResponse;
     #[wasm_bindgen(method, getter)]
     pub fn id(this: &ConversionResponse) -> String;
-    #[wasm_bindgen(method, getter)]
-    pub fn name(this: &ConversionResponse) -> String;
-    #[wasm_bindgen(method, getter, js_name = "mimeType")]
-    pub fn mime_type(this: &ConversionResponse) -> String;
-    #[wasm_bindgen(method, getter)]
-    pub fn format(this: &ConversionResponse) -> String;
-    #[wasm_bindgen(method, getter)]
-    pub fn tokens(this: &ConversionResponse) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn data(this: &ConversionResponse) -> Option<String>;
-    #[wasm_bindgen(method, getter)]
-    pub fn error(this: &ConversionResponse) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &ConversionResponse, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn name(this: &ConversionResponse) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_name(this: &ConversionResponse, val: &str);
+    #[wasm_bindgen(method, getter, js_name = "mimeType")]
+    pub fn mime_type(this: &ConversionResponse) -> String;
     #[wasm_bindgen(method, setter, js_name = "mimeType")]
     pub fn set_mime_type(this: &ConversionResponse, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn format(this: &ConversionResponse) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_format(this: &ConversionResponse, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn tokens(this: &ConversionResponse) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
     pub fn set_tokens(this: &ConversionResponse, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn data(this: &ConversionResponse) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_data(this: &ConversionResponse, val: &str);
+    #[wasm_bindgen(method, getter)]
+    pub fn error(this: &ConversionResponse) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_error(this: &ConversionResponse, val: &str);
 }
@@ -46128,35 +46100,55 @@ impl ConversionResponse {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `format: \"markdown\"`"]
-    pub fn new_markdown(id: &str, name: &str, mime_type: &str) -> ConversionResponse {
-        Self::builder_markdown(id, name, mime_type).build()
+    pub fn new_markdown(
+        id: &str,
+        name: &str,
+        mime_type: &str,
+        tokens: f64,
+        data: &str,
+    ) -> ConversionResponse {
+        Self::builder_markdown(id, name, mime_type, tokens, data).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `format: \"error\"`"]
-    pub fn new_error(id: &str, name: &str, mime_type: &str) -> ConversionResponse {
-        Self::builder_error(id, name, mime_type).build()
+    pub fn new_error(id: &str, name: &str, mime_type: &str, error: &str) -> ConversionResponse {
+        Self::builder_error(id, name, mime_type, error).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `format: \"markdown\"`"]
-    pub fn builder_markdown(id: &str, name: &str, mime_type: &str) -> ConversionResponseBuilder {
+    pub fn builder_markdown(
+        id: &str,
+        name: &str,
+        mime_type: &str,
+        tokens: f64,
+        data: &str,
+    ) -> ConversionResponseBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_name(name);
         inner.set_mime_type(mime_type);
         inner.set_format("markdown");
+        inner.set_tokens(tokens);
+        inner.set_data(data);
         ConversionResponseBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `format: \"error\"`"]
-    pub fn builder_error(id: &str, name: &str, mime_type: &str) -> ConversionResponseBuilder {
+    pub fn builder_error(
+        id: &str,
+        name: &str,
+        mime_type: &str,
+        error: &str,
+    ) -> ConversionResponseBuilder {
         let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_name(name);
         inner.set_mime_type(mime_type);
         inner.set_format("error");
+        inner.set_error(error);
         ConversionResponseBuilder { inner }
     }
 }
@@ -47268,14 +47260,14 @@ extern "C" {
     pub type VectorizeIndexConfig;
     #[wasm_bindgen(method, getter)]
     pub fn dimensions(this: &VectorizeIndexConfig) -> Option<f64>;
-    #[wasm_bindgen(method, getter)]
-    pub fn metric(this: &VectorizeIndexConfig) -> Option<VectorizeDistanceMetric>;
-    #[wasm_bindgen(method, getter)]
-    pub fn preset(this: &VectorizeIndexConfig) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_dimensions(this: &VectorizeIndexConfig, val: f64);
+    #[wasm_bindgen(method, getter)]
+    pub fn metric(this: &VectorizeIndexConfig) -> Option<VectorizeDistanceMetric>;
     #[wasm_bindgen(method, setter)]
     pub fn set_metric(this: &VectorizeIndexConfig, val: &VectorizeDistanceMetric);
+    #[wasm_bindgen(method, getter)]
+    pub fn preset(this: &VectorizeIndexConfig) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_preset(this: &VectorizeIndexConfig, val: &str);
 }


### PR DESCRIPTION
A type alias `type Foo = A | B | …` whose branches share a required, literal-typed property now lands in a new `TypeKind::DiscriminatedUnion` rather than merging into a flat `InterfaceDecl`. The discriminator can be a string, number, or boolean literal — the three forms TS narrows on.

The motivation is per-branch required-vs-optional accuracy. With the previous merged-shape model, `EmailAttachment.contentId` (required in the `inline` branch, `?: undefined` in `attachment`) collapsed to merged-optional, so `new_inline(...)` didn't take it as a parameter even though the source contract requires it:

```rs
// before
EmailAttachment::new_inline(filename: &str, type_: &str, content: &str)
// after
EmailAttachment::new_inline(content_id: &str, filename: &str, type_: &str, content: &str)
EmailAttachment::new_attachment(filename: &str, type_: &str, content: &str)
```

The codegen keeps a per-branch view:

* **Extern block** stays merged — one `pub type Foo` plus a getter/setter set per property across all branches. No change for downstream consumers reaching for the bare type.
* **`impl Foo`** emits one `new_<discriminator>` / `builder_<discriminator>` cohort per branch, driven by that branch's required set. Each branch independently goes through the literal-collapse / value-union expansion / `_with_<type>` suffixing rules.
* **Wrapper builder** is still merged — `EmailAttachmentBuilder::content_id(self, val)` is always available so callers going through `builder_attachment(...).content_id(x).build()` aren't blocked. The branch invariant is enforced at the `new_<discriminator>` boundary; once past that, the wrapper exposes the runtime-permissive view of the type.
* **`builder_<branch>` suppression**: when a branch's required set already covers every merged-optional field, the `builder_<branch>` companion would have nothing to chain — so `new_<branch>` is emitted with an inlined body and no builder. For `EmailAttachment`, `inline` covers the only merged-optional (`contentId`) so it gets an inlined body, while `attachment` leaves `contentId` for the wrapper and keeps its `builder_attachment` companion.

Implementation:

* `parse/literal_union.rs::detect_discriminators` — a property qualifies when it's required and string/number/boolean-literal-typed in every branch.
* `parse/first_pass/populate.rs::try_synthesize_alias_decl` — returns `TypeKind` (was `InterfaceDecl`); routes to `DiscriminatedUnion` when discriminators are detected, plain `Interface` otherwise.
* `codegen/classes.rs` — `generate_dictionary_factory` is now a thin wrapper around `generate_dictionary_factory_with_passes`, which takes an optional list of required-field passes. Plain interfaces pass nothing and behave as before; the new module passes one entry per branch. A shared `emitted_names` set deduplicates combos that converge across passes, and the per-pass `pass_covers_optionals` check drives the new `builder_<branch>` suppression.
* `codegen/discriminated_unions.rs` — new module wiring `DiscriminatedUnionDecl` through the shared infra.

Snapshot diffs are limited to discriminated unions and dictionaries that previously landed alphabetical (now source-order, per #21). Plain interfaces are unchanged. `CONVENTIONS.md` gains a `## Discriminated unions` section spelling out the detection rule, the per-branch factory shape, the wrapper-stays-merged invariant, and the `builder_<branch>` suppression rule.