### PR TITLE
Outer-type lowering: TS spelling controls Rust ABI form

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -18,6 +18,7 @@ in sync with the snapshot fixtures (`tests/fixtures/*.d.ts` paired with
 * [Primitive types](#primitive-types)
 * [Optional and nullable types](#optional-and-nullable-types)
 * [Array and slice types](#array-and-slice-types)
+* [Outer-type ABI fan-out](#outer-type-abi-fan-out)
 * [Property accessors](#property-accessors)
 * [Naming conversion](#naming-conversion)
 * [JS-name collisions with `js_sys` glob imports](#js-name-collisions-with-js_sys-glob-imports)
@@ -133,6 +134,55 @@ imported callable that has at least one qualifying parameter gets
 its own `slice_to_array`. Functions whose only slice params are
 numeric (`&[f64]`, `&[i64]`) keep the default typed-array
 representation and do not get the attribute.
+
+## Outer-type ABI fan-out
+
+Some Rust-idiomatic outer-type lowerings imply a copy across the
+Wasm boundary for large data:
+
+* `&str` arguments incur a UTF-8 conversion vs the JS-side
+  `String`/`JsString` representation.
+* `&[T]` arguments with non-numeric `T` materialise a JS `Array`
+  element-by-element via the `slice_to_array` attribute.
+
+Rather than emit dual variants for every callable, ts-gen
+**defers to the TS author** to pick the form. Each ABI choice
+is exposed as a distinct TS spelling:
+
+| TS arg form        | Rust arg-pos       | Rust return-pos | Notes                                  |
+| ------------------ | ------------------ | --------------- | -------------------------------------- |
+| `string`           | `&str`             | `String`        | Idiomatic Rust; UTF-8 copy on boundary |
+| `String`           | `&JsString`        | `JsString`      | Zero-copy JS handle                    |
+| `T[]`              | `&[T]`             | `Vec<T>`        | Idiomatic Rust slice / owned vec       |
+| `Array<T>`         | `&Array<U>`        | `Array<U>`      | Zero-copy JS array handle              |
+| `ReadonlyArray<T>` | `&Array<U>`        | `Array<U>`      | Same as `Array<T>` for FFI purposes    |
+
+Where `U` is the element's inner-position lowering (`JsString`
+for `string`, `Number` for `number`, `Foo` for a named ref).
+
+Writing `Array<T>` (the explicit generic) gets the JS-array
+reference form; writing `T[]` (the syntactic shortcut) gets
+the Rust slice form. Writing `String` (the JS wrapper class) gets
+`&JsString`; writing `string` (the primitive) gets `&str`. The
+TS spelling controls the choice 1:1 — no fan-out, no duplicate
+variants.
+
+Other arg lowerings are independent of this rule:
+
+* `&Foo` / `&Uint8Array` / `&Headers` — already JS references.
+* `bool` / `f64` / `i64` — pass-by-value primitives.
+
+### Why TS-spelling control rather than fan-out
+
+An earlier design emitted both `&str` and `&JsString` variants
+of every `string`-taking callable (`new_with_body` plus
+`new_with_js_string`), letting the *caller* pick at the call
+site. That doubled the API surface for every fan-out-eligible
+arg and cartesian-multiplied when combined with union
+expansion — a 13-required-field dict (Cloudflare worker-types'
+`AIGatewayHeaders`) ballooned to 279,936 variants. Deferring to
+the TS author keeps each callable's surface compact and makes
+the binding's perf characteristics part of the TS contract.
 
 ## Property accessors
 

--- a/src/codegen/classes.rs
+++ b/src/codegen/classes.rs
@@ -524,15 +524,11 @@ pub(crate) fn generate_dictionary_factory_with_passes(
         options: Vec<FieldOption>,
     }
 
-    // Decompose a getter's `type_ref` into its union members (or the
-    // single member if it isn't a union), with literal types peeled
-    // out for the discriminant collapse.
-    fn split_union(ty: &crate::ir::TypeRef) -> Vec<&crate::ir::TypeRef> {
-        match ty {
-            crate::ir::TypeRef::Union(members) => members.iter().collect(),
-            other => vec![other],
-        }
-    }
+    // Decompose a getter's `type_ref` into union members + ABI
+    // fan-out flavors.
+    let split_union = |ty: &crate::ir::TypeRef| -> Vec<crate::ir::TypeRef> {
+        crate::codegen::signatures::flatten_type_pub(ty, config.cgctx, config.scope)
+    };
 
     // Helper that turns one required-getter list into a list of
     // `FieldDim`s — the cartesian product axes for that pass.
@@ -545,10 +541,15 @@ pub(crate) fn generate_dictionary_factory_with_passes(
                 continue;
             }
 
-            // Each member of the union (or the single non-union type) maps
-            // to one option. Literals find their setter by matching the
-            // setter's param type_ref structurally; non-literals get their
-            // own option with an `expand_signatures`-compatible param.
+            // Each alternative (union member or ABI fan-out flavor)
+            // maps to one option. Literals find their setter by
+            // matching the setter's param type_ref structurally;
+            // non-literals get their own option with an
+            // `expand_signatures`-compatible param. Fan-out flavors
+            // emitted by `flatten_type` (e.g. `JsString` next to
+            // `String`) appear as additional Value alternatives and
+            // pick up their matching setter (`set_from_with_js_string`)
+            // via the same `pick_setter` lookup.
             let mut options: Vec<FieldOption> = Vec::new();
             let members = split_union(&g.type_ref);
             let any_literal = members.iter().any(|m| {
@@ -561,7 +562,6 @@ pub(crate) fn generate_dictionary_factory_with_passes(
             });
             let value_members: Vec<&crate::ir::TypeRef> = members
                 .iter()
-                .copied()
                 .filter(|m| {
                     !matches!(
                         m,
@@ -632,7 +632,7 @@ pub(crate) fn generate_dictionary_factory_with_passes(
             let value_targets: Vec<&crate::ir::TypeRef> = if any_literal {
                 value_members
             } else {
-                members.clone()
+                members.iter().collect()
             };
             for m in value_targets {
                 let setter_ident = pick_setter(m).unwrap_or_else(|| default_setter.clone());
@@ -695,7 +695,39 @@ pub(crate) fn generate_dictionary_factory_with_passes(
             .all(|opt| required_pass.iter().any(|req| req.js_name == opt.js_name));
         let pass_emit_builder = emit_builder && !pass_covers_optionals;
 
-        let field_dims = build_field_dims(required_pass);
+        let mut field_dims = build_field_dims(required_pass);
+
+        // Cap the dict-factory cartesian. The product across
+        // required fields can blow up (a 13-required-field dict
+        // with a few small unions each is the case that motivated
+        // this cap — workers-types' `AIGatewayHeaders`).
+        // Above the cap, every field's options collapse to its
+        // single idiomatic-LUB Value option so the cartesian
+        // degenerates to one combo per literal-prefix group.
+        const DICT_FACTORY_COMBO_LIMIT: usize = 64;
+        let combo_count: usize = field_dims
+            .iter()
+            .map(|d| d.options.len())
+            .fold(1usize, |a, n| a.saturating_mul(n));
+        if combo_count > DICT_FACTORY_COMBO_LIMIT {
+            if let Some(c) = config.cgctx {
+                c.warn(format!(
+                    "dictionary `{}` factory cartesian is {} combinations (above the \
+                     {}-combo limit) — collapsing each required field's setter \
+                     overloads to its idiomatic form and suppressing ABI fan-out \
+                     for this required set",
+                    config.rust_name, combo_count, DICT_FACTORY_COMBO_LIMIT,
+                ));
+            }
+            for dim in &mut field_dims {
+                // Keep only the first option (the idiomatic /
+                // first-listed setter for the field). All other
+                // alternatives are dropped — the wrapper builder's
+                // fluent setters still expose them on a per-field
+                // basis, no combinatorial cost there.
+                dim.options.truncate(1);
+            }
+        }
 
         // Cartesian product across field dimensions → list of combos
         // (each is a Vec<&FieldOption>).

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -583,12 +583,51 @@ fn expand_single_overload(
         (params, None)
     };
 
+    // Pre-flatten every param's alternatives once. Reused below in
+    // the cartesian-size projection and in the expansion loop, so
+    // we never re-flatten the same `TypeRef`.
+    let per_param_alts: Vec<Vec<TypeRef>> = non_variadic
+        .iter()
+        .map(|p| flatten_type(&p.type_ref, cgctx, scope))
+        .collect();
+
+    // Cap the cartesian product across params. Each optional param
+    // contributes +1 (the truncation case) on top of its alt count;
+    // required params multiply. Above the cap, every param's
+    // alternative list collapses to a single LUB so the cartesian
+    // degenerates to one signature.
+    let projected: usize = non_variadic
+        .iter()
+        .zip(per_param_alts.iter())
+        .map(|(p, alts)| {
+            let n = alts.len().max(1);
+            if p.optional {
+                n + 1
+            } else {
+                n
+            }
+        })
+        .fold(1usize, |acc, n| acc.saturating_mul(n));
+    let collapse_each = projected > CARTESIAN_PRODUCT_LIMIT;
+    if collapse_each {
+        if let Some(c) = cgctx {
+            c.warn(format!(
+                "callable cartesian product is {projected} signatures (above the \
+                 {CARTESIAN_PRODUCT_LIMIT}-variant limit) — collapsing each \
+                 union-typed parameter to its LUB and suppressing ABI fan-out \
+                 for this callable",
+            ));
+        }
+    }
+
     // Build expanded signatures via cartesian product.
     // Start with one empty signature, iterate params left to right.
     let mut sigs: Vec<Vec<ConcreteParam>> = vec![vec![]];
 
-    for (i, param) in non_variadic.iter().enumerate() {
-        let type_alternatives = flatten_type(&param.type_ref, cgctx, scope);
+    for (i, (param, mut type_alternatives)) in non_variadic.iter().zip(per_param_alts).enumerate() {
+        if collapse_each && type_alternatives.len() > 1 {
+            type_alternatives = vec![flatten_collapse_to_lub(&param.type_ref, cgctx, scope)];
+        }
 
         if param.optional {
             // Only extend sigs that are "full" up to this point (len == i).
@@ -662,51 +701,188 @@ fn expand_single_overload(
     sigs
 }
 
-/// Recursively flatten a type into its concrete alternatives.
+/// Public alias of [`flatten_type`] for callers in sibling modules
+/// (e.g. the dictionary-factory pipeline) that need to apply the
+/// same union + ABI fan-out rules to ad-hoc field types.
+pub fn flatten_type_pub(
+    ty: &TypeRef,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> Vec<TypeRef> {
+    flatten_type(ty, cgctx, scope)
+}
+
+/// Hard cap on the number of alternatives any single [`flatten_type`]
+/// call may produce. Above this, the entire input collapses to a
+/// single LUB alternative — the per-callable cartesian downstream
+/// then degrades to a single signature rather than exploding.
 ///
-/// - `Union([A, B])` → flatten(A) ++ flatten(B)
-/// - `Nullable(T)` → flatten(T) wrapped in Nullable
-/// - `Named("Foo")` → resolve alias; if alias is a union, flatten it
-/// - Generic container type arguments do not flatten
-/// - Everything else → single leaf
+/// 32 is enough for every realistic TS union the codegen pipeline
+/// has seen (the largest fixture in the test suite tops out around
+/// a dozen). The Cloudflare worker-types dictionary that motivated
+/// this limit had a union of 68 string literals on one field —
+/// well above 32 — and that case is exactly what the saturation
+/// is here to handle.
+const FLATTEN_ALTERNATIVE_LIMIT: usize = 8;
+
+/// Hard cap on the per-callable cartesian product size in
+/// [`expand_single_overload`]. When the product of per-param
+/// alternative counts (each clamped by [`FLATTEN_ALTERNATIVE_LIMIT`])
+/// exceeds this cap, every union-typed param collapses to its LUB
+/// and ABI fan-out is suppressed for the callable — the cartesian
+/// degenerates to a single signature. A warning surfaces the
+/// dropped overloads through the codegen context.
+///
+/// 64 is enough room for a 6-param fn whose every arg is a fan-out
+/// terminal (2^6 = 64), or a 5-param fn with one binary union arg
+/// (2^5 × 2 = 64). Beyond that the rendered API is already an
+/// unreadable wall of `_with_…` function names.
+const CARTESIAN_PRODUCT_LIMIT: usize = 64;
+
+/// Flatten a type into its concrete codegen alternatives.
+///
+/// Two orthogonal axes of fan-out compose in one recursive pass:
+///
+/// 1. **Semantic** — `Union` / `Nullable` / single-segment aliases
+///    unfold into each member, mirroring TS's narrowing semantics.
+///
+/// 2. **ABI** — arg-position outer types whose Rust-idiomatic
+///    lowering implies a Wasm-boundary copy emit a parallel
+///    JS-handle alternative:
+///    * `string` / `StringLiteral` → also `TypeRef::JsString`
+///      (`&JsString` lowering, no UTF-8 conversion).
+///    * `T[]` / `Array<T>` → also `TypeRef::JsArray(T)`
+///      (`&Array<U>` lowering, no element-wise materialisation).
+///
+/// `Foo | string` arg fans into `[Foo, string, JsString]`. The
+/// per-overload cartesian step in [`expand_single_overload`] then
+/// handles the cross-param product.
+///
+/// Fan-out terminates at the param boundary: `Promise<string>` /
+/// `Array<string>` don't recurse into their type arguments — the
+/// inner `string` keeps its source form and goes through
+/// inner-position lowering at codegen time.
+///
+/// ## Saturation
+///
+/// The output is capped at [`FLATTEN_ALTERNATIVE_LIMIT`]. A union
+/// of 68 string literals would fan out to 69 alternatives (one
+/// per literal plus the shared `JsString` ABI variant), exploding
+/// the cartesian product of any signature it appears in. The
+/// recursion **short-circuits as soon as the cap is hit** —
+/// downstream members aren't even visited — and the entire input
+/// is replaced with a single LUB alternative computed by
+/// [`flatten_collapse_to_lub`]. A warning surfaces through the
+/// codegen context so the user sees that some source-level
+/// alternatives were dropped from the public API.
 fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId) -> Vec<TypeRef> {
+    let mut out: Vec<TypeRef> = Vec::new();
+    if flatten_into(ty, cgctx, scope, &mut out) {
+        return out;
+    }
+    if let Some(c) = cgctx {
+        c.warn(format!(
+            "flattening `{}` exceeded the {}-alternative limit \
+             — collapsing to the union LUB and suppressing \
+             per-member overloads / ABI fan-out for this site",
+            ty.format_ts(),
+            FLATTEN_ALTERNATIVE_LIMIT,
+        ));
+    }
+    vec![flatten_collapse_to_lub(ty, cgctx, scope)]
+}
+
+/// Push every flatten-alternative for `ty` into `out`. Returns
+/// `false` the first time the running total exceeds
+/// [`FLATTEN_ALTERNATIVE_LIMIT`], short-circuiting the recursion
+/// so a 1000-member union doesn't materialise every member just
+/// to be discarded.
+///
+/// `out` may contain garbage on early-return (partial fan-out).
+/// Callers ignore `out` entirely when `false` is returned.
+fn flatten_into(
+    ty: &TypeRef,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+    out: &mut Vec<TypeRef>,
+) -> bool {
+    if out.len() > FLATTEN_ALTERNATIVE_LIMIT {
+        return false;
+    }
     match ty {
-        // Unions fan out into each member, recursively
-        TypeRef::Union(members) => members
-            .iter()
-            .flat_map(|m| flatten_type(m, cgctx, scope))
-            .collect(),
+        // Unions fan out into each member recursively. Short-circuit
+        // as soon as the limit trips so a huge union doesn't pay for
+        // members beyond the cap.
+        TypeRef::Union(members) => {
+            for m in members {
+                if !flatten_into(m, cgctx, scope, out) {
+                    return false;
+                }
+            }
+            true
+        }
 
         // Bare references: resolve through aliases, then re-flatten.
         // Generic instantiations and qualified paths don't follow
-        // aliases (they're already concrete enough at this level).
+        // aliases (they're already concrete at this level).
         TypeRef::Reference { .. } if ty.as_ident().is_some() => {
             let head = ty.as_ident().unwrap();
             if let Some(c) = cgctx {
                 if let Some(target) = c.resolve_alias(head, scope) {
                     let target = target.clone();
-                    return flatten_type(&target, cgctx, scope);
+                    return flatten_into(&target, cgctx, scope, out);
                 }
             }
-            vec![ty.clone()]
+            out.push(ty.clone());
+            true
         }
 
-        // Nullable: flatten the inner type, dropping the Null arm.
-        //
-        // Argument-position `Nullable<T>` carries no information that helps
-        // the caller — a `_with_null(val: &Null)` overload is always
-        // useless: callers either have a value to pass (use the `T` arm)
-        // or they don't (use an optional-truncation overload, or the
-        // setter just isn't called). Forcing them to construct a `Null`
-        // value just to clear a field is API noise.
-        //
-        // Return-position handling (`Option<T>` / `JsOption<T>`) is
-        // independent of this fan-out — it lives in `to_syn_type`.
-        TypeRef::Nullable(inner) => flatten_type(inner, cgctx, scope),
+        // Nullable: flatten the inner, dropping the `Null` arm.
+        // Argument-position `Nullable<T>` carries no useful overload
+        // information — a `_with_null(val: &Null)` variant is API
+        // noise. Return-position handling (`Option<T>` /
+        // `JsOption<T>`) is independent and lives in `to_syn_type`.
+        TypeRef::Nullable(inner) => flatten_into(inner, cgctx, scope, out),
 
-        // Generic containers are not distributive: `Array<A | B>` and
-        // `Record<K, A | B>` are single parameter shapes, not overloads.
-        _ => vec![ty.clone()],
+        // Everything else is terminal — generic containers are not
+        // distributive (`Array<A | B>` and `Record<K, A | B>` are
+        // single parameter shapes, not overloads), and TS spelling
+        // controls Rust outer lowering rather than fanning out into
+        // alternative forms.
+        _ => {
+            out.push(ty.clone());
+            true
+        }
+    }
+}
+
+/// Compute the LUB-collapsed single alternative for a `TypeRef`
+/// whose normal flatten would exceed
+/// [`FLATTEN_ALTERNATIVE_LIMIT`].
+///
+/// Returns [`crate::codegen::subtyping::lub_union`] for unions
+/// (and aliases that chase through to one); otherwise returns the
+/// input unchanged. The `Null`-arm-drop applied by `Nullable`
+/// flattening carries through for argument-position consistency.
+fn flatten_collapse_to_lub(
+    ty: &TypeRef,
+    cgctx: Option<&CodegenContext<'_>>,
+    scope: ScopeId,
+) -> TypeRef {
+    match ty {
+        TypeRef::Union(members) => {
+            crate::codegen::subtyping::lub_union(members, cgctx, scope).unwrap_or(TypeRef::Any)
+        }
+        TypeRef::Nullable(inner) => flatten_collapse_to_lub(inner, cgctx, scope),
+        TypeRef::Reference { .. } if ty.as_ident().is_some() => {
+            if let Some(c) = cgctx {
+                if let Some(target) = c.resolve_alias(ty.as_ident().unwrap(), scope) {
+                    return flatten_collapse_to_lub(&target.clone(), cgctx, scope);
+                }
+            }
+            ty.clone()
+        }
+        other => other.clone(),
     }
 }
 
@@ -740,7 +916,14 @@ fn compute_rust_names(base_name: &str, signatures: &[Vec<ConcreteParam>]) -> Vec
     // Only the "middle" params that differ contribute to naming suffixes.
     let (trim_start, trim_end) = compute_trim(signatures);
 
-    let mut names = Vec::new();
+    // Greedy single-pass naming: the first signature with a given
+    // candidate suffix keeps it; subsequent siblings whose
+    // type-name-driven suffix would collide retry the offending
+    // position using the param-name path instead. This replaces
+    // numeric dedup (`_with_record` + `_with_record_2`) with
+    // semantic disambiguation (`_with_record` + `_with_context`).
+    let mut names = Vec::with_capacity(signatures.len());
+    let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for (sig_idx, sig) in signatures.iter().enumerate() {
         // The first signature (shortest / most basic) gets the base name
@@ -748,11 +931,16 @@ fn compute_rust_names(base_name: &str, signatures: &[Vec<ConcreteParam>]) -> Vec
         // common calling pattern uses the simplest name.
         if sig_idx == 0 {
             names.push(base_name.to_string());
+            used.insert(base_name.to_string());
             continue;
         }
 
-        let mut name = base_name.to_string();
-        let mut first_suffix = true;
+        // Compute per-position suffix parts, each tagged with whether
+        // the suffix used the type-name (which is collision-prone) or
+        // the param-name (uniquely identifying). On collision the
+        // type-name-tagged parts get rewritten to param-name during
+        // the post-collision retry.
+        let mut parts: Vec<SuffixPart> = Vec::new();
 
         let end = if sig.len() >= trim_end {
             sig.len() - trim_end
@@ -765,8 +953,6 @@ fn compute_rust_names(base_name: &str, signatures: &[Vec<ConcreteParam>]) -> Vec
         for (param_idx, param) in sig[start..end].iter().enumerate() {
             let abs_idx = start + param_idx;
 
-            // Check if this param position differs from any other signature
-            // we need to disambiguate against (using original absolute indices).
             let mut any_different = false;
             let mut any_same_name_different_type = false;
 
@@ -795,26 +981,130 @@ fn compute_rust_names(base_name: &str, signatures: &[Vec<ConcreteParam>]) -> Vec
                 continue;
             }
 
-            if first_suffix {
-                name.push_str("_with_");
-                first_suffix = false;
+            let param_snake = to_snake_case(&param.name);
+            let (text, from_type) = if any_same_name_different_type {
+                (type_snake_name(&param.type_ref), true)
             } else {
-                name.push_str("_and_");
-            }
+                (param_snake.clone(), false)
+            };
+            parts.push(SuffixPart {
+                text,
+                from_type,
+                param_snake,
+            });
+        }
 
-            if any_same_name_different_type {
-                // Union expansion: use the type name
-                name.push_str(&type_snake_name(&param.type_ref));
-            } else {
-                // Optional expansion or overload: use the param name
-                name.push_str(&to_snake_case(&param.name));
+        // Assemble the candidate name. If it collides with a sibling
+        // already in `used`, retry the type-name parts by prepending
+        // the param name. The retry runs at most twice — once
+        // upgrading the entire suffix to the param-name path, once
+        // upgrading param-name to param-name + flavor. Anything past
+        // that returns to numeric dedup as the last-resort safety
+        // net.
+        let mut name = compose_name(base_name, &parts, NamingStrategy::Greedy);
+        if used.contains(&name) {
+            // Strategy 1: every type-name part adopts its param-name
+            // prefix. The fanned side keeps its flavor as a suffix.
+            name = compose_name(base_name, &parts, NamingStrategy::ParamNamePlusFlavor);
+        }
+        if used.contains(&name) {
+            // Strategy 2: numeric fallback. Unlikely to fire in
+            // practice — the param-name + flavor form is already
+            // very specific.
+            let mut n = 2;
+            let base = name.clone();
+            while used.contains(&name) {
+                name = format!("{base}_{n}");
+                n += 1;
             }
         }
 
+        used.insert(name.clone());
         names.push(name);
     }
 
     names
+}
+
+/// How [`compute_rust_names`] assembles a name from its per-position
+/// [`SuffixPart`] list. Used to retry name composition when a
+/// greedy first-pass name collides with a sibling.
+enum NamingStrategy {
+    /// Use each part's chosen `text` as-is (`_with_record`,
+    /// `_with_context`). The greedy default.
+    Greedy,
+    /// Prefer the **param name** for every part that originally came
+    /// from the type-name path, suffixed with the ABI flavor when
+    /// the part marks itself as a fan-out variant. This is the
+    /// collision-rescue path: `_with_context_record` /
+    /// `_with_default_value_js_string` over numeric dedup.
+    ParamNamePlusFlavor,
+}
+
+fn compose_name(
+    base_name: &str,
+    parts: &[impl SuffixPartView],
+    strategy: NamingStrategy,
+) -> String {
+    let mut name = base_name.to_string();
+    let mut first = true;
+    for p in parts {
+        if first {
+            name.push_str("_with_");
+            first = false;
+        } else {
+            name.push_str("_and_");
+        }
+        let chunk = match strategy {
+            NamingStrategy::Greedy => p.greedy_text().to_string(),
+            NamingStrategy::ParamNamePlusFlavor => p.param_name_plus_flavor(),
+        };
+        name.push_str(&chunk);
+    }
+    name
+}
+
+/// One position's contribution to a `_with_<…>_and_<…>` suffix.
+/// Created by [`compute_rust_names`] and consumed by [`compose_name`]
+/// for greedy-then-retry naming.
+struct SuffixPart {
+    /// The greedy first-pass token (`record`, `context`, `flag_key`,
+    /// …). Comes from `type_snake_name` for union differences, from
+    /// the param name for optional / overload differences.
+    text: String,
+    /// `true` when [`text`] came from `type_snake_name`. Type-name
+    /// suffixes (e.g. two `Record<X,Y>` / `Record<X,Z>` args both
+    /// snake-casing to `record`) are the collision-prone ones and
+    /// get rewritten on retry.
+    from_type: bool,
+    /// Param name in snake_case — the retry fallback that replaces
+    /// the type-name path on greedy-collision.
+    param_snake: String,
+}
+
+impl SuffixPartView for SuffixPart {
+    fn greedy_text(&self) -> &str {
+        &self.text
+    }
+    fn param_name_plus_flavor(&self) -> String {
+        if !self.from_type {
+            // Originally param-name driven — no upgrade needed.
+            self.text.clone()
+        } else {
+            // Type-name driven and lost on collision — swap in the
+            // param name. The original type-name token (`record`,
+            // `js_string`, …) becomes the secondary modifier so the
+            // resulting suffix carries both axes.
+            format!("{}_{}", self.param_snake, self.text)
+        }
+    }
+}
+
+/// Read-only view of the suffix part fields needed by
+/// [`compose_name`]. Lets the assembly step stay strategy-agnostic.
+trait SuffixPartView {
+    fn greedy_text(&self) -> &str;
+    fn param_name_plus_flavor(&self) -> String;
 }
 
 /// Compute how many params to trim from the start and end of all signatures.
@@ -896,13 +1186,15 @@ fn type_snake_name(ty: &TypeRef) -> String {
         TypeRef::ArrayBufferView => "typed_array".to_string(),
         // Snake-case the leftmost (head) segment of any named
         // reference. Type args don't participate in `_with_` suffixes.
-        // `Array<T>` and `ReadonlyArray<T>` lower to `&[T]` /
-        // `Vec<T>` so they're named after the Rust slice form,
-        // not the JS class.
+        // `Array<T>` and `ReadonlyArray<T>` lower to `&Array<U>` /
+        // `Array<U>` — the JS-array reference form. Their suffix is
+        // `array`, matching what callers see in the rendered Rust
+        // type. The syntactic `T[]` (a `TypeRef::Array`) is the
+        // slice form and gets `slice`.
         TypeRef::Reference { segments, .. } => {
             let head = segments.first().map_or("", |s| s.as_str());
             if head == "Array" || head == "ReadonlyArray" {
-                return "slice".to_string();
+                return "array".to_string();
             }
             to_snake_case(head)
         }
@@ -1702,7 +1994,7 @@ mod tests {
     #[test]
     fn test_overloads_with_different_types() {
         // foo(x: string) and foo(x: Promise<string>) should expand as
-        // foo_with_str and foo_with_promise
+        // foo and foo_with_promise.
         let mut used = no_used();
         let overload1 = [typed_param("x", TypeRef::String)];
         let overload2 = [typed_param(
@@ -1720,7 +2012,6 @@ mod tests {
 
         let non_try: Vec<_> = sigs.iter().filter(|s| !s.catch).collect();
         assert_eq!(non_try.len(), 2);
-        // First overload gets base name, second gets type suffix
         assert_eq!(non_try[0].rust_name, "foo");
         assert_eq!(non_try[1].rust_name, "foo_with_promise");
     }

--- a/src/codegen/signatures.rs
+++ b/src/codegen/signatures.rs
@@ -611,11 +611,15 @@ fn expand_single_overload(
     let collapse_each = projected > CARTESIAN_PRODUCT_LIMIT;
     if collapse_each {
         if let Some(c) = cgctx {
+            let param_summary = non_variadic
+                .iter()
+                .map(|p| format!("{}: {}", p.name, p.type_ref.format_ts()))
+                .collect::<Vec<_>>()
+                .join(", ");
             c.warn(format!(
                 "callable cartesian product is {projected} signatures (above the \
                  {CARTESIAN_PRODUCT_LIMIT}-variant limit) — collapsing each \
-                 union-typed parameter to its LUB and suppressing ABI fan-out \
-                 for this callable",
+                 union-typed parameter to its LUB. Params: ({param_summary})",
             ));
         }
     }
@@ -741,22 +745,10 @@ const CARTESIAN_PRODUCT_LIMIT: usize = 64;
 
 /// Flatten a type into its concrete codegen alternatives.
 ///
-/// Two orthogonal axes of fan-out compose in one recursive pass:
-///
-/// 1. **Semantic** — `Union` / `Nullable` / single-segment aliases
-///    unfold into each member, mirroring TS's narrowing semantics.
-///
-/// 2. **ABI** — arg-position outer types whose Rust-idiomatic
-///    lowering implies a Wasm-boundary copy emit a parallel
-///    JS-handle alternative:
-///    * `string` / `StringLiteral` → also `TypeRef::JsString`
-///      (`&JsString` lowering, no UTF-8 conversion).
-///    * `T[]` / `Array<T>` → also `TypeRef::JsArray(T)`
-///      (`&Array<U>` lowering, no element-wise materialisation).
-///
-/// `Foo | string` arg fans into `[Foo, string, JsString]`. The
-/// per-overload cartesian step in [`expand_single_overload`] then
-/// handles the cross-param product.
+/// `Union` / `Nullable` / single-segment aliases unfold into each
+/// member, mirroring TS's narrowing semantics. `Foo | string` arg
+/// fans into `[Foo, string]`. The per-overload cartesian step in
+/// [`expand_single_overload`] then handles the cross-param product.
 ///
 /// Fan-out terminates at the param boundary: `Promise<string>` /
 /// `Array<string>` don't recurse into their type arguments — the
@@ -766,15 +758,14 @@ const CARTESIAN_PRODUCT_LIMIT: usize = 64;
 /// ## Saturation
 ///
 /// The output is capped at [`FLATTEN_ALTERNATIVE_LIMIT`]. A union
-/// of 68 string literals would fan out to 69 alternatives (one
-/// per literal plus the shared `JsString` ABI variant), exploding
-/// the cartesian product of any signature it appears in. The
-/// recursion **short-circuits as soon as the cap is hit** —
-/// downstream members aren't even visited — and the entire input
-/// is replaced with a single LUB alternative computed by
-/// [`flatten_collapse_to_lub`]. A warning surfaces through the
-/// codegen context so the user sees that some source-level
-/// alternatives were dropped from the public API.
+/// of 68 string literals would explode the cartesian product of
+/// any signature it appears in. The recursion **short-circuits as
+/// soon as the cap is hit** — downstream members aren't even
+/// visited — and the entire input is replaced with a single LUB
+/// alternative computed by [`flatten_collapse_to_lub`]. A
+/// warning surfaces through the codegen context so the user sees
+/// that some source-level alternatives were dropped from the
+/// public API.
 fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId) -> Vec<TypeRef> {
     let mut out: Vec<TypeRef> = Vec::new();
     if flatten_into(ty, cgctx, scope, &mut out) {
@@ -784,7 +775,7 @@ fn flatten_type(ty: &TypeRef, cgctx: Option<&CodegenContext<'_>>, scope: ScopeId
         c.warn(format!(
             "flattening `{}` exceeded the {}-alternative limit \
              — collapsing to the union LUB and suppressing \
-             per-member overloads / ABI fan-out for this site",
+             per-member overloads for this site",
             ty.format_ts(),
             FLATTEN_ALTERNATIVE_LIMIT,
         ));

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -887,8 +887,12 @@ pub fn to_syn_type(
         // `to_syn_type`, bypassing the outer `maybe_ref` wrap so the
         // already-borrowed slice / `Vec<T>` shape isn't double-borrowed:
         //
-        // * `Array<T>` / `ReadonlyArray<T>` — re-routed through the
-        //   syntactic `T[]` arm.
+        // * `Array<T>` / `ReadonlyArray<T>` — lower to the JS-array
+        //   reference form (`&Array<U>` / `Array<U>`), distinct from
+        //   the syntactic `T[]` which keeps the Rust-slice form.
+        //   TS spelling drives the choice: callers who want a JS
+        //   array reference (no element-wise materialisation) write
+        //   `Array<T>`; callers who want a Rust slice write `T[]`.
         // * Bare references that resolve to a type alias whose target
         //   carries its own borrow shape (e.g. `string`, `T[]`,
         //   `Array<U>`) — recursing into the target re-runs
@@ -900,13 +904,9 @@ pub fn to_syn_type(
         } => {
             if segments.len() == 1 && (segments[0] == "Array" || segments[0] == "ReadonlyArray") {
                 let inner = generic_args.first().cloned().unwrap_or(TypeRef::Any);
-                return to_syn_type(
-                    &TypeRef::Array(Box::new(inner)),
-                    pos,
-                    ctx,
-                    scope,
-                    from_module,
-                );
+                let base =
+                    generic_container(quote! { Array }, &inner, pos, ctx, scope, from_module);
+                return maybe_ref(base, borrow);
             }
             if segments.len() == 1 && generic_args.is_empty() {
                 if let Some(c) = ctx {

--- a/src/codegen/typemap.rs
+++ b/src/codegen/typemap.rs
@@ -818,17 +818,17 @@ pub fn to_syn_type(
             }
             if let Some(c) = ctx {
                 c.warn(format!(
-                    "union with no common supertype erased to JsValue ({} variants)",
-                    members.len()
+                    "union `{}` has no common supertype, erased to JsValue",
+                    ty.format_ts(),
                 ));
             }
             maybe_ref(quote! { JsValue }, borrow)
         }
-        TypeRef::Intersection(parts) => {
+        TypeRef::Intersection(_) => {
             if let Some(c) = ctx {
                 c.warn(format!(
-                    "intersection of {} types erased to JsValue (no structural merge yet)",
-                    parts.len()
+                    "intersection `{}` has no structural merge yet, erased to JsValue",
+                    ty.format_ts(),
                 ));
             }
             maybe_ref(quote! { JsValue }, borrow)

--- a/tests/snapshots/coverage.rs
+++ b/tests/snapshots/coverage.rs
@@ -216,7 +216,7 @@ extern "C" {
     pub fn set_next(this: &LinkedList, val: &LinkedList);
 }
 impl LinkedList {
-    pub fn new(data: &JsValue, next: Option<&LinkedList>) -> LinkedList {
+    pub fn new(data: &JsValue, next: &LinkedList) -> LinkedList {
         let inner: LinkedList = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_data(data);
         inner.set_next(next);

--- a/tests/snapshots/dynamic-union-return.rs
+++ b/tests/snapshots/dynamic-union-return.rs
@@ -14,7 +14,7 @@ extern "C" {
     pub fn content(this: &Erased) -> ContentKind;
     #[doc = " Inner-erased generic — outer Array stays as `Vec<JsValue>`."]
     #[wasm_bindgen(method, getter)]
-    pub fn tags(this: &Erased) -> Vec<JsValue>;
+    pub fn tags(this: &Erased) -> Array;
 }
 impl Erased {
     #[allow(clippy::new_without_default)]

--- a/tests/snapshots/es-module-lexer.rs
+++ b/tests/snapshots/es-module-lexer.rs
@@ -125,7 +125,7 @@ pub mod es_module_lexer {
         #[doc = " // Returns [['type', 'json'], ['integrity', 'sha384-...']]"]
         #[doc = " ```"]
         #[wasm_bindgen(method, getter)]
-        pub fn at(this: &ImportSpecifier) -> Option<Vec<ArrayTuple<(JsString, JsString)>>>;
+        pub fn at(this: &ImportSpecifier) -> Option<Array<ArrayTuple<(JsString, JsString)>>>;
     }
     impl ImportSpecifier {
         #[allow(clippy::new_without_default)]

--- a/tests/snapshots/workers-types.rs
+++ b/tests/snapshots/workers-types.rs
@@ -8205,7 +8205,7 @@ impl KVNamespaceListResult {
     pub fn new_false(
         keys: &[KVNamespaceListKey<Metadata, Key>],
         cursor: &str,
-        cache_status: Option<&str>,
+        cache_status: &str,
     ) -> KVNamespaceListResult {
         let inner: KVNamespaceListResult = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_list_complete(false);
@@ -8219,7 +8219,7 @@ impl KVNamespaceListResult {
     #[doc = " * `list_complete: true`"]
     pub fn new_true(
         keys: &[KVNamespaceListKey<Metadata, Key>],
-        cache_status: Option<&str>,
+        cache_status: &str,
     ) -> KVNamespaceListResult {
         Self::builder_true(keys, cache_status).build()
     }
@@ -8228,7 +8228,7 @@ impl KVNamespaceListResult {
     #[doc = " * `list_complete: true`"]
     pub fn builder_true(
         keys: &[KVNamespaceListKey<Metadata, Key>],
-        cache_status: Option<&str>,
+        cache_status: &str,
     ) -> KVNamespaceListResultBuilder {
         let inner: KVNamespaceListResult = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_list_complete(true);
@@ -8272,32 +8272,36 @@ extern "C" {
         r#type: &str,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "get")]
-    pub async fn get_with_key_and_kv_namespace_get_options_2<Key: ::wasm_bindgen::JsGeneric>(
+    pub async fn get_with_key_key_and_options_kv_namespace_get_options<
+        Key: ::wasm_bindgen::JsGeneric,
+    >(
         this: &KVNamespace<Key>,
         key: &Key,
         options: &KVNamespaceGetOptions<JsString>,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "get")]
-    pub async fn get_with_slice_and_type<Key: ::wasm_bindgen::JsGeneric>(
+    pub async fn get_with_array_and_type<Key: ::wasm_bindgen::JsGeneric>(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         r#type: &str,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "get")]
-    pub async fn get_with_slice<Key: ::wasm_bindgen::JsGeneric>(
+    pub async fn get_with_array<Key: ::wasm_bindgen::JsGeneric>(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "get")]
-    pub async fn get_with_slice_and_kv_namespace_get_options<Key: ::wasm_bindgen::JsGeneric>(
+    pub async fn get_with_array_and_kv_namespace_get_options<Key: ::wasm_bindgen::JsGeneric>(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         options: &KVNamespaceGetOptions<Undefined>,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "get")]
-    pub async fn get_with_slice_and_kv_namespace_get_options_2<Key: ::wasm_bindgen::JsGeneric>(
+    pub async fn get_with_key_array_and_options_kv_namespace_get_options<
+        Key: ::wasm_bindgen::JsGeneric,
+    >(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         options: &KVNamespaceGetOptions<JsString>,
     ) -> Result<JsOption<JsString>, JsValue>;
     #[wasm_bindgen(method, catch)]
@@ -8391,7 +8395,7 @@ extern "C" {
         r#type: &str,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch, js_name = "getWithMetadata")]
-    pub async fn get_with_metadata_with_key_and_kv_namespace_get_options_2<
+    pub async fn get_with_metadata_with_key_key_and_options_kv_namespace_get_options<
         Key: ::wasm_bindgen::JsGeneric,
         Metadata: ::wasm_bindgen::JsGeneric,
     >(
@@ -8400,38 +8404,38 @@ extern "C" {
         options: &KVNamespaceGetOptions<JsString>,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "getWithMetadata")]
-    pub async fn get_with_metadata_with_slice_and_type<
+    pub async fn get_with_metadata_with_array_and_type<
         Key: ::wasm_bindgen::JsGeneric,
         Metadata: ::wasm_bindgen::JsGeneric,
     >(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         r#type: &str,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "getWithMetadata")]
-    pub async fn get_with_metadata_with_slice<
+    pub async fn get_with_metadata_with_array<
         Key: ::wasm_bindgen::JsGeneric,
         Metadata: ::wasm_bindgen::JsGeneric,
     >(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "getWithMetadata")]
-    pub async fn get_with_metadata_with_slice_and_kv_namespace_get_options<
+    pub async fn get_with_metadata_with_array_and_kv_namespace_get_options<
         Key: ::wasm_bindgen::JsGeneric,
         Metadata: ::wasm_bindgen::JsGeneric,
     >(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         options: &KVNamespaceGetOptions<Undefined>,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch, slice_to_array, js_name = "getWithMetadata")]
-    pub async fn get_with_metadata_with_slice_and_kv_namespace_get_options_2<
+    pub async fn get_with_metadata_with_key_array_and_options_kv_namespace_get_options<
         Key: ::wasm_bindgen::JsGeneric,
         Metadata: ::wasm_bindgen::JsGeneric,
     >(
         this: &KVNamespace<Key>,
-        key: &[Key],
+        key: &Array<Key>,
         options: &KVNamespaceGetOptions<JsString>,
     ) -> Result<KVNamespaceGetWithMetadataResult<JsString, Metadata>, JsValue>;
     #[wasm_bindgen(method, catch)]
@@ -8620,9 +8624,9 @@ impl<Value: ::wasm_bindgen::JsGeneric, Metadata: ::wasm_bindgen::JsGeneric>
     KVNamespaceGetWithMetadataResult<Value, Metadata>
 {
     pub fn new(
-        value: Option<&Value>,
-        metadata: Option<&Metadata>,
-        cache_status: Option<&str>,
+        value: &Value,
+        metadata: &Metadata,
+        cache_status: &str,
     ) -> KVNamespaceGetWithMetadataResult<Value, Metadata> {
         let inner: KVNamespaceGetWithMetadataResult<Value, Metadata> =
             JsCast::unchecked_into(js_sys::Object::new());
@@ -14128,19 +14132,19 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiSearchSearchRequest;
     #[wasm_bindgen(method, getter)]
-    pub fn messages(this: &AiSearchSearchRequest) -> Vec<Object>;
+    pub fn messages(this: &AiSearchSearchRequest) -> Array<Object>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_messages(this: &AiSearchSearchRequest, val: &[Object]);
+    pub fn set_messages(this: &AiSearchSearchRequest, val: &Array<Object>);
     #[wasm_bindgen(method, getter)]
     pub fn ai_search_options(this: &AiSearchSearchRequest) -> Option<Object>;
     #[wasm_bindgen(method, setter)]
     pub fn set_ai_search_options(this: &AiSearchSearchRequest, val: &Object);
 }
 impl AiSearchSearchRequest {
-    pub fn new(messages: &[Object]) -> AiSearchSearchRequest {
+    pub fn new(messages: &Array<Object>) -> AiSearchSearchRequest {
         Self::builder(messages).build()
     }
-    pub fn builder(messages: &[Object]) -> AiSearchSearchRequestBuilder {
+    pub fn builder(messages: &Array<Object>) -> AiSearchSearchRequestBuilder {
         let inner: AiSearchSearchRequest = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_messages(messages);
         AiSearchSearchRequestBuilder { inner }
@@ -14164,9 +14168,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type AiSearchChatCompletionsRequest;
     #[wasm_bindgen(method, getter)]
-    pub fn messages(this: &AiSearchChatCompletionsRequest) -> Vec<Object>;
+    pub fn messages(this: &AiSearchChatCompletionsRequest) -> Array<Object>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_messages(this: &AiSearchChatCompletionsRequest, val: &[Object]);
+    pub fn set_messages(this: &AiSearchChatCompletionsRequest, val: &Array<Object>);
     #[wasm_bindgen(method, getter)]
     pub fn model(this: &AiSearchChatCompletionsRequest) -> Option<String>;
     #[wasm_bindgen(method, setter)]
@@ -14181,10 +14185,10 @@ extern "C" {
     pub fn set_ai_search_options(this: &AiSearchChatCompletionsRequest, val: &Object);
 }
 impl AiSearchChatCompletionsRequest {
-    pub fn new(messages: &[Object]) -> AiSearchChatCompletionsRequest {
+    pub fn new(messages: &Array<Object>) -> AiSearchChatCompletionsRequest {
         Self::builder(messages).build()
     }
-    pub fn builder(messages: &[Object]) -> AiSearchChatCompletionsRequestBuilder {
+    pub fn builder(messages: &Array<Object>) -> AiSearchChatCompletionsRequestBuilder {
         let inner: AiSearchChatCompletionsRequest = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_messages(messages);
         AiSearchChatCompletionsRequestBuilder { inner }
@@ -14220,12 +14224,12 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_search_query(this: &AiSearchSearchResponse, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn chunks(this: &AiSearchSearchResponse) -> Vec<Object>;
+    pub fn chunks(this: &AiSearchSearchResponse) -> Array<Object>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_chunks(this: &AiSearchSearchResponse, val: &[Object]);
+    pub fn set_chunks(this: &AiSearchSearchResponse, val: &Array<Object>);
 }
 impl AiSearchSearchResponse {
-    pub fn new(search_query: &str, chunks: &[Object]) -> AiSearchSearchResponse {
+    pub fn new(search_query: &str, chunks: &Array<Object>) -> AiSearchSearchResponse {
         let inner: AiSearchSearchResponse = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_search_query(search_query);
         inner.set_chunks(chunks);
@@ -16015,15 +16019,15 @@ extern "C" {
         val: &ResponseConversationParam,
     );
     #[wasm_bindgen(method, getter)]
-    pub fn include(this: &ResponsesInput) -> Option<Vec<ResponseIncludable>>;
+    pub fn include(this: &ResponsesInput) -> Option<Array<ResponseIncludable>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_include(this: &ResponsesInput, val: &[ResponseIncludable]);
+    pub fn set_include(this: &ResponsesInput, val: &Array<ResponseIncludable>);
     #[wasm_bindgen(method, getter)]
     pub fn input(this: &ResponsesInput) -> Option<InputKind>;
     #[wasm_bindgen(method, setter)]
     pub fn set_input(this: &ResponsesInput, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "input")]
-    pub fn set_input_with_slice(this: &ResponsesInput, val: &[JsValue]);
+    pub fn set_input_with_array(this: &ResponsesInput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn instructions(this: &ResponsesInput) -> Option<String>;
     #[wasm_bindgen(method, setter)]
@@ -16082,9 +16086,9 @@ extern "C" {
         val: &ToolChoiceFunction,
     );
     #[wasm_bindgen(method, getter)]
-    pub fn tools(this: &ResponsesInput) -> Option<Vec<ResponsesFunctionTool>>;
+    pub fn tools(this: &ResponsesInput) -> Option<Array<ResponsesFunctionTool>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_tools(this: &ResponsesInput, val: &[ResponsesFunctionTool]);
+    pub fn set_tools(this: &ResponsesInput, val: &Array<ResponsesFunctionTool>);
     #[wasm_bindgen(method, getter)]
     pub fn top_p(this: &ResponsesInput) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
@@ -16124,7 +16128,7 @@ impl ResponsesInputBuilder {
             .set_conversation_with_response_conversation_param(val);
         self
     }
-    pub fn include(self, val: &[ResponseIncludable]) -> Self {
+    pub fn include(self, val: &Array<ResponseIncludable>) -> Self {
         self.inner.set_include(val);
         self
     }
@@ -16132,8 +16136,8 @@ impl ResponsesInputBuilder {
         self.inner.set_input(val);
         self
     }
-    pub fn input_with_slice(self, val: &[JsValue]) -> Self {
-        self.inner.set_input_with_slice(val);
+    pub fn input_with_array(self, val: &Array) -> Self {
+        self.inner.set_input_with_array(val);
         self
     }
     pub fn instructions(self, val: &str) -> Self {
@@ -16192,7 +16196,7 @@ impl ResponsesInputBuilder {
         self.inner.set_tool_choice_with_tool_choice_function(val);
         self
     }
-    pub fn tools(self, val: &[ResponsesFunctionTool]) -> Self {
+    pub fn tools(self, val: &Array<ResponsesFunctionTool>) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -16238,15 +16242,15 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_instructions(this: &ResponsesOutput, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "instructions")]
-    pub fn set_instructions_with_slice(this: &ResponsesOutput, val: &[JsValue]);
+    pub fn set_instructions_with_array(this: &ResponsesOutput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn object(this: &ResponsesOutput) -> Option<String>;
     #[wasm_bindgen(method, setter)]
     pub fn set_object(this: &ResponsesOutput, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn output(this: &ResponsesOutput) -> Option<Vec<JsValue>>;
+    pub fn output(this: &ResponsesOutput) -> Option<Array>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_output(this: &ResponsesOutput, val: &[JsValue]);
+    pub fn set_output(this: &ResponsesOutput, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn parallel_tool_calls(this: &ResponsesOutput) -> Option<bool>;
     #[wasm_bindgen(method, setter)]
@@ -16265,9 +16269,9 @@ extern "C" {
         val: &ToolChoiceFunction,
     );
     #[wasm_bindgen(method, getter)]
-    pub fn tools(this: &ResponsesOutput) -> Option<Vec<ResponsesFunctionTool>>;
+    pub fn tools(this: &ResponsesOutput) -> Option<Array<ResponsesFunctionTool>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_tools(this: &ResponsesOutput, val: &[ResponsesFunctionTool]);
+    pub fn set_tools(this: &ResponsesOutput, val: &Array<ResponsesFunctionTool>);
     #[wasm_bindgen(method, getter)]
     pub fn top_p(this: &ResponsesOutput) -> Option<f64>;
     #[wasm_bindgen(method, setter)]
@@ -16351,15 +16355,15 @@ impl ResponsesOutputBuilder {
         self.inner.set_instructions(val);
         self
     }
-    pub fn instructions_with_slice(self, val: &[JsValue]) -> Self {
-        self.inner.set_instructions_with_slice(val);
+    pub fn instructions_with_array(self, val: &Array) -> Self {
+        self.inner.set_instructions_with_array(val);
         self
     }
     pub fn object(self, val: &str) -> Self {
         self.inner.set_object(val);
         self
     }
-    pub fn output(self, val: &[JsValue]) -> Self {
+    pub fn output(self, val: &Array) -> Self {
         self.inner.set_output(val);
         self
     }
@@ -16379,7 +16383,7 @@ impl ResponsesOutputBuilder {
         self.inner.set_tool_choice_with_tool_choice_function(val);
         self
     }
-    pub fn tools(self, val: &[ResponsesFunctionTool]) -> Self {
+    pub fn tools(self, val: &Array<ResponsesFunctionTool>) -> Self {
         self.inner.set_tools(val);
         self
     }
@@ -16441,7 +16445,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_content(this: &EasyInputMessage, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "content")]
-    pub fn set_content_with_slice(this: &EasyInputMessage, val: &[JsValue]);
+    pub fn set_content_with_array(this: &EasyInputMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &EasyInputMessage) -> EasyInputMessageRoleKind;
     #[wasm_bindgen(method, setter)]
@@ -16479,34 +16483,26 @@ impl EasyInputMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessage {
-        Self::builder_user_with_response_input_message_content_list(content).build()
+    pub fn new_user_with_array(content: &Array) -> EasyInputMessage {
+        Self::builder_user_with_array(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"assistant\"`"]
-    pub fn new_assistant_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessage {
-        Self::builder_assistant_with_response_input_message_content_list(content).build()
+    pub fn new_assistant_with_array(content: &Array) -> EasyInputMessage {
+        Self::builder_assistant_with_array(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn new_system_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessage {
-        Self::builder_system_with_response_input_message_content_list(content).build()
+    pub fn new_system_with_array(content: &Array) -> EasyInputMessage {
+        Self::builder_system_with_array(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn new_developer_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessage {
-        Self::builder_developer_with_response_input_message_content_list(content).build()
+    pub fn new_developer_with_array(content: &Array) -> EasyInputMessage {
+        Self::builder_developer_with_array(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -16547,44 +16543,36 @@ impl EasyInputMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn builder_user_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessageBuilder {
+    pub fn builder_user_with_array(content: &Array) -> EasyInputMessageBuilder {
         let inner: EasyInputMessage = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_content(content);
+        inner.set_content_with_array(content);
         inner.set_role("user");
         EasyInputMessageBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"assistant\"`"]
-    pub fn builder_assistant_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessageBuilder {
+    pub fn builder_assistant_with_array(content: &Array) -> EasyInputMessageBuilder {
         let inner: EasyInputMessage = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_content(content);
+        inner.set_content_with_array(content);
         inner.set_role("assistant");
         EasyInputMessageBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn builder_system_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessageBuilder {
+    pub fn builder_system_with_array(content: &Array) -> EasyInputMessageBuilder {
         let inner: EasyInputMessage = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_content(content);
+        inner.set_content_with_array(content);
         inner.set_role("system");
         EasyInputMessageBuilder { inner }
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn builder_developer_with_response_input_message_content_list(
-        content: &[JsValue],
-    ) -> EasyInputMessageBuilder {
+    pub fn builder_developer_with_array(content: &Array) -> EasyInputMessageBuilder {
         let inner: EasyInputMessage = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_content(content);
+        inner.set_content_with_array(content);
         inner.set_role("developer");
         EasyInputMessageBuilder { inner }
     }
@@ -16631,11 +16619,7 @@ impl ResponsesFunctionTool {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"function\"`"]
-    pub fn new_function(
-        name: &str,
-        parameters: Option<&Object>,
-        strict: Option<bool>,
-    ) -> ResponsesFunctionTool {
+    pub fn new_function(name: &str, parameters: &Object, strict: bool) -> ResponsesFunctionTool {
         Self::builder_function(name, parameters, strict).build()
     }
     #[doc = " ## Inlined fields"]
@@ -16643,8 +16627,8 @@ impl ResponsesFunctionTool {
     #[doc = " * `type: \"function\"`"]
     pub fn builder_function(
         name: &str,
-        parameters: Option<&Object>,
-        strict: Option<bool>,
+        parameters: &Object,
+        strict: bool,
     ) -> ResponsesFunctionToolBuilder {
         let inner: ResponsesFunctionTool = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_name(name);
@@ -16878,7 +16862,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseCustomToolCallOutput, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "output")]
-    pub fn set_output_with_slice(this: &ResponseCustomToolCallOutput, val: &[JsValue]);
+    pub fn set_output_with_array(this: &ResponseCustomToolCallOutput, val: &Array);
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &ResponseCustomToolCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
@@ -16901,11 +16885,11 @@ impl ResponseCustomToolCallOutput {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"custom_tool_call_output\"`"]
-    pub fn new_custom_tool_call_output_with_slice(
+    pub fn new_custom_tool_call_output_with_array(
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseCustomToolCallOutput {
-        Self::builder_custom_tool_call_output_with_slice(call_id, output).build()
+        Self::builder_custom_tool_call_output_with_array(call_id, output).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -16923,13 +16907,13 @@ impl ResponseCustomToolCallOutput {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"custom_tool_call_output\"`"]
-    pub fn builder_custom_tool_call_output_with_slice(
+    pub fn builder_custom_tool_call_output_with_array(
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseCustomToolCallOutputBuilder {
         let inner: ResponseCustomToolCallOutput = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_call_id(call_id);
-        inner.set_output_with_slice(output);
+        inner.set_output_with_array(output);
         inner.set_type("custom_tool_call_output");
         ResponseCustomToolCallOutputBuilder { inner }
     }
@@ -16961,165 +16945,9 @@ extern "C" {
     pub fn set_message(this: &ResponseError, val: &str);
 }
 impl ResponseError {
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"server_error\"`"]
-    pub fn new_server_error(message: &str) -> ResponseError {
+    pub fn new(code: &str, message: &str) -> ResponseError {
         let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("server_error");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"rate_limit_exceeded\"`"]
-    pub fn new_rate_limit_exceeded(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("rate_limit_exceeded");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_prompt\"`"]
-    pub fn new_invalid_prompt(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_prompt");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"vector_store_timeout\"`"]
-    pub fn new_vector_store_timeout(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("vector_store_timeout");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_image\"`"]
-    pub fn new_invalid_image(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_image");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_image_format\"`"]
-    pub fn new_invalid_image_format(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_image_format");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_base64_image\"`"]
-    pub fn new_invalid_base64_image(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_base64_image");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_image_url\"`"]
-    pub fn new_invalid_image_url(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_image_url");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_too_large\"`"]
-    pub fn new_image_too_large(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_too_large");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_too_small\"`"]
-    pub fn new_image_too_small(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_too_small");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_parse_error\"`"]
-    pub fn new_image_parse_error(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_parse_error");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_content_policy_violation\"`"]
-    pub fn new_image_content_policy_violation(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_content_policy_violation");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"invalid_image_mode\"`"]
-    pub fn new_invalid_image_mode(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("invalid_image_mode");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_file_too_large\"`"]
-    pub fn new_image_file_too_large(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_file_too_large");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"unsupported_image_media_type\"`"]
-    pub fn new_unsupported_image_media_type(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("unsupported_image_media_type");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"empty_image_file\"`"]
-    pub fn new_empty_image_file(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("empty_image_file");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"failed_to_download_image\"`"]
-    pub fn new_failed_to_download_image(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("failed_to_download_image");
-        inner.set_message(message);
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `code: \"image_file_not_found\"`"]
-    pub fn new_image_file_not_found(message: &str) -> ResponseError {
-        let inner: ResponseError = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_code("image_file_not_found");
+        inner.set_code(code);
         inner.set_message(message);
         inner
     }
@@ -17155,9 +16983,9 @@ impl ResponseErrorEvent {
     #[doc = ""]
     #[doc = " * `type: \"error\"`"]
     pub fn new_error(
-        code: Option<&str>,
+        code: &str,
         message: &str,
-        param: Option<&str>,
+        param: &str,
         sequence_number: f64,
     ) -> ResponseErrorEvent {
         let inner: ResponseErrorEvent = JsCast::unchecked_into(js_sys::Object::new());
@@ -17515,7 +17343,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseFunctionToolCallOutputItem, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "output")]
-    pub fn set_output_with_slice(this: &ResponseFunctionToolCallOutputItem, val: &[JsValue]);
+    pub fn set_output_with_array(this: &ResponseFunctionToolCallOutputItem, val: &Array);
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &ResponseFunctionToolCallOutputItem) -> String;
     #[wasm_bindgen(method, setter)]
@@ -17539,12 +17367,12 @@ impl ResponseFunctionToolCallOutputItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"function_call_output\"`"]
-    pub fn new_function_call_output_with_slice(
+    pub fn new_function_call_output_with_array(
         id: &str,
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseFunctionToolCallOutputItem {
-        Self::builder_function_call_output_with_slice(id, call_id, output).build()
+        Self::builder_function_call_output_with_array(id, call_id, output).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -17565,16 +17393,16 @@ impl ResponseFunctionToolCallOutputItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"function_call_output\"`"]
-    pub fn builder_function_call_output_with_slice(
+    pub fn builder_function_call_output_with_array(
         id: &str,
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseFunctionToolCallOutputItemBuilder {
         let inner: ResponseFunctionToolCallOutputItem =
             JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_call_id(call_id);
-        inner.set_output_with_slice(output);
+        inner.set_output_with_array(output);
         inner.set_type("function_call_output");
         ResponseFunctionToolCallOutputItemBuilder { inner }
     }
@@ -17789,7 +17617,7 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_output(this: &ResponseInputItemFunctionCallOutput, val: &str);
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "output")]
-    pub fn set_output_with_slice(this: &ResponseInputItemFunctionCallOutput, val: &[JsValue]);
+    pub fn set_output_with_array(this: &ResponseInputItemFunctionCallOutput, val: &Array);
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &ResponseInputItemFunctionCallOutput) -> String;
     #[wasm_bindgen(method, setter)]
@@ -17816,14 +17644,11 @@ impl ResponseInputItemFunctionCallOutput {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"function_call_output\"`"]
-    pub fn new_function_call_output_with_response_function_call_output_item_list(
+    pub fn new_function_call_output_with_array(
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseInputItemFunctionCallOutput {
-        Self::builder_function_call_output_with_response_function_call_output_item_list(
-            call_id, output,
-        )
-        .build()
+        Self::builder_function_call_output_with_array(call_id, output).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
@@ -17842,14 +17667,14 @@ impl ResponseInputItemFunctionCallOutput {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `type: \"function_call_output\"`"]
-    pub fn builder_function_call_output_with_response_function_call_output_item_list(
+    pub fn builder_function_call_output_with_array(
         call_id: &str,
-        output: &[JsValue],
+        output: &Array,
     ) -> ResponseInputItemFunctionCallOutputBuilder {
         let inner: ResponseInputItemFunctionCallOutput =
             JsCast::unchecked_into(js_sys::Object::new());
         inner.set_call_id(call_id);
-        inner.set_output(output);
+        inner.set_output_with_array(output);
         inner.set_type("function_call_output");
         ResponseInputItemFunctionCallOutputBuilder { inner }
     }
@@ -17876,9 +17701,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ResponseInputItemMessage;
     #[wasm_bindgen(method, getter)]
-    pub fn content(this: &ResponseInputItemMessage) -> Vec<JsValue>;
+    pub fn content(this: &ResponseInputItemMessage) -> Array;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_content(this: &ResponseInputItemMessage, val: &[JsValue]);
+    pub fn set_content(this: &ResponseInputItemMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseInputItemMessage) -> ResponseInputItemMessageRoleKind;
     #[wasm_bindgen(method, setter)]
@@ -17896,25 +17721,25 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user(content: &[JsValue]) -> ResponseInputItemMessage {
+    pub fn new_user(content: &Array) -> ResponseInputItemMessage {
         Self::builder_user(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn new_system(content: &[JsValue]) -> ResponseInputItemMessage {
+    pub fn new_system(content: &Array) -> ResponseInputItemMessage {
         Self::builder_system(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn new_developer(content: &[JsValue]) -> ResponseInputItemMessage {
+    pub fn new_developer(content: &Array) -> ResponseInputItemMessage {
         Self::builder_developer(content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn builder_user(content: &[JsValue]) -> ResponseInputItemMessageBuilder {
+    pub fn builder_user(content: &Array) -> ResponseInputItemMessageBuilder {
         let inner: ResponseInputItemMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("user");
@@ -17923,7 +17748,7 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn builder_system(content: &[JsValue]) -> ResponseInputItemMessageBuilder {
+    pub fn builder_system(content: &Array) -> ResponseInputItemMessageBuilder {
         let inner: ResponseInputItemMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("system");
@@ -17932,7 +17757,7 @@ impl ResponseInputItemMessage {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn builder_developer(content: &[JsValue]) -> ResponseInputItemMessageBuilder {
+    pub fn builder_developer(content: &Array) -> ResponseInputItemMessageBuilder {
         let inner: ResponseInputItemMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_content(content);
         inner.set_role("developer");
@@ -17967,9 +17792,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &ResponseInputMessageItem, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn content(this: &ResponseInputMessageItem) -> Vec<JsValue>;
+    pub fn content(this: &ResponseInputMessageItem) -> Array;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_content(this: &ResponseInputMessageItem, val: &[JsValue]);
+    pub fn set_content(this: &ResponseInputMessageItem, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseInputMessageItem) -> ResponseInputItemMessageRoleKind;
     #[wasm_bindgen(method, setter)]
@@ -17987,25 +17812,25 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn new_user(id: &str, content: &[JsValue]) -> ResponseInputMessageItem {
+    pub fn new_user(id: &str, content: &Array) -> ResponseInputMessageItem {
         Self::builder_user(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn new_system(id: &str, content: &[JsValue]) -> ResponseInputMessageItem {
+    pub fn new_system(id: &str, content: &Array) -> ResponseInputMessageItem {
         Self::builder_system(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn new_developer(id: &str, content: &[JsValue]) -> ResponseInputMessageItem {
+    pub fn new_developer(id: &str, content: &Array) -> ResponseInputMessageItem {
         Self::builder_developer(id, content).build()
     }
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"user\"`"]
-    pub fn builder_user(id: &str, content: &[JsValue]) -> ResponseInputMessageItemBuilder {
+    pub fn builder_user(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
         let inner: ResponseInputMessageItem = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18015,7 +17840,7 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"system\"`"]
-    pub fn builder_system(id: &str, content: &[JsValue]) -> ResponseInputMessageItemBuilder {
+    pub fn builder_system(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
         let inner: ResponseInputMessageItem = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18025,7 +17850,7 @@ impl ResponseInputMessageItem {
     #[doc = " ## Inlined fields"]
     #[doc = ""]
     #[doc = " * `role: \"developer\"`"]
-    pub fn builder_developer(id: &str, content: &[JsValue]) -> ResponseInputMessageItemBuilder {
+    pub fn builder_developer(id: &str, content: &Array) -> ResponseInputMessageItemBuilder {
         let inner: ResponseInputMessageItem = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18140,12 +17965,42 @@ impl ResponseOutputItemAddedEvent {
     #[doc = ""]
     #[doc = " * `type: \"response.output_item.added\"`"]
     pub fn new_responseoutput_itemadded(
-        item: &JsValue,
+        item: &ResponseOutputMessage,
         output_index: f64,
         sequence_number: f64,
     ) -> ResponseOutputItemAddedEvent {
         let inner: ResponseOutputItemAddedEvent = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_item(item);
+        inner.set_output_index(output_index);
+        inner.set_sequence_number(sequence_number);
+        inner.set_type("response.output_item.added");
+        inner
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `type: \"response.output_item.added\"`"]
+    pub fn new_responseoutput_itemadded_with_response_function_tool_call(
+        item: &ResponseFunctionToolCall,
+        output_index: f64,
+        sequence_number: f64,
+    ) -> ResponseOutputItemAddedEvent {
+        let inner: ResponseOutputItemAddedEvent = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_item_with_response_function_tool_call(item);
+        inner.set_output_index(output_index);
+        inner.set_sequence_number(sequence_number);
+        inner.set_type("response.output_item.added");
+        inner
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `type: \"response.output_item.added\"`"]
+    pub fn new_responseoutput_itemadded_with_response_reasoning_item(
+        item: &ResponseReasoningItem,
+        output_index: f64,
+        sequence_number: f64,
+    ) -> ResponseOutputItemAddedEvent {
+        let inner: ResponseOutputItemAddedEvent = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_item_with_response_reasoning_item(item);
         inner.set_output_index(output_index);
         inner.set_sequence_number(sequence_number);
         inner.set_type("response.output_item.added");
@@ -18189,12 +18044,42 @@ impl ResponseOutputItemDoneEvent {
     #[doc = ""]
     #[doc = " * `type: \"response.output_item.done\"`"]
     pub fn new_responseoutput_itemdone(
-        item: &JsValue,
+        item: &ResponseOutputMessage,
         output_index: f64,
         sequence_number: f64,
     ) -> ResponseOutputItemDoneEvent {
         let inner: ResponseOutputItemDoneEvent = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_item(item);
+        inner.set_output_index(output_index);
+        inner.set_sequence_number(sequence_number);
+        inner.set_type("response.output_item.done");
+        inner
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `type: \"response.output_item.done\"`"]
+    pub fn new_responseoutput_itemdone_with_response_function_tool_call(
+        item: &ResponseFunctionToolCall,
+        output_index: f64,
+        sequence_number: f64,
+    ) -> ResponseOutputItemDoneEvent {
+        let inner: ResponseOutputItemDoneEvent = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_item_with_response_function_tool_call(item);
+        inner.set_output_index(output_index);
+        inner.set_sequence_number(sequence_number);
+        inner.set_type("response.output_item.done");
+        inner
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `type: \"response.output_item.done\"`"]
+    pub fn new_responseoutput_itemdone_with_response_reasoning_item(
+        item: &ResponseReasoningItem,
+        output_index: f64,
+        sequence_number: f64,
+    ) -> ResponseOutputItemDoneEvent {
+        let inner: ResponseOutputItemDoneEvent = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_item_with_response_reasoning_item(item);
         inner.set_output_index(output_index);
         inner.set_sequence_number(sequence_number);
         inner.set_type("response.output_item.done");
@@ -18211,9 +18096,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &ResponseOutputMessage, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn content(this: &ResponseOutputMessage) -> Vec<JsValue>;
+    pub fn content(this: &ResponseOutputMessage) -> Array;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_content(this: &ResponseOutputMessage, val: &[JsValue]);
+    pub fn set_content(this: &ResponseOutputMessage, val: &Array);
     #[wasm_bindgen(method, getter)]
     pub fn role(this: &ResponseOutputMessage) -> String;
     #[wasm_bindgen(method, setter)]
@@ -18233,10 +18118,7 @@ impl ResponseOutputMessage {
     #[doc = " * `role: \"assistant\"`"]
     #[doc = " * `status: \"in_progress\"`"]
     #[doc = " * `type: \"message\"`"]
-    pub fn new_assistant_in_progress_message(
-        id: &str,
-        content: &[JsValue],
-    ) -> ResponseOutputMessage {
+    pub fn new_assistant_in_progress_message(id: &str, content: &Array) -> ResponseOutputMessage {
         let inner: ResponseOutputMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18250,7 +18132,7 @@ impl ResponseOutputMessage {
     #[doc = " * `role: \"assistant\"`"]
     #[doc = " * `status: \"completed\"`"]
     #[doc = " * `type: \"message\"`"]
-    pub fn new_assistant_completed_message(id: &str, content: &[JsValue]) -> ResponseOutputMessage {
+    pub fn new_assistant_completed_message(id: &str, content: &Array) -> ResponseOutputMessage {
         let inner: ResponseOutputMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18264,10 +18146,7 @@ impl ResponseOutputMessage {
     #[doc = " * `role: \"assistant\"`"]
     #[doc = " * `status: \"incomplete\"`"]
     #[doc = " * `type: \"message\"`"]
-    pub fn new_assistant_incomplete_message(
-        id: &str,
-        content: &[JsValue],
-    ) -> ResponseOutputMessage {
+    pub fn new_assistant_incomplete_message(id: &str, content: &Array) -> ResponseOutputMessage {
         let inner: ResponseOutputMessage = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_content(content);
@@ -18316,9 +18195,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &ResponseOutputText, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn logprobs(this: &ResponseOutputText) -> Option<Vec<Logprob>>;
+    pub fn logprobs(this: &ResponseOutputText) -> Option<Array<Logprob>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_logprobs(this: &ResponseOutputText, val: &[Logprob]);
+    pub fn set_logprobs(this: &ResponseOutputText, val: &Array<Logprob>);
 }
 impl ResponseOutputText {
     #[doc = " ## Inlined fields"]
@@ -18341,7 +18220,7 @@ pub struct ResponseOutputTextBuilder {
     inner: ResponseOutputText,
 }
 impl ResponseOutputTextBuilder {
-    pub fn logprobs(self, val: &[Logprob]) -> Self {
+    pub fn logprobs(self, val: &Array<Logprob>) -> Self {
         self.inner.set_logprobs(val);
         self
     }
@@ -18359,17 +18238,17 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_id(this: &ResponseReasoningItem, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn summary(this: &ResponseReasoningItem) -> Vec<ResponseReasoningSummaryItem>;
+    pub fn summary(this: &ResponseReasoningItem) -> Array<ResponseReasoningSummaryItem>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_summary(this: &ResponseReasoningItem, val: &[ResponseReasoningSummaryItem]);
+    pub fn set_summary(this: &ResponseReasoningItem, val: &Array<ResponseReasoningSummaryItem>);
     #[wasm_bindgen(method, getter, js_name = "type")]
     pub fn type_(this: &ResponseReasoningItem) -> String;
     #[wasm_bindgen(method, setter)]
     pub fn set_type(this: &ResponseReasoningItem, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn content(this: &ResponseReasoningItem) -> Option<Vec<ResponseReasoningContentItem>>;
+    pub fn content(this: &ResponseReasoningItem) -> Option<Array<ResponseReasoningContentItem>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_content(this: &ResponseReasoningItem, val: &[ResponseReasoningContentItem]);
+    pub fn set_content(this: &ResponseReasoningItem, val: &Array<ResponseReasoningContentItem>);
     #[wasm_bindgen(method, getter)]
     pub fn encrypted_content(this: &ResponseReasoningItem) -> Option<String>;
     #[wasm_bindgen(method, setter)]
@@ -18385,7 +18264,7 @@ impl ResponseReasoningItem {
     #[doc = " * `type: \"reasoning\"`"]
     pub fn new_reasoning(
         id: &str,
-        summary: &[ResponseReasoningSummaryItem],
+        summary: &Array<ResponseReasoningSummaryItem>,
     ) -> ResponseReasoningItem {
         Self::builder_reasoning(id, summary).build()
     }
@@ -18394,7 +18273,7 @@ impl ResponseReasoningItem {
     #[doc = " * `type: \"reasoning\"`"]
     pub fn builder_reasoning(
         id: &str,
-        summary: &[ResponseReasoningSummaryItem],
+        summary: &Array<ResponseReasoningSummaryItem>,
     ) -> ResponseReasoningItemBuilder {
         let inner: ResponseReasoningItem = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
@@ -18407,7 +18286,7 @@ pub struct ResponseReasoningItemBuilder {
     inner: ResponseReasoningItem,
 }
 impl ResponseReasoningItemBuilder {
-    pub fn content(self, val: &[ResponseReasoningContentItem]) -> Self {
+    pub fn content(self, val: &Array<ResponseReasoningContentItem>) -> Self {
         self.inner.set_content(val);
         self
     }
@@ -18808,9 +18687,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_item_id(this: &ResponseTextDeltaEvent, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn logprobs(this: &ResponseTextDeltaEvent) -> Vec<Logprob>;
+    pub fn logprobs(this: &ResponseTextDeltaEvent) -> Array<Logprob>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_logprobs(this: &ResponseTextDeltaEvent, val: &[Logprob]);
+    pub fn set_logprobs(this: &ResponseTextDeltaEvent, val: &Array<Logprob>);
     #[wasm_bindgen(method, getter)]
     pub fn output_index(this: &ResponseTextDeltaEvent) -> f64;
     #[wasm_bindgen(method, setter)]
@@ -18832,7 +18711,7 @@ impl ResponseTextDeltaEvent {
         content_index: f64,
         delta: &str,
         item_id: &str,
-        logprobs: &[Logprob],
+        logprobs: &Array<Logprob>,
         output_index: f64,
         sequence_number: f64,
     ) -> ResponseTextDeltaEvent {
@@ -18861,9 +18740,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_item_id(this: &ResponseTextDoneEvent, val: &str);
     #[wasm_bindgen(method, getter)]
-    pub fn logprobs(this: &ResponseTextDoneEvent) -> Vec<Logprob>;
+    pub fn logprobs(this: &ResponseTextDoneEvent) -> Array<Logprob>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_logprobs(this: &ResponseTextDoneEvent, val: &[Logprob]);
+    pub fn set_logprobs(this: &ResponseTextDoneEvent, val: &Array<Logprob>);
     #[wasm_bindgen(method, getter)]
     pub fn output_index(this: &ResponseTextDoneEvent) -> f64;
     #[wasm_bindgen(method, setter)]
@@ -18888,7 +18767,7 @@ impl ResponseTextDoneEvent {
     pub fn new_responseoutput_textdone(
         content_index: f64,
         item_id: &str,
-        logprobs: &[Logprob],
+        logprobs: &Array<Logprob>,
         output_index: f64,
         sequence_number: f64,
         text: &str,
@@ -18918,9 +18797,9 @@ extern "C" {
     #[wasm_bindgen(method, setter)]
     pub fn set_logprob(this: &Logprob, val: f64);
     #[wasm_bindgen(method, getter)]
-    pub fn top_logprobs(this: &Logprob) -> Option<Vec<TopLogprob>>;
+    pub fn top_logprobs(this: &Logprob) -> Option<Array<TopLogprob>>;
     #[wasm_bindgen(method, setter, slice_to_array)]
-    pub fn set_top_logprobs(this: &Logprob, val: &[TopLogprob]);
+    pub fn set_top_logprobs(this: &Logprob, val: &Array<TopLogprob>);
 }
 impl Logprob {
     pub fn new(token: &str, logprob: f64) -> Logprob {
@@ -18937,7 +18816,7 @@ pub struct LogprobBuilder {
     inner: Logprob,
 }
 impl LogprobBuilder {
-    pub fn top_logprobs(self, val: &[TopLogprob]) -> Self {
+    pub fn top_logprobs(self, val: &Array<TopLogprob>) -> Self {
         self.inner.set_top_logprobs(val);
         self
     }
@@ -26167,888 +26046,25 @@ extern "C" {
     pub fn set_target_language(this: &Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input, val: &str);
 }
 impl Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"asm_Beng\"` - Target language to translate to"]
-    #[doc = ""]
     #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_asm_beng(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
+    #[doc = " * `target_language` - Target language to translate to"]
+    pub fn new(text: &str, target_language: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
         let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
             JsCast::unchecked_into(js_sys::Object::new());
         inner.set_text(text);
-        inner.set_target_language("asm_Beng");
+        inner.set_target_language(target_language);
         inner
     }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"awa_Deva\"` - Target language to translate to"]
-    #[doc = ""]
     #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_awa_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("awa_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"ben_Beng\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_ben_beng(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("ben_Beng");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"bho_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_bho_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("bho_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"brx_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_brx_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("brx_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"doi_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_doi_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("doi_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"eng_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_eng_latn(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("eng_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"gom_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_gom_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("gom_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"gon_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_gon_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("gon_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"guj_Gujr\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_guj_gujr(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("guj_Gujr");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"hin_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_hin_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("hin_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"hne_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_hne_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("hne_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kan_Knda\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kan_knda(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("kan_Knda");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kas_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kas_arab(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("kas_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kas_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kas_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("kas_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kha_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kha_latn(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("kha_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"lus_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_lus_latn(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("lus_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mag_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mag_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mag_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mai_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mai_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mai_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mal_Mlym\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mal_mlym(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mal_Mlym");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mar_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mar_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mar_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mni_Beng\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mni_beng(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mni_Beng");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mni_Mtei\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mni_mtei(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("mni_Mtei");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"npi_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_npi_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("npi_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"ory_Orya\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_ory_orya(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("ory_Orya");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"pan_Guru\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_pan_guru(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("pan_Guru");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"san_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_san_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("san_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"sat_Olck\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_sat_olck(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("sat_Olck");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"snd_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_snd_arab(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("snd_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"snd_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_snd_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("snd_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"tam_Taml\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_tam_taml(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("tam_Taml");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"tel_Telu\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_tel_telu(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("tel_Telu");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"urd_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_urd_arab(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("urd_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"unr_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_unr_deva(text: &str) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text(text);
-        inner.set_target_language("unr_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"asm_Beng\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_asm_beng_with_slice(
+    #[doc = " * `target_language` - Target language to translate to"]
+    pub fn new_with_slice(
         text: &[String],
+        target_language: &str,
     ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
         let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
             JsCast::unchecked_into(js_sys::Object::new());
         inner.set_text_with_slice(text);
-        inner.set_target_language("asm_Beng");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"awa_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_awa_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("awa_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"ben_Beng\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_ben_beng_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("ben_Beng");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"bho_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_bho_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("bho_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"brx_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_brx_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("brx_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"doi_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_doi_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("doi_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"eng_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_eng_latn_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("eng_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"gom_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_gom_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("gom_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"gon_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_gon_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("gon_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"guj_Gujr\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_guj_gujr_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("guj_Gujr");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"hin_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_hin_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("hin_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"hne_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_hne_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("hne_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kan_Knda\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kan_knda_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("kan_Knda");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kas_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kas_arab_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("kas_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kas_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kas_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("kas_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"kha_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_kha_latn_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("kha_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"lus_Latn\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_lus_latn_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("lus_Latn");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mag_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mag_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mag_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mai_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mai_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mai_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mal_Mlym\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mal_mlym_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mal_Mlym");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mar_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mar_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mar_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mni_Beng\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mni_beng_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mni_Beng");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"mni_Mtei\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_mni_mtei_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("mni_Mtei");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"npi_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_npi_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("npi_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"ory_Orya\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_ory_orya_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("ory_Orya");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"pan_Guru\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_pan_guru_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("pan_Guru");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"san_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_san_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("san_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"sat_Olck\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_sat_olck_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("sat_Olck");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"snd_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_snd_arab_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("snd_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"snd_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_snd_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("snd_Deva");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"tam_Taml\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_tam_taml_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("tam_Taml");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"tel_Telu\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_tel_telu_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("tel_Telu");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"urd_Arab\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_urd_arab_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("urd_Arab");
-        inner
-    }
-    #[doc = " ## Inlined fields"]
-    #[doc = ""]
-    #[doc = " * `target_language: \"unr_Deva\"` - Target language to translate to"]
-    #[doc = ""]
-    #[doc = " * `text` - Input text to translate. Can be a single string or a list of strings."]
-    pub fn new_unr_deva_with_slice(
-        text: &[String],
-    ) -> Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input {
-        let inner: Ai_Cf_Ai4Bharat_Indictrans2_En_Indic_1B_Input =
-            JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_text_with_slice(text);
-        inner.set_target_language("unr_Deva");
+        inner.set_target_language(target_language);
         inner
     }
 }
@@ -30459,7942 +29475,6 @@ impl AIGatewayHeaders {
         inner.set_content_type(content_type);
         inner
     }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_record_and_str_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &Object,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_object_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &Object,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_f64_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: f64,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_bool_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: bool,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_f64_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: f64,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_f64_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_f64_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_f64_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_f64_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: f64,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_str_and_f64_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_str_and_f64_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: f64,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_str_and_str_and_bool(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: bool,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
-    pub fn new_with_str_and_str_and_str_and_str_and_str_and_str_and_str_and_str(
-        cf_aig_metadata: &str,
-        cf_aig_custom_cost: &str,
-        cf_aig_cache_ttl: &str,
-        cf_aig_skip_cache: &str,
-        cf_aig_cache_key: &str,
-        cf_aig_event_id: &str,
-        cf_aig_request_timeout: &str,
-        cf_aig_max_attempts: &str,
-        cf_aig_retry_delay: &str,
-        cf_aig_backoff: &str,
-        cf_aig_collect_log: &str,
-        authorization: &str,
-        content_type: &str,
-    ) -> AIGatewayHeaders {
-        let inner: AIGatewayHeaders = JsCast::unchecked_into(js_sys::Object::new());
-        inner.set_cf_aig_metadata_with_str(cf_aig_metadata);
-        inner.set_cf_aig_custom_cost_with_str(cf_aig_custom_cost);
-        inner.set_cf_aig_cache_ttl_with_str(cf_aig_cache_ttl);
-        inner.set_cf_aig_skip_cache_with_str(cf_aig_skip_cache);
-        inner.set_cf_aig_cache_key(cf_aig_cache_key);
-        inner.set_cf_aig_event_id(cf_aig_event_id);
-        inner.set_cf_aig_request_timeout_with_str(cf_aig_request_timeout);
-        inner.set_cf_aig_max_attempts_with_str(cf_aig_max_attempts);
-        inner.set_cf_aig_retry_delay_with_str(cf_aig_retry_delay);
-        inner.set_cf_aig_backoff(cf_aig_backoff);
-        inner.set_cf_aig_collect_log_with_str(cf_aig_collect_log);
-        inner.set_authorization(authorization);
-        inner.set_content_type(content_type);
-        inner
-    }
 }
 #[wasm_bindgen]
 extern "C" {
@@ -38919,7 +29999,7 @@ impl AutoRagSearchResponse {
         search_query: &str,
         data: &[Object],
         has_more: bool,
-        next_page: Option<&str>,
+        next_page: &str,
     ) -> AutoRagSearchResponse {
         let inner: AutoRagSearchResponse = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_object("vector_store.search_results.page");
@@ -39838,17 +30918,20 @@ extern "C" {
     );
 }
 impl IncomingRequestCfPropertiesBase {
-    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
-    #[doc = " airport code of the data center that the request hit."]
+    #[doc = " ## Inlined fields"]
     #[doc = ""]
-    #[doc = " @example \"DFW\""]
-    #[doc = " * `edge_request_keep_alive_status` - Represents the upstream's response to a"]
+    #[doc = " * `edgeRequestKeepAliveStatus: 0` - Represents the upstream's response to a"]
     #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
     #[doc = " from cloudflare."]
     #[doc = ""]
     #[doc = " For workers with no upstream, this will always be `1`."]
     #[doc = ""]
     #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
     #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
     #[doc = ""]
     #[doc = " @example \"HTTP/2\""]
@@ -39866,17 +30949,15 @@ impl IncomingRequestCfPropertiesBase {
     #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
     #[doc = ""]
     #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
-    pub fn new(
+    pub fn new_0(
         colo: &str,
-        edge_request_keep_alive_status: f64,
         http_protocol: &str,
         request_priority: &str,
         tls_version: &str,
         tls_cipher: &str,
     ) -> IncomingRequestCfPropertiesBase {
-        Self::builder(
+        Self::builder_0(
             colo,
-            edge_request_keep_alive_status,
             http_protocol,
             request_priority,
             tls_version,
@@ -39884,17 +30965,20 @@ impl IncomingRequestCfPropertiesBase {
         )
         .build()
     }
-    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
-    #[doc = " airport code of the data center that the request hit."]
+    #[doc = " ## Inlined fields"]
     #[doc = ""]
-    #[doc = " @example \"DFW\""]
-    #[doc = " * `edge_request_keep_alive_status` - Represents the upstream's response to a"]
+    #[doc = " * `edgeRequestKeepAliveStatus: 1` - Represents the upstream's response to a"]
     #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
     #[doc = " from cloudflare."]
     #[doc = ""]
     #[doc = " For workers with no upstream, this will always be `1`."]
     #[doc = ""]
     #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
     #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
     #[doc = ""]
     #[doc = " @example \"HTTP/2\""]
@@ -39912,9 +30996,243 @@ impl IncomingRequestCfPropertiesBase {
     #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
     #[doc = ""]
     #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
-    pub fn builder(
+    pub fn new_1(
         colo: &str,
-        edge_request_keep_alive_status: f64,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBase {
+        Self::builder_1(
+            colo,
+            http_protocol,
+            request_priority,
+            tls_version,
+            tls_cipher,
+        )
+        .build()
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 2` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn new_2(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBase {
+        Self::builder_2(
+            colo,
+            http_protocol,
+            request_priority,
+            tls_version,
+            tls_cipher,
+        )
+        .build()
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 3` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn new_3(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBase {
+        Self::builder_3(
+            colo,
+            http_protocol,
+            request_priority,
+            tls_version,
+            tls_cipher,
+        )
+        .build()
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 4` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn new_4(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBase {
+        Self::builder_4(
+            colo,
+            http_protocol,
+            request_priority,
+            tls_version,
+            tls_cipher,
+        )
+        .build()
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 5` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn new_5(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBase {
+        Self::builder_5(
+            colo,
+            http_protocol,
+            request_priority,
+            tls_version,
+            tls_cipher,
+        )
+        .build()
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 0` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_0(
+        colo: &str,
         http_protocol: &str,
         request_priority: &str,
         tls_version: &str,
@@ -39922,7 +31240,242 @@ impl IncomingRequestCfPropertiesBase {
     ) -> IncomingRequestCfPropertiesBaseBuilder {
         let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_colo(colo);
-        inner.set_edge_request_keep_alive_status(edge_request_keep_alive_status);
+        inner.set_edge_request_keep_alive_status(0);
+        inner.set_http_protocol(http_protocol);
+        inner.set_request_priority(request_priority);
+        inner.set_tls_version(tls_version);
+        inner.set_tls_cipher(tls_cipher);
+        IncomingRequestCfPropertiesBaseBuilder { inner }
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 1` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_1(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBaseBuilder {
+        let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_colo(colo);
+        inner.set_edge_request_keep_alive_status(1);
+        inner.set_http_protocol(http_protocol);
+        inner.set_request_priority(request_priority);
+        inner.set_tls_version(tls_version);
+        inner.set_tls_cipher(tls_cipher);
+        IncomingRequestCfPropertiesBaseBuilder { inner }
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 2` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_2(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBaseBuilder {
+        let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_colo(colo);
+        inner.set_edge_request_keep_alive_status(2);
+        inner.set_http_protocol(http_protocol);
+        inner.set_request_priority(request_priority);
+        inner.set_tls_version(tls_version);
+        inner.set_tls_cipher(tls_cipher);
+        IncomingRequestCfPropertiesBaseBuilder { inner }
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 3` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_3(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBaseBuilder {
+        let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_colo(colo);
+        inner.set_edge_request_keep_alive_status(3);
+        inner.set_http_protocol(http_protocol);
+        inner.set_request_priority(request_priority);
+        inner.set_tls_version(tls_version);
+        inner.set_tls_cipher(tls_cipher);
+        IncomingRequestCfPropertiesBaseBuilder { inner }
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 4` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_4(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBaseBuilder {
+        let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_colo(colo);
+        inner.set_edge_request_keep_alive_status(4);
+        inner.set_http_protocol(http_protocol);
+        inner.set_request_priority(request_priority);
+        inner.set_tls_version(tls_version);
+        inner.set_tls_cipher(tls_cipher);
+        IncomingRequestCfPropertiesBaseBuilder { inner }
+    }
+    #[doc = " ## Inlined fields"]
+    #[doc = ""]
+    #[doc = " * `edgeRequestKeepAliveStatus: 5` - Represents the upstream's response to a"]
+    #[doc = " [TCP `keepalive` message](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html)"]
+    #[doc = " from cloudflare."]
+    #[doc = ""]
+    #[doc = " For workers with no upstream, this will always be `1`."]
+    #[doc = ""]
+    #[doc = " @example 3"]
+    #[doc = ""]
+    #[doc = " * `colo` - The three-letter [IATA](https://en.wikipedia.org/wiki/IATA_airport_code)"]
+    #[doc = " airport code of the data center that the request hit."]
+    #[doc = ""]
+    #[doc = " @example \"DFW\""]
+    #[doc = " * `http_protocol` - The HTTP Protocol the request used."]
+    #[doc = ""]
+    #[doc = " @example \"HTTP/2\""]
+    #[doc = " * `request_priority` - The browser-requested prioritization information in the request object."]
+    #[doc = ""]
+    #[doc = " If no information was set, defaults to the empty string `\"\"`"]
+    #[doc = ""]
+    #[doc = " @example \"weight=192;exclusive=0;group=3;group-weight=127\""]
+    #[doc = " @default \"\""]
+    #[doc = " * `tls_version` - The TLS version of the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"TLSv1.3\""]
+    #[doc = " * `tls_cipher` - The cipher for the connection to Cloudflare."]
+    #[doc = " In requests served over plaintext (without TLS), this property is the empty string `\"\"`."]
+    #[doc = ""]
+    #[doc = " @example \"AEAD-AES128-GCM-SHA256\""]
+    pub fn builder_5(
+        colo: &str,
+        http_protocol: &str,
+        request_priority: &str,
+        tls_version: &str,
+        tls_cipher: &str,
+    ) -> IncomingRequestCfPropertiesBaseBuilder {
+        let inner: IncomingRequestCfPropertiesBase = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_colo(colo);
+        inner.set_edge_request_keep_alive_status(5);
         inner.set_http_protocol(http_protocol);
         inner.set_request_priority(request_priority);
         inner.set_tls_version(tls_version);
@@ -45132,9 +36685,9 @@ extern "C" {
     pub fn set_preview(this: &StreamVideo, val: &str);
     #[doc = " Origins allowed to display the video."]
     #[wasm_bindgen(method, getter, js_name = "allowedOrigins")]
-    pub fn allowed_origins(this: &StreamVideo) -> Vec<String>;
+    pub fn allowed_origins(this: &StreamVideo) -> Array<JsString>;
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "allowedOrigins")]
-    pub fn set_allowed_origins(this: &StreamVideo, val: &[String]);
+    pub fn set_allowed_origins(this: &StreamVideo, val: &Array<JsString>);
     #[doc = " Indicates whether signed URLs are required."]
     #[wasm_bindgen(method, getter, js_name = "requireSignedURLs")]
     pub fn require_signed_ur_ls(this: &StreamVideo) -> Option<bool>;
@@ -45227,30 +36780,30 @@ impl StreamVideo {
     #[doc = " * `public_details` - Public details associated with the video."]
     pub fn new(
         id: &str,
-        creator: Option<&str>,
+        creator: &str,
         thumbnail: &str,
         thumbnail_timestamp_pct: f64,
         ready_to_stream: bool,
-        ready_to_stream_at: Option<&str>,
+        ready_to_stream_at: &str,
         status: &StreamVideoStatus,
         meta: &Object<JsString>,
         created: &str,
         modified: &str,
-        scheduled_deletion: Option<&str>,
+        scheduled_deletion: &str,
         size: f64,
-        allowed_origins: &[String],
-        require_signed_ur_ls: Option<bool>,
-        uploaded: Option<&str>,
-        upload_expiry: Option<&str>,
-        max_size_bytes: Option<f64>,
-        max_duration_seconds: Option<f64>,
+        allowed_origins: &Array<JsString>,
+        require_signed_ur_ls: bool,
+        uploaded: &str,
+        upload_expiry: &str,
+        max_size_bytes: f64,
+        max_duration_seconds: f64,
         duration: f64,
         input: &StreamVideoInput,
         hls_playback_url: &str,
         dash_playback_url: &str,
-        watermark: Option<&StreamWatermark>,
-        clipped_from_id: Option<&str>,
-        public_details: Option<&StreamPublicDetails>,
+        watermark: &StreamWatermark,
+        clipped_from_id: &str,
+        public_details: &StreamPublicDetails,
     ) -> StreamVideo {
         Self::builder(
             id,
@@ -45307,30 +36860,30 @@ impl StreamVideo {
     #[doc = " * `public_details` - Public details associated with the video."]
     pub fn builder(
         id: &str,
-        creator: Option<&str>,
+        creator: &str,
         thumbnail: &str,
         thumbnail_timestamp_pct: f64,
         ready_to_stream: bool,
-        ready_to_stream_at: Option<&str>,
+        ready_to_stream_at: &str,
         status: &StreamVideoStatus,
         meta: &Object<JsString>,
         created: &str,
         modified: &str,
-        scheduled_deletion: Option<&str>,
+        scheduled_deletion: &str,
         size: f64,
-        allowed_origins: &[String],
-        require_signed_ur_ls: Option<bool>,
-        uploaded: Option<&str>,
-        upload_expiry: Option<&str>,
-        max_size_bytes: Option<f64>,
-        max_duration_seconds: Option<f64>,
+        allowed_origins: &Array<JsString>,
+        require_signed_ur_ls: bool,
+        uploaded: &str,
+        upload_expiry: &str,
+        max_size_bytes: f64,
+        max_duration_seconds: f64,
         duration: f64,
         input: &StreamVideoInput,
         hls_playback_url: &str,
         dash_playback_url: &str,
-        watermark: Option<&StreamWatermark>,
-        clipped_from_id: Option<&str>,
-        public_details: Option<&StreamPublicDetails>,
+        watermark: &StreamWatermark,
+        clipped_from_id: &str,
+        public_details: &StreamPublicDetails,
     ) -> StreamVideoBuilder {
         let inner: StreamVideo = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
@@ -45504,10 +37057,10 @@ impl StreamPublicDetails {
     #[doc = " * `channel_link` - The public channel link."]
     #[doc = " * `logo` - The public logo URL."]
     pub fn new(
-        title: Option<&str>,
-        share_link: Option<&str>,
-        channel_link: Option<&str>,
-        logo: Option<&str>,
+        title: &str,
+        share_link: &str,
+        channel_link: &str,
+        logo: &str,
     ) -> StreamPublicDetails {
         let inner: StreamPublicDetails = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_title(title);
@@ -45551,8 +37104,8 @@ impl StreamDirectUpload {
     pub fn new(
         upload_url: &str,
         id: &str,
-        watermark: Option<&StreamWatermark>,
-        scheduled_deletion: Option<&str>,
+        watermark: &StreamWatermark,
+        scheduled_deletion: &str,
     ) -> StreamDirectUpload {
         let inner: StreamDirectUpload = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_upload_url(upload_url);
@@ -45590,9 +37143,9 @@ extern "C" {
     pub fn set_meta(this: &StreamDirectUploadCreateParams, val: &Object<JsString>);
     #[doc = " Lists the origins allowed to display the video."]
     #[wasm_bindgen(method, getter, js_name = "allowedOrigins")]
-    pub fn allowed_origins(this: &StreamDirectUploadCreateParams) -> Option<Vec<String>>;
+    pub fn allowed_origins(this: &StreamDirectUploadCreateParams) -> Option<Array<JsString>>;
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "allowedOrigins")]
-    pub fn set_allowed_origins(this: &StreamDirectUploadCreateParams, val: &[String]);
+    pub fn set_allowed_origins(this: &StreamDirectUploadCreateParams, val: &Array<JsString>);
     #[doc = " Indicates whether the video can be accessed using the id. When set to `true`,"]
     #[doc = " a signed token must be generated with a signing key to view the video."]
     #[wasm_bindgen(method, getter, js_name = "requireSignedURLs")]
@@ -45644,7 +37197,7 @@ impl StreamDirectUploadCreateParamsBuilder {
         self.inner.set_meta(val);
         self
     }
-    pub fn allowed_origins(self, val: &[String]) -> Self {
+    pub fn allowed_origins(self, val: &Array<JsString>) -> Self {
         self.inner.set_allowed_origins(val);
         self
     }
@@ -45696,9 +37249,9 @@ extern "C" {
     #[doc = " domains in an array and use `*` for wildcard subdomains. Empty arrays allow the"]
     #[doc = " video to be viewed on any origin."]
     #[wasm_bindgen(method, getter, js_name = "allowedOrigins")]
-    pub fn allowed_origins(this: &StreamUrlUploadParams) -> Option<Vec<String>>;
+    pub fn allowed_origins(this: &StreamUrlUploadParams) -> Option<Array<JsString>>;
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "allowedOrigins")]
-    pub fn set_allowed_origins(this: &StreamUrlUploadParams, val: &[String]);
+    pub fn set_allowed_origins(this: &StreamUrlUploadParams, val: &Array<JsString>);
     #[doc = " A user-defined identifier for the media creator."]
     #[wasm_bindgen(method, getter)]
     pub fn creator(this: &StreamUrlUploadParams) -> Option<String>;
@@ -45754,7 +37307,7 @@ pub struct StreamUrlUploadParamsBuilder {
     inner: StreamUrlUploadParams,
 }
 impl StreamUrlUploadParamsBuilder {
-    pub fn allowed_origins(self, val: &[String]) -> Self {
+    pub fn allowed_origins(self, val: &Array<JsString>) -> Self {
         self.inner.set_allowed_origins(val);
         self
     }
@@ -46083,9 +37636,9 @@ extern "C" {
     #[doc = " domains in an array and use `*` for wildcard subdomains. Empty arrays allow the"]
     #[doc = " video to be viewed on any origin."]
     #[wasm_bindgen(method, getter, js_name = "allowedOrigins")]
-    pub fn allowed_origins(this: &StreamUpdateVideoParams) -> Option<Vec<String>>;
+    pub fn allowed_origins(this: &StreamUpdateVideoParams) -> Option<Array<JsString>>;
     #[wasm_bindgen(method, setter, slice_to_array, js_name = "allowedOrigins")]
-    pub fn set_allowed_origins(this: &StreamUpdateVideoParams, val: &[String]);
+    pub fn set_allowed_origins(this: &StreamUpdateVideoParams, val: &Array<JsString>);
     #[doc = " A user-defined identifier for the media creator."]
     #[wasm_bindgen(method, getter)]
     pub fn creator(this: &StreamUpdateVideoParams) -> Option<String>;
@@ -46144,7 +37697,7 @@ pub struct StreamUpdateVideoParamsBuilder {
     inner: StreamUpdateVideoParams,
 }
 impl StreamUpdateVideoParamsBuilder {
-    pub fn allowed_origins(self, val: &[String]) -> Self {
+    pub fn allowed_origins(self, val: &Array<JsString>) -> Self {
         self.inner.set_allowed_origins(val);
         self
     }
@@ -46454,7 +38007,7 @@ impl StreamWatermark {
         height: f64,
         width: f64,
         created: &str,
-        downloaded_from: Option<&str>,
+        downloaded_from: &str,
         name: &str,
         opacity: f64,
         padding: f64,
@@ -48237,8 +39790,13 @@ extern "C" {
 impl VectorizeVector {
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
     #[doc = " * `values` - The vector values"]
-    pub fn new(id: &str, values: &JsValue) -> VectorizeVector {
+    pub fn new(id: &str, values: &Float32Array) -> VectorizeVector {
         Self::builder(id, values).build()
+    }
+    #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
+    #[doc = " * `values` - The vector values"]
+    pub fn new_with_float64_array(id: &str, values: &Float64Array) -> VectorizeVector {
+        Self::builder_with_float64_array(id, values).build()
     }
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
     #[doc = " * `values` - The vector values"]
@@ -48247,10 +39805,18 @@ impl VectorizeVector {
     }
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
     #[doc = " * `values` - The vector values"]
-    pub fn builder(id: &str, values: &JsValue) -> VectorizeVectorBuilder {
+    pub fn builder(id: &str, values: &Float32Array) -> VectorizeVectorBuilder {
         let inner: VectorizeVector = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_id(id);
         inner.set_values(values);
+        VectorizeVectorBuilder { inner }
+    }
+    #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
+    #[doc = " * `values` - The vector values"]
+    pub fn builder_with_float64_array(id: &str, values: &Float64Array) -> VectorizeVectorBuilder {
+        let inner: VectorizeVector = JsCast::unchecked_into(js_sys::Object::new());
+        inner.set_id(id);
+        inner.set_values_with_float64_array(values);
         VectorizeVectorBuilder { inner }
     }
     #[doc = " * `id` - The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents."]
@@ -49570,7 +41136,7 @@ pub enum ConversationKind {
 #[wasm_bindgen]
 pub enum InputKind {
     String(String),
-    ResponseInput(Vec<JsValue>),
+    ResponseInput(Array),
 }
 #[wasm_bindgen]
 pub enum ServiceTierKind {
@@ -49593,12 +41159,12 @@ pub enum TruncationKind {
 #[wasm_bindgen]
 pub enum InstructionsKind {
     String(String),
-    Array(Vec<JsValue>),
+    Array(Array),
 }
 #[wasm_bindgen]
 pub enum ContentKind {
     String(String),
-    ResponseInputMessageContentList(Vec<JsValue>),
+    ResponseInputMessageContentList(Array),
 }
 #[wasm_bindgen]
 pub enum EasyInputMessageRoleKind {
@@ -49621,7 +41187,7 @@ pub enum GenerateSummaryKind {
 #[wasm_bindgen]
 pub enum OutputKind {
     String(String),
-    Array(Vec<JsValue>),
+    Array(Array),
 }
 #[wasm_bindgen]
 pub enum CodeKind {
@@ -49659,7 +41225,7 @@ pub enum DetailKind {
 #[wasm_bindgen]
 pub enum ResponseInputItemFunctionCallOutputOutputKind {
     String(String),
-    ResponseFunctionCallOutputItemList(Vec<JsValue>),
+    ResponseFunctionCallOutputItemList(Array),
 }
 #[wasm_bindgen]
 pub enum ResponseInputItemMessageRoleKind {


### PR DESCRIPTION
This implements perf-aware control over the Rust outer-type form generated for arg-position `string` and `Array<T>` parameters. The TS author picks the form per param by choosing the spelling; ts-gen lowers 1:1.

Some Rust-idiomatic outer-type lowerings imply a copy across the Wasm boundary for large data. `&str` arguments incur a UTF-8 conversion, and `&[T]` arguments with non-numeric `T` materialise a JS `Array` element-by-element via `slice_to_array`. Where this matters, callers want the zero-copy alternative: `&JsString` and `&Array<U>`.

Rather than fan every callable out into both forms (which we explored and abandoned — combinatorial explosion crossed with union expansion is brutal, and Cloudflare worker-types' `AIGatewayHeaders` would have emitted 279,936 factory variants), the choice is deferred to the TS author. Each ABI flavor is exposed as a distinct TS spelling:

| TS arg form        | Rust arg-pos    | Notes                                  |
| ------------------ | --------------- | -------------------------------------- |
| `string`           | `&str`          | idiomatic, UTF-8 copy                  |
| `String`           | `&JsString`     | zero-copy JS string handle             |
| `T[]`              | `&[T]`          | `slice_to_array` elementwise copy      |
| `Array<T>`         | `&Array<U>`     | zero-copy JS array handle              |
| `ReadonlyArray<T>` | `&Array<U>`     | same as `Array<T>` on the FFI          |

Writing `Array<T>` (the explicit generic) selects the JS-array reference form; writing `T[]` (the syntactic shortcut) selects the Rust slice form. Same for `String` vs `string`. The TS spelling drives the lowering 1:1.

**Breaking change**: `TypeRef::Reference { [\"Array\"], [T] }` previously re-routed through the syntactic `T[]` arm and emitted `&[T]`. It now lowers directly to `&Array<U>`. Existing `.d.ts` files that wrote `Array<T>` meaning \"a Rust slice\" need to switch to `T[]` for the slice form.

Two codegen hardening fixes ride along, both surfaced while exploring the larger design but useful independently:

* **Per-flatten alternative cap and per-callable cartesian product cap.** Above the limit the offending param collapses to its subtyping LUB and a warning surfaces the dropped overloads. Prevents combinatorial explosion on TS dictionaries with many required union-typed fields.
* **Greedy naming-collision rescue.** Two signatures whose type-name-driven `_with_<type>` suffixes would collide now rescue with the param name instead of numeric dedup: `append_with_js_string_2` becomes `append_with_value_js_string`.

Snapshot updates across all fixtures reflect the new lowering and the collision-rescue rule. Unit tests, snapshots, clippy, and rustfmt all pass.